### PR TITLE
Count for queries should be Int32 in swift.

### DIFF
--- a/en/ios/queries.mdown
+++ b/en/ios/queries.mdown
@@ -846,7 +846,7 @@ PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 var query = PFQuery(className:"GameScore")
 query.whereKey("playerName", equalTo:"Sean Plott")
 query.countObjectsInBackgroundWithBlock {
-  (count: Int, error: NSError?) -> Void in
+  (count: Int32, error: NSError?) -> Void in
   if error == nil {
     println("Sean has played \(count) games")
   }


### PR DESCRIPTION
It needs to be this way for legacy purposes mostly, but this would cause compile issues for people using our SDK in swift on 64-bit targets.