### PR TITLE
Docs - incorrect function definition

### DIFF
--- a/en/ios/objects.mdown
+++ b/en/ios/objects.mdown
@@ -600,7 +600,7 @@ class Armor : PFObject, PFSubclassing {
     }
   }
 
-  static func parseClassName() -> String! {
+  static func parseClassName() -> String {
     return "Armor"
   }
 }


### PR DESCRIPTION
 parseClassName returns String, not String!