### PR TITLE
Arduino guide doc: replacing client with global Parse

### DIFF
--- a/en/arduino/getting-started.mdown
+++ b/en/arduino/getting-started.mdown
@@ -14,8 +14,7 @@ In order for Parse to know which app is associated with the Arduino device, simp
 
 ```cpp
 void setup() {
-	ParseClient client;
-	client.begin("${APPLICATION_ID}", "${CLIENT_KEY}");
+	Parse.begin("${APPLICATION_ID}", "${CLIENT_KEY}");
 	// ...
 }
 ```

--- a/en/arduino/other.mdown
+++ b/en/arduino/other.mdown
@@ -5,7 +5,7 @@ Because the Arduino SDK was designed to minimize memory footprint, it doesn't pr
 For example, you could sign up a user from Arduino through a REST call:
 
 ```cpp
-ParseResponse response = client.sendRequest("POST", "/1/users", "{\"username\":\"cooldude6\",\"password\":\"p_n7!-e8\"}", "");
+ParseResponse response = Parse.sendRequest("POST", "/1/users", "{\"username\":\"cooldude6\",\"password\":\"p_n7!-e8\"}", "");
 ```
 
 In this case, the response will contain the objectId of the created user, assuming it was created successfully.

--- a/en/arduino/push-notifications.mdown
+++ b/en/arduino/push-notifications.mdown
@@ -10,8 +10,7 @@ There are two ways to create an Installation for the Arduino. You can generate a
 
 ```cpp
 // In this example, we associate this device with a pre-generated installation ID
-ParseClient client;
-client.setInstallationId("ab946c14-757a-4448-8b77-69704b01bb7b");
+Parse.setInstallationId("ab946c14-757a-4448-8b77-69704b01bb7b");
 ```
 
 The installation ID is a unique identifier for the device, so you should make sure to assign different installation IDs to different devices (i.e. your UUID generator has enough randomness). After you do the above, the arduino will automatically create an Installation object with this installation ID.
@@ -21,7 +20,7 @@ If you do not pass in an installation ID, the`ParseClient` will automatically ge
 You can retrieve your installation ID with the`getInstallationId` function:
 
 ```cpp
-String installationId = client.getInstallationId();
+String installationId = Parse.getInstallationId();
 ```
 
 The installation ID is persisted across reboots.
@@ -40,14 +39,14 @@ The Installation class has several special fields that help you manage and targe
 To subscribe to push notifications, make the following call in your`setup` function:
 
 ```cpp
-client.startPushService();
+Parse.startPushService();
 ```
 
 Then, in your`loop` function:
 
 ```
-if (client.pushAvailable()) {
-	ParsePush push = client.nextPush();
+if (Parse.pushAvailable()) {
+	ParsePush push = Parse.nextPush();
 	// Print whole JSON body
 	String message = push.getJSONBody();
 	Serial.print("New push message size: ");

--- a/en/arduino/requests.mdown
+++ b/en/arduino/requests.mdown
@@ -5,7 +5,7 @@ Because the Arduino SDK was designed to minimize memory footprint, it doesn't pr
 For example, you could sign up a user from Arduino through a REST call:
 
 ```cpp
-ParseResponse response = client.sendRequest("POST", "/1/users", "{\"username\":\"cooldude6\",\"password\":\"p_n7!-e8\"}", "");
+ParseResponse response = Parse.sendRequest("POST", "/1/users", "{\"username\":\"cooldude6\",\"password\":\"p_n7!-e8\"}", "");
 ```
 
 In this case, the response will contain the objectId of the created user, assuming it was created successfully.

--- a/en/arduino/users.mdown
+++ b/en/arduino/users.mdown
@@ -9,8 +9,7 @@ The Arduino SDK does not provide methods to directly sign in as a user. If you w
 Once you have created a Restricted Session via the companion app or through the REST API, you can send the Session Token to the Arduino using push notifications, BLE, or some other appropriate method. After that, you can set it:
 
 ```cpp
-ParseClient client;
-client.setSessionToken("r:olqZkbv8fefVFNjWegyIXIggd");
+Parse.setSessionToken("r:olqZkbv8fefVFNjWegyIXIggd");
 ```
 
 From then on, the device will act on behalf of the user.


### PR DESCRIPTION
We have two different instances for ParseClient in Arduino Yun examples. One is the global "ParseClient Parse" in SDK, the other is what is defined in the sketch "ParseClient client". The one defined in sketch can be actually replaced by the one in SDK. 
