### PR TITLE
pointer permissions docs

### DIFF
--- a/en/common/security.mdown
+++ b/en/common/security.mdown
@@ -55,9 +55,24 @@ For each of the above actions, you can grant permission to all users (which is t
 
 ### Pointer Permissions
 
-Pointer permissions are a special type of class-level permission that create a virtual ACL on every object in a class, based on users stored in pointer fields on those objects. For example given a class with an `owner` field, setting a read pointer permission on `owner` will make each object in the class behave as if it had an ACL that only allowed reads for the user in that object's `owner` field. Given that objects often already have pointers to the user that should have permissions on the object, pointer permissions provides a simple solution for utilizing that data which is already there.
+Pointer permissions are a special type of class-level permission that create a virtual ACL on every object in a class, based on users stored in pointer fields on those objects. For example given a class with an `owner` field, setting a read pointer permission on `owner` will make each object in the class behave as if it had an ACL that only allowed reads for the user in that object's `owner` field. Given that objects often already have pointers to the user that should have permissions on the object, pointer permissions provide a simple solution for utilizing data which is already there.
 
-Like other CLPs, pointer permissions provide a separate layer of security than ACLs, and so can be dangerous to combine. Pointer permissions are recommended for apps and classes that don't already have many ACLs set. Read more about how CLPs and ACLs interact [here](https://parse.com/docs/data#security-interaction).
+For example you have a Message class, and each message has a `sender` and a `receiver`, which are each pointers to a `User`. You want to make sure only the sender and receiver of the message can see the message, so you can set read pointer permissions on both of those pointers. You also want only the sender to be able to edit the message, so you can set a write pointer permission on the `sender` pointer. This set of pointer permissions will cause the each object in the `Message` class to act as if it had an ACL of:
+
+```
+{
+    "<SENDER_USER_ID>": {
+        "read": true,
+        "write": true
+    },
+    "<RECEIVER_USER_ID>": {
+        "read": true
+    }
+}
+```
+
+Note that this ACL is not actually created on each object, it only acts like this ACL is on the object, assuming that the actual ACL on the object is public read and public write. If any of the objects in the `Message` class have a non-public ACL set then the virtual ACL for the object would be a combination of the two, and may make the object unreadable or unwritable. Like other CLPs, pointer permissions provide a separate layer of security than ACLs, and so can be dangerous to combine. Pointer permissions are recommended for apps and classes that don't already have many ACLs set. Read more about how CLPs and ACLs interact [here](https://parse.com/docs/data#security-interaction).
+
 
 ## Object-Level Access Control
 

--- a/en/common/security.mdown
+++ b/en/common/security.mdown
@@ -53,6 +53,12 @@ You can configure the client's ability to perform each of the following operatio
 
 For each of the above actions, you can grant permission to all users (which is the default), or lock permissions down to a list of roles and users. For example, a class that should be available to all users would be set to read-only by only enabling get and find. A logging class could be set to write-only by only allowing creates. You could enable moderation of user-generated content by providing update and delete access to a particular set of users or roles.
 
+### Pointer Permissions
+
+Pointer permissions are a special type of class-level permission that create a virtual ACL on every object in a class, based on users stored in pointer fields on those objects. For example given a class with an `owner` field, setting a read pointer permission on `owner` will make each object in the class behave as if it had an ACL that only allowed reads for the user in that object's `owner` field. Given that objects often already have pointers to the user that should have permissions on the object, pointer permissions provides a simple solution for utilizing that data which is already there.
+
+Like other CLPs, pointer permissions provide a separate layer of security than ACLs, and so can be dangerous to combine. Pointer permissions are recommended for apps and classes that don't already have many ACLs set. Read more about how CLPs and ACLs interact [here](https://parse.com/docs/data#security-interaction).
+
 ## Object-Level Access Control
 
 Once you've locked down your schema and class-level permissions, it's time to think about how data is accessed by your users. Object-level access control enables one user's data to be kept separate from another's, because sometimes different objects in a class need to be accessible by different people. For example, a user’s private personal data should be accessible only to them.

--- a/en/common/security.mdown
+++ b/en/common/security.mdown
@@ -53,27 +53,6 @@ You can configure the client's ability to perform each of the following operatio
 
 For each of the above actions, you can grant permission to all users (which is the default), or lock permissions down to a list of roles and users. For example, a class that should be available to all users would be set to read-only by only enabling get and find. A logging class could be set to write-only by only allowing creates. You could enable moderation of user-generated content by providing update and delete access to a particular set of users or roles.
 
-### Pointer Permissions
-
-Pointer permissions are a special type of class-level permission that create a virtual ACL on every object in a class, based on users stored in pointer fields on those objects. For example given a class with an `owner` field, setting a read pointer permission on `owner` will make each object in the class behave as if it had an ACL that only allowed reads for the user in that object's `owner` field. Given that objects often already have pointers to the user that should have permissions on the object, pointer permissions provide a simple solution for utilizing data which is already there.
-
-For example you have a Message class, and each message has a `sender` and a `receiver`, which are each pointers to a `User`. You want to make sure only the sender and receiver of the message can see the message, so you can set read pointer permissions on both of those pointers. You also want only the sender to be able to edit the message, so you can set a write pointer permission on the `sender` pointer. This set of pointer permissions will cause the each object in the `Message` class to act as if it had an ACL of:
-
-```
-{
-    "<SENDER_USER_ID>": {
-        "read": true,
-        "write": true
-    },
-    "<RECEIVER_USER_ID>": {
-        "read": true
-    }
-}
-```
-
-Note that this ACL is not actually created on each object, it only acts like this ACL is on the object, assuming that the actual ACL on the object is public read and public write. If any of the objects in the `Message` class have a non-public ACL set then the virtual ACL for the object would be a combination of the two, and may make the object unreadable or unwritable. Like other CLPs, pointer permissions provide a separate layer of security than ACLs, and so can be dangerous to combine. Pointer permissions are recommended for apps and classes that don't already have many ACLs set. Read more about how CLPs and ACLs interact [here](https://parse.com/docs/data#security-interaction).
-
-
 ## Object-Level Access Control
 
 Once you've locked down your schema and class-level permissions, it's time to think about how data is accessed by your users. Object-level access control enables one user's data to be kept separate from another's, because sometimes different objects in a class need to be accessible by different people. For example, a user’s private personal data should be accessible only to them.
@@ -262,6 +241,26 @@ And here's another example of the format of an ACL that uses a Role:
     "aSaMpLeUsErId": { "read": true, "write": true } 
 }
 ```
+
+## Pointer Permissions
+
+Pointer permissions are a special type of class-level permission that create a virtual ACL on every object in a class, based on users stored in pointer fields on those objects. For example given a class with an `owner` field, setting a read pointer permission on `owner` will make each object in the class behave as if it had an ACL that only allowed reads for the user in that object's `owner` field. Given that objects often already have pointers to the user that should have permissions on the object, pointer permissions provide a simple solution for utilizing data which is already there.
+
+For example you have a Message class, and each message has a `sender` and a `receiver`, which are each pointers to a `User`. You want to make sure only the sender and receiver of the message can see the message, so you can set read pointer permissions on both of those pointers. You also want only the sender to be able to edit the message, so you can set a write pointer permission on the `sender` pointer. This set of pointer permissions will cause the each object in the `Message` class to act as if it had an ACL of:
+
+```
+{
+    "<SENDER_USER_ID>": {
+        "read": true,
+        "write": true
+    },
+    "<RECEIVER_USER_ID>": {
+        "read": true
+    }
+}
+```
+
+Note that this ACL is not actually created on each object, it only acts like this ACL is on the object, assuming that the actual ACL on the object is public read and public write. If any of the objects in the `Message` class have a non-public ACL set then the virtual ACL for the object would be a combination of the two, and may make the object unreadable or unwritable. Like other CLPs, pointer permissions provide a separate layer of security than ACLs, and so can be dangerous to combine. Pointer permissions are recommended for apps and classes that don't already have many ACLs set. Read more about how CLPs and ACLs interact [here](https://parse.com/docs/data#security-interaction).
 
 ## Data Integrity in Cloud Code
 


### PR DESCRIPTION
This diff is at https://phab.parse.com/D11251, which will most likely be landed after I'm gone. These docs also refer to the CLP-ACL interaction docs that are missing from the new docs, so it would be good if those got moved over before this is merged.