### PR TITLE
Document success/error errors.

### DIFF
--- a/en/common/errors.mdown
+++ b/en/common/errors.mdown
@@ -1,6 +1,6 @@
 # Error Codes
 
-The following is a list of all the error codes that can be returned by the Parse API. You may also refer to [RFC2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) for a list of http error codes. Make sure to check the error message for more details. 
+The following is a list of all the error codes that can be returned by the Parse API. You may also refer to [RFC2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) for a list of http error codes. Make sure to check the error message for more details.
 
 | Name                             | Code | Description                                                   |
 |----------------------------------|------|---------------------------------------------------------------|
@@ -61,6 +61,8 @@ The following is a list of all the error codes that can be returned by the Parse
 | `ScriptFailed`	                 |  141 | Cloud Code script failed. Usually points to a JavaScript error. Check error message for more details. |
 | `FunctionNotFound`	             |  141 | Cloud function not found. Check that the specified Cloud function is present in your Cloud Code script and has been deployed. |
 | `JobNotFound`	                   |  141 | Background job not found. Check that the specified job is present in your Cloud Code script and has been deployed. |
+| `SuccessErrorNotCalled`          |  141 | success/error was not called. A cloud function will return once response.success() or response.error() is called. A background job will similarly finish execution once status.success() or status.error() is called. If a function or job never reaches either of the success/error methods, this error will be returned. This may happen when a function does not handle an error response correctly, preventing code execution from reaching the success() method call. |
+| `MultupleSuccessErrorCalls`      |  141 | Can't call success/error multiple times. A cloud function will return once response.success() or response.error() is called. A background job will similarly finish execution once status.success() or status.error() is called. If a function or job calls success() and/or error() more than once in a single execution path, this error will be returned. |
 | `ValidationFailed`	             |  142 | Cloud Code validation failed. |
 | `WebhookError`	                 |  143 | Webhook error. |
 | `ReceiptMissing`	               |  143 | Product purchase receipt is missing. |


### PR DESCRIPTION
These are technically 141 errors, so it makes sense to list them in the errors list.