### PR TITLE
Fixed typos in Retrieving File Contents example

### DIFF
--- a/en/php/files.mdown
+++ b/en/php/files.mdown
@@ -46,7 +46,7 @@ How to best retrieve the file contents back depends on the context of your appli
 
 ```php
 $profilePhoto = $profile->get("photoFile");
-echo '![]()getURL() . '">';
+echo '<img src="'.$profilePhoto->getURL() . '">';
 ```
 
 If you want to fetch the contents of the file, you can retrieve it like this:


### PR DESCRIPTION
The current example for "Retrieving File Contents" contains typos.
