### PR TITLE
Fix setRoleWriteAccess  typo in "Security for Other Objects" documentation

### DIFF
--- a/en/php/roles.mdown
+++ b/en/php/roles.mdown
@@ -63,7 +63,7 @@ You can avoid querying for a role by specifying its name for the ACL:
 ```php
 $wallPost = new ParseObject("WallPost");
 $postACL = new ParseACL();
-$postACL->setRoleWriteAccess("Moderators", true);
+$postACL->setRoleWriteAccessWithName("Moderators", true);
 $wallPost->setACL($postACL);
 $wallPost->save();
 ```


### PR DESCRIPTION
Bug reported here: https://developers.facebook.com/bugs/1443247899303928/

To set role access by name we need to use `setRoleWriteAccessWithName`.