### PR TITLE
Fix sample code for common performance section

### DIFF
--- a/en/common/performance.mdown
+++ b/en/common/performance.mdown
@@ -46,28 +46,37 @@ The order of a query constraint's usefulness is:
 
 Take a look at the following query to retrieve GameScore objects:
 
-```objc
+```common-js
 var GameScore = Parse.Object.extend("GameScore");
 var query = new Parse.Query(GameScore);
 query.equalTo("score", 50);
 query.containedIn("playerName",
     ["Jonathan Walsh", "Dario Wunsch", "Shawn Simon"]);
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
+[query whereKey:@"score" equalTo:@50];
+[query whereKey:@"playerName"
+    containedIn:@[@"Jonathan Walsh", @"Dario Wunsch", @"Shawn Simon"]];
+```
+```common-swift
+let query = PFQuery.queryWithClassName("GameScore")
+query.whereKey("score", equalTo: 50)
+query.whereKey("playerName", containedIn: ["Jonathan Walsh", "Dario Wunsch", "Shawn Simon"])
 ```
 
 Creating an index query based on the score field would yield a smaller search space in general than creating one on the playerName field.
 
 When examining data types, booleans have a very low entropy and and do not make good indexes. Take the following query constraint:
 
-```objc
+```common-js
 query.equalTo("cheatMode", false);
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+[query whereKey:@"cheatMode" equalTo:@NO];
+```
+```common-swift
+query.whereKey("cheatMode", equalTo: false)
 ```
 
 The two possible values for cheatMode are true and false. If an index was added on this field it would be of little use because it's likely that 50% of the records will have to be looked at to return query results.
@@ -101,7 +110,7 @@ Additionally, the following queries under certain scenarios may result in slow q
 
 For example, let's say you're tracking high scores for a game in a GameScore class. Now say you want to retrieve the scores for all players except a certain one. You could create this query:
 
-```objc
+```common-js
 var GameScore = Parse.Object.extend("GameScore");
 var query = new Parse.Query(GameScore);
 query.notEqualTo("playerName", "Michael Yabuti");
@@ -109,9 +118,24 @@ query.find().then(function(results) {
   // Retrieved scores successfully
 });
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
+[query whereKey:@"playerName" notEqualTo:@"Michael Yabuti"];
+[query findObjectsInBackgroundWithBlock:^(NSArray *objects, NSError *error) {
+  if (!error) {
+    // Retrieved scores successfully
+  }
+}];
+```
+```common-swift
+let query = PFQuery.queryWithClassName("GameScore")
+query.whereKey("playerName", notEqualTo: "Michael Yabuti")
+query.findObjectsInBackgroundWithBlock {
+  (objects, error) in
+  if !error {
+    // Retrieved scores successfully
+  }
+}
 ```
 
 This query can't take advantage of indexes. The database has to look at all the objects in the GameScore class to satisfy the constraint and retrieve the results. As the number of entries in the class grows, the query takes longer to run.
@@ -120,28 +144,35 @@ Luckily, most of the time a “Not Equal To” query condition can be rewritten 
 
 For example if the User class has a column called state which has values “SignedUp”, “Verified”, and “Invited”, the slow way to find all users who have used the app at least once would be to run the query:
 
-```objc
+```common-js
 var query = new Parse.Query(Parse.User);
 query.notEqualTo("state", "Invited");
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+PFQuery *query = [PFUser query];
+[query whereKey:@"state" notEqualTo:@"Invited"];
+```
+```common-swift
+var query = PFUser.query()
+query.whereKey("state", notEqualTo: "Invited")
 ```
 
 It would be faster to use the “Contained In” condition when setting up the query:
 
-```objc
+```common-js
 query.containedIn("state", ["SignedUp", "Verified"]);
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+[query whereKey:@"state"
+    containedIn:@[@"SignedUp", @"Verified"]];
+```
+```common-swift
+query.whereKey("state", containedIn: ["SignedUp", "Verified"])
 ```
 
 Sometimes, you may have to completely rewrite your query. Going back to the GameScore example, let's say we were running that query to display players who had scored higher than the given player. We could do this differently, by first getting the given player's high score and then using the following query:
 
-```objc
+```common-js
 var GameScore = Parse.Object.extend("GameScore");
 var query = new Parse.Query(GameScore);
 // Previously retrieved highScore for Michael Yabuti
@@ -150,34 +181,57 @@ query.find().then(function(results) {
   // Retrieved scores successfully
 });
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
+// Previously retrieved highScore for Michael Yabuti
+[query whereKey:@"score" greaterThan:highScore];
+[query findObjectsInBackgroundWithBlock:^(NSArray *objects, NSError *error) {
+  if (!error) {
+    // Retrieved scores successfully
+  }
+}];
+```
+```common-swift
+let query = PFQuery.queryWithClassName("GameScore")
+// Previously retrieved highScore for Michael Yabuti
+query.whereKey("score", greaterThan: highScore)
+query.findObjectsInBackgroundWithBlock {
+  (objects, error) in
+  if !error {
+    // Retrieved scores successfully
+  }
+}
 ```
 
-The new query you use depends  on your use case. This may sometimes mean a redesign of your data model.
+The new query you use depends on your use case. This may sometimes mean a redesign of your data model.
 
 ### Not Contained In
 
 Similar to “Not Equal To”, the “Not Contained In” query constraint can't use an index. You should try and use the complementary “Contained In” constraint. Building on the User example, if the state column had one more value, “Blocked”, to represent blocked users, a slow query to find active users would be:
 
-```objc
+```common-js
 var query = new Parse.Query(Parse.User);
 query.notContainedIn("state", ["Invited", "Blocked"];
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+PFQuery *query = [PFUser query];
+[query whereKey:@"state" notContainedIn:@[@"Invited", @"Blocked"]];
+```
+```common-swift
+var query = PFUser.query()
+query.whereKey("state", containedIn: ["Invited", "Blocked"])
 ```
 
 Using a complimentary “Contained In” query constraint will always be faster:
 
-```objc
+```common-js
 query.containedIn("state", ["SignedUp", "Verified"]);
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+query whereKey:@"state" containedIn:@[@"SignedUp", @"Verified"]];
+```
+```common-swift
+query.whereKey("state", containedIn: ["SignedUp", "Verified"])
 ```
 
 This means rewriting your queries accordingly. Your query rewrites will depend on your schema set up. It may mean redoing that schema.
@@ -188,44 +242,52 @@ Most regular expression queries in Parse have been deprecated due to performance
 
 You should avoid using regular expression constraints that don't use indexes. For example, the following query looks for data with a given string in the playerName field. The string search is case insensitive:
 
-```objc
+```common-js
 query.matches("playerName", "Michael", “i”);
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+[query whereKey:@"playerName" matchesRegex:@"Michael" modifiers:@"i"];
+```
+```common-swift
+query.whereKey("playerName", matchesRegex: "Michael", modifiers: "i")
 ```
 
 A similar query looks for any occurrence of the string in the field, however the search is case sensitive:
 
-```objc
+```common-js
 query.contains("playerName", "Michael");
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+[query whereKey:@"playerName" containsString:@"Michael"];
+```
+```common-swift
+query.whereKey("playerName", containsString: "Michael")
 ```
 
 These queries are both slow. Depending on your use case, you should switch to using the following constraint that uses an index:
 
-```objc
+```common-js
 query.startsWith("playerName", "Michael");
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+[query whereKey:@"playerName" hasPrefix:@"Michael"];
+```
+```common-swift
+query.whereKey("playerName", hasPrefix: "Michael")
 ```
 
 This looks for data that starts with the given string. This query will use the backend index, so it will be faster even for large datasets.
 
 As a best practice, when you use regular expression constraints, you'll want to ensure that other constraints in the query reduce the result set to the order of hundreds of objects to make the query efficient. If you must use the matches()constraint for legacy reasons, then use case sensitive, anchored queries where possible, for example:
 
-```objc
+```common-js
 query.matches("playerName", "^Michael");
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+[query whereKey:@"playerName" matchesRegex:@"^Michael"];
+```
+```common-swift
+query.whereKey("playerName", matchesRegex: "^Michael")
 ```
 
 Most of the use cases around using regular expressions involve implementing search. A more performant way of implementing search is detailed later.
@@ -236,31 +298,48 @@ Writing restrictive queries allows you to return only the data that the client n
 
 You can limit the number of query results returned. The limit is 100 by default but anything from 1 to 1000 is a valid limit:
 
-```objc
+```common-js
 query.limit(10); // limit to at most 10 results
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+query.limit = 10; // limit to at most 10 results
+```
+```common-swift
+query.limit = 10 // limit to at most 10 results
 ```
 
 If you're issuing queries on GeoPoints, make sure you specify a reasonable radius:
 
-```objc
+```common-js
 var query = new Parse.Query(PlaceObject);
 query.withinMiles("location", userGeoPoint, 10.0);
 query.find().then(function(placesObjects) {
   // Get a list of objects within 10 miles of a user's location
 });
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+PFQuery *query = [PFQuery queryWithClassName:@"Place"];
+[query whereKey:@"location" nearGeoPoint:userGeoPoint withinMiles:10.0];
+[query findObjectsInBackgroundWithBlock:^(NSArray *places, NSError *error) {
+  if (!error) {
+    // List of objects within 10 miles of a user's location
+  }
+}];
+```
+```common-swift
+let query = PFQuery.queryWithClassName("Place")
+query.whereKey("location", nearGeoPoint: userGeoPoint, withinMiles: 10.0)
+query.findObjectsInBackgroundWithBlock {
+  (places, error) in
+  if !error {
+    // List of places within 10 miles of a user's location
+  }
+}
 ```
 
 You can further limit the fields returned by calling select:
 
-```objc
+```common-js
 var GameScore = Parse.Object.extend("GameScore");
 var query = new Parse.Query(GameScore);
 query.select("score", "playerName");
@@ -268,9 +347,24 @@ query.find().then(function(results) {
   // each of results will only have the selected fields available.
 });
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
+[query selectKeys:@[@"score", @"playerName"]];
+[query findObjectsInBackgroundWithBlock:^(NSArray *objects, NSError *error) {
+  if (!error) {
+    // each of results will only have the selected fields available.
+  }
+}];
+```
+```common-swift
+let query = PFQuery.queryWithClassName("GameScore")
+query.selectKeys(["score", "playerName"])
+query.findObjectsInBackgroundWithBlock {
+  (objects, error) in
+  if !error {
+    // each of results will only have the selected fields available.
+  }
+}
 ```
 
 ## Client-side Caching
@@ -285,7 +379,7 @@ You can use this to off load processing to the Parse servers thus increasing you
 
 We saw examples of limiting the data returned by writing restrictive queries. You can also use [Cloud Functions](https://www.parse.com/docs/js/guide#cloud-code-cloud-functions) to help limit the amount of data returned to your app. In the following example, we use a Cloud Function to get a movie's average rating:
 
-```objc
+```js
 Parse.Cloud.define("averageStars", function(request, response) {
   var Review = Parse.Object.extend("Review");
   var query = new Parse.Query(Review);
@@ -301,16 +395,12 @@ Parse.Cloud.define("averageStars", function(request, response) {
   });
 });
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
-```
 
 You could have ran a query on the Review class on the client, returned only the stars field data and computed the result on the client. As the number of reviews for a movie increases you can see that the data being returned to the device using this methodology also increases. Implementing the functionality through a Cloud Function returns the one result if successful.
 
-As you look at optimizing your queries, you'll find that you may have to change the queries - sometimes even after you've shipped your app to the App Store or Google Play. The ability to change your queries without a client update is possible if you use [Cloud Functions](https://www.parse.com/docs/js/guide#cloud-code-cloud-functions). Even if you have to redesign your schema, you could make all the changes in your Cloud Functions while keeping the client interface the same to avoid an app update. Take the average ratings Cloud Function example from before, calling it from an iOS client would look like this:
+As you look at optimizing your queries, you'll find that you may have to change the queries - sometimes even after you've shipped your app to the App Store or Google Play. The ability to change your queries without a client update is possible if you use [Cloud Functions](https://www.parse.com/docs/js/guide#cloud-code-cloud-functions). Even if you have to redesign your schema, you could make all the changes in your Cloud Functions while keeping the client interface the same to avoid an app update. Take the average ratings Cloud Function example from before, calling it from a client SDK would look like this:
 
-```objc
+```common-objc
 [PFCloud callFunctionInBackground:@"averageStars"
                   withParameters:@{@"movie": @"The Matrix"}
                            block:^(NSNumber *ratings, NSError *error) {
@@ -319,9 +409,13 @@ As you look at optimizing your queries, you'll find that you may have to change 
   }
 }];
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-swift
+PFCloud.callFunctionInBackground("averageStars", withParameters: ["movie": "The Matrix"]) {
+  (ratings, error) in
+  if !error {
+    // ratings is 4.5
+  }
+}
 ```
 
 If later on, you need to modify the underlying data model, your client call can remain the same, as long as you return back a number that represents the ratings result.
@@ -332,25 +426,40 @@ For classes with over 1,000 objects, count operations are limited by timeouts. T
 
 Suppose you are displaying movie information in your app and your data model consists of a Movie class and a Review class that contains a pointer to the corresponding movie. You might want to display the review count for each movie on the top-level navigation screen using a query like this:
 
-```objc
+```common-js
 var Review = Parse.Object.extend("Review");
 var query = new Parse.Query("Review");
 // movieId corresponds to a given movie's id
 query.equalTo(“movie”, movieId);
 query.count().then(function(count) {
   // Request succeeded
-}, function(error) {
-  // Request failed
 });
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+PFQuery *query = [PFQuery queryWithClassName:@"Review"];
+// movieId corresponds to a given movie's id
+[query whereKey:@"movie" equalTo:movieId];
+[query countObjectsInBackgroundWithBlock:^(int number, NSError *error) {
+  if (!error) {
+    // Request succeeded
+  }
+}];
+```
+```common-swift
+let query = PFQuery.queryWithClassName("Review")
+// movieId corresponds to a given movie's id
+query.whereKey("movie", equalTo: movieId)
+query.countObjectsInBackgroundWithBlock {
+  (number, error) in
+  if !error {
+    // Request succeeded
+  }
+}
 ```
 
 If you run the count query for each of the UI elements, they will not run efficiently on large data sets. One approach to avoid using the `count()` operator could be to add a field to the Movie class that represents the review count for that movie. When saving an entry to the Review class you could increment the corresponding movie's review count field. This can be done in an `afterSave` handler:
 
-```objc
+```js
 Parse.Cloud.afterSave("Review", function(request) {
   // Get the movie id for the Review
   var movieId = request.object.get("movie").id;
@@ -366,14 +475,10 @@ Parse.Cloud.afterSave("Review", function(request) {
   });
 });
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
-```
 
 Your new optimized query would not need to look at the Review class to get the review count:
 
-```objc
+```common-js
 var Movie = Parse.Object.extend("Movie");
 var query = new Parse.Query(Movie);
 query.find().then(function(results) {
@@ -382,9 +487,22 @@ query.find().then(function(results) {
   // Request failed
 });
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+PFQuery *query = [PFQuery queryWithClassName:@"Movie"];
+[query findObjectsInBackgroundWithBlock:^(NSArray *objects, NSError *error) {
+  if (!error) {
+    // Results include the reviews count field
+  }
+}];
+```
+```common-swift
+let query = PFQuery.queryWithClassName("Movie")
+query.findObjectsInBackgroundWithBlock {
+  (objects, error) in
+  if !error {
+    // Results include the reviews count field
+  }
+}
 ```
 
 You could also use a separate Parse Object to keep track of counts for each review. Whenever a review gets added or deleted, you can increment or decrement the counts in an `afterSave` or `afterDelete` Cloud Code handler. The approach you choose depends on your use case.
@@ -420,7 +538,7 @@ This saves your words and hashtags in array fields, which MongoDB will store wit
 
 Once you've got the keywords set up, you can efficiently look them up using “All” constraint on your query:
 
-```objc
+```common-js
 var Post = Parse.Object.extend("Post");
 var query = new Parse.Query(Post);
 query.containsAll("hashtags", [“#parse”, “#ftw”]);
@@ -430,9 +548,24 @@ query.find().then(function(results) {
   // Request failed
 });
 ```
-```swift
-// No Swift example.
-// Want to contribute to this doc? https://github.com/ParsePlatform/Docs/issues/21
+```common-objc
+PFQuery *query = [PFQuery queryWithClassName:@"Post"];
+[query whereKey:@"hashtags" containsAllObjectsInArray:@[@"#parse", @"#ftw"]];
+[query findObjectsInBackgroundWithBlock:^(NSArray *objects, NSError *error) {
+  if (!error) {
+    // Request succeeded
+  }
+}];
+```
+```common-swift
+let query = PFQuery.queryWithClassName("Post")
+query.whereKey("hashtags", containsAllObjectsInArray: ["#parse", "#ftw"])
+query.findObjectsInBackgroundWithBlock {
+  (objects, error) in
+  if !error {
+    // Request succeeded
+  }
+}
 ```
 
 ## Limits and Other Considerations


### PR DESCRIPTION
Updates the js samples to be referenced as common-js.

And also includes sample code for Objective-C and Swift.

Will be able to add the other language samples soon.