### PR TITLE
Change incorrect string concatenation character

### DIFF
--- a/en/php/objects.mdown
+++ b/en/php/objects.mdown
@@ -29,7 +29,7 @@ try {
 } catch (ParseException $ex) {  
   // Execute any logic that should take place if the save fails.
   // error is a ParseException object with an error code and message.
-  echo 'Failed to create new object, with error message: ' + $ex->getMessage();
+  echo 'Failed to create new object, with error message: ' . $ex->getMessage();
 }
 ```
 


### PR DESCRIPTION
In the very first PHP code example, the string concat character is given as "+" in the code. It should be "." I think this is critical, because most users might copy-paste the first example and might get "0" if there was an exception, instead of the actual message.
