### PR TITLE
(minor) Removes typo and Clarifies text

### DIFF
--- a/en/js/queries.mdown
+++ b/en/js/queries.mdown
@@ -6,7 +6,7 @@ We've already seen how a `Parse.Query` with `get` can retrieve a single `Parse.O
 
 In many cases, `get` isn't powerful enough to specify which objects you want to retrieve. `Parse.Query` offers different ways to retrieve a list of objects rather than just a single object.
 
-The general pattern is to create a `Parse.Query`, put conditions on it, and then retrieve an `Array` of matching `Parse.Object`s using `find`. For example, to retrieve of the scores with a particular `playerName`, use the `equalTo` method to constrain the value for a key.
+The general pattern is to create a `Parse.Query`, put conditions on it, and then retrieve an `Array` of matching `Parse.Object`s using `find`. For example, to retrieve the scores that have a particular `playerName`, use the `equalTo` method to constrain the value for a key.
 
 ```js
 var GameScore = Parse.Object.extend("GameScore");
@@ -96,7 +96,7 @@ query.greaterThan("wins", 50);
 query.greaterThanOrEqualTo("wins", 50);
 ```
 
-If you want to retrieve objects matching several different values, you can use `containedIn`, providing an array of acceptable values. This is often useful to replace multiple queries with a single query. For example, if you want to retrieve scores made by any player in a particular list:
+If you want to retrieve objects matching any of the values in a list of values, you can use `containedIn`, providing an array of acceptable values. This is often useful to replace multiple queries with a single query. For example, if you want to retrieve scores made by any player in a particular list:
 
 ```js
 // Finds scores from any of Jonathan, Dario, or Shawn


### PR DESCRIPTION
1. removes an unnecessary "of" (Typo) and clarifies language

2. removes a possible misconception that a queries match all items in a list