### PR TITLE
Update minimum deployment target for iOS SDK.

### DIFF
--- a/en/ios/getting-started.mdown
+++ b/en/ios/getting-started.mdown
@@ -1,6 +1,6 @@
 # Getting Started
 
-If you haven't installed the SDK yet, please [head over to the QuickStart guide](/apps/quickstart#parse_data/mobile/ios/native/new) to get our SDK up and running in Xcode. Note that we support iOS 6.0 and higher. You can also check out our [iOS API Reference](/docs/ios/api) and [OSX API Reference](/docs/osx/api) for more detailed information about our SDK.
+If you haven't installed the SDK yet, please [head over to the QuickStart guide](/apps/quickstart#parse_data/mobile/ios/native/new) to get our SDK up and running in Xcode. Note that we support iOS 7.0 and higher. You can also check out our [iOS API Reference](/docs/ios/api) and [OS X API Reference](/docs/osx/api) for more detailed information about our SDK.
 
 The Parse platform provides a complete backend solution for your mobile application. Our goal is to totally eliminate the need for writing server code or maintaining servers.
 

--- a/en/ios/handling-errors.mdown
+++ b/en/ios/handling-errors.mdown
@@ -138,4 +138,4 @@ For synchronous (non-background) methods, error handling is mostly the same exce
 
 By default, all connections have a timeout of 10 seconds, so the synchronous methods will not hang indefinitely.
 
-For a list of all possible `NSError` types, scroll down to [Error Codes](#errors), or see the `PFErrorCode` section of the [iOS API](/docs/ios/api/Constants/PFErrorCode.html) or [OSX API](/docs/osx/api/Constants/PFErrorCode.html).
+For a list of all possible `NSError` types, scroll down to [Error Codes](#errors), or see the `PFErrorCode` section of the [iOS API](/docs/ios/api/Constants/PFErrorCode.html) or [OS X API](/docs/osx/api/Constants/PFErrorCode.html).

--- a/en/ios/local-datastore.mdown
+++ b/en/ios/local-datastore.mdown
@@ -1,6 +1,6 @@
 # Local Datastore
 
-The Parse iOS/OSX SDK provides a local datastore which can be used to store and retrieve `%{ParseObject}`s, even when the network is unavailable. To enable this functionality, add `libsqlite3.dylib` and call `[Parse enableLocalDatastore]` before your call to `setApplicationId:clientKey:`.
+The Parse iOS/OS X SDK provides a local datastore which can be used to store and retrieve `%{ParseObject}`s, even when the network is unavailable. To enable this functionality, add `libsqlite3.dylib` and call `[Parse enableLocalDatastore]` before your call to `setApplicationId:clientKey:`.
 
 ```objc
 @implementation AppDelegate


### PR DESCRIPTION
Use iOS 7.0 which is the current SDK version minimum deployment target, also updated all links to OSX to use proper name.