### PR TITLE
Small grammar and style fixes for the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Parse Docs
 
-These are the markdown version of all the [platform guides](https://parse.com/docs) of Parse. The content for the guides is stored in this repo, and we use a [Background Job](https://parse.com/docs/js/guide#cloud-code-advanced-background-jobs) to process the markdown and store it in a Parse app. The guides you see on our website are simply served from this Parse app!
+These are the markdown sources for all of the [platform guides](https://parse.com/docs) of Parse. The content for the guides is stored in this repo, and we use a [Background Job](https://parse.com/docs/js/guide#cloud-code-advanced-background-jobs) to process the markdown and store it in a Parse app. The guides you see on our website are simply served from this Parse app!
 
 ## How Do I Contribute?
 
-If you have any fix or suggestion, simply send us a pull request! The guides are organized first by language, then by platform. So for example, `/en/ios/` contains all of sections for the iOS guide in English. You'll notice a `common` folder in each language. This folder contains content that is shared amongst all of the platform. That helps us not duplicate content unnecessarily.
+If you have any fixes or suggestions, simply send us a pull request! The guides are organized first by language, then by platform. So for example, `/en/ios/` contains all of sections for the iOS guide in English. You'll notice a `common` folder in each language. This folder contains content that is shared amongst all of the platforms. That helps us avoid duplicating content unnecessarily.
 
 ## Can I Access The Docs Offline?
 


### PR DESCRIPTION
A handful of small grammar and style changes for the repo's README.

Changes "markdown versions" to "markdown sources"--I think that's a bit more specific/accurate.

Changes "have any fix or suggestion" to "have any fixes or suggestions" because I think that it reads better in plural.

Fixes grammatical issue in "shared amongst all platform[s]."