### PR TITLE
Update ParseFacebookUtils swift example to use better import syntax.

### DIFF
--- a/en/ios/users.mdown
+++ b/en/ios/users.mdown
@@ -482,9 +482,8 @@ There's also two code changes you'll need to make. First, add the following to y
 
 ```
 ```swift
-// Import this header into your Swift bridge header file
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
-#import <ParseFacebookUtilsV4/PFFacebookUtils.h>
+import FBSDKCoreKit
+import ParseFacebookUtilsV4
 
 // AppDelegate.swift
 func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {


### PR DESCRIPTION
This is not needed anymore, as we fully support modulemaps which gets us Swift imports without bridging headers.