### PR TITLE
Change Portrait and Landscape info

### DIFF
--- a/en/ios/user-interface.mdown
+++ b/en/ios/user-interface.mdown
@@ -213,7 +213,7 @@ Developers interested in this kind of customization should take a look at the in
 
 ### Portrait and Landscape
 
-By default, the `PFLogInViewController` supports all orientations, except `UIInterfaceOrientationPortraitUpsideDown` on iPhone.
+By default, the `PFLogInViewController` supports all orientations on iPad and `UIInterfaceOrientationPortrait` on iPhone.
 
 ### Resolution Independent
 
@@ -396,7 +396,7 @@ Developer interested in this kind of customization should take a look at the int
 
 ### Portrait and Landscape
 
-By default, the `PFSignUpViewController` supports all orientations, except `UIInterfaceOrientationPortraitUpsideDown` on iPhone.
+By default, the `PFSignUpViewController` supports all orientations on iPad and `UIInterfaceOrientationPortrait` on iPhone.
 
 ### Resolution Independent
 


### PR DESCRIPTION
In our doc,we say PFLoginViewController and PFSignupViewController support all orientations. But actually they only support UIInterfaceOrientationPortrait on iPhone. Make a change for that.
