### PR TITLE
Migrated the Twitter REST API to v1.1

### DIFF
--- a/en/android/users.mdown
+++ b/en/android/users.mdown
@@ -529,7 +529,7 @@ Our SDK provides a straightforward way to sign your API HTTP requests to the [Tw
 ```java
 HttpClient client = new DefaultHttpClient();
 HttpGet verifyGet = new HttpGet(
-        "https://api.twitter.com/1/account/verify_credentials.json");
+        "https://api.twitter.com/1.1/account/verify_credentials.json");
 ParseTwitterUtils.getTwitter().signRequest(verifyGet);
 HttpResponse response = client.execute(verifyGet);
 ```


### PR DESCRIPTION
Migrated the Twitter REST API to v1.1 as the Twitter REST API v1 is no longer active.