### PR TITLE
Special properties are not exposed to set and get methods

### DIFF
--- a/en/js/objects.mdown
+++ b/en/js/objects.mdown
@@ -172,7 +172,7 @@ var playerName = gameScore.get("playerName");
 var cheatMode = gameScore.get("cheatMode");
 ```
 
-The three special values are provided as properties:
+The three special reserved values are provided as properties and cannot be retrieved using the 'get' method nor modified with the 'set' method:
 
 ```js
 var objectId = gameScore.id;


### PR DESCRIPTION
Added clarification that objectId, updatedAt, and createdAt cannot be modified with .set nor retrieved with .get. 

This has been a source of confusion for some: https://parse.com/questions/javascript-get-objectid