### PR TITLE
Add a warning where override the constructor.

### DIFF
--- a/en/php/objects.mdown
+++ b/en/php/objects.mdown
@@ -325,4 +325,20 @@ class Monster extends ParseObject
 $monster = Monster::spawn(200);
 echo monster->strength();  // Displays 200.
 echo monster->hasSuperHumanStrength();  // Displays true.
-```   
+``` 
+
+If you want to override the __construct method, make sure the first three params is exactly as same as ParseObject.
+
+
+```php
+class GameScore extends ParseObject
+{
+  public static $parseClassName = "GameScore";
+  
+  public function __construct($className = null, $objectId = null, $isPointer = false, $another_param) {
+    // do what you want
+    parent::__construct("GameScore", $objectId, $isPointer);
+    // do what you want
+  }
+}
+```


### PR DESCRIPTION
After I override the constructor and change the params. I get a strange error when I trying to save an object with a unsaved object as it's property

I found the following Code in ParseObject.php L493 which is used for create objects.

``` php
    public static function create($className, $objectId = null,
        $isPointer = false
    ) {
        if (isset(self::$registeredSubclasses[$className])) {
            return new self::$registeredSubclasses[$className](
                $className, $objectId, $isPointer
            );
        } else {
            return new ParseObject($className, $objectId, $isPointer);
        }
    }

```

Instead of suggest creating an static function create in the Subclass, I suggest adding a warning in the document.

Thank you.
