### PR TITLE
Update queries.down - specifically, Querying Subclasses

### DIFF
--- a/en/ios/queries.mdown
+++ b/en/ios/queries.mdown
@@ -909,7 +909,7 @@ let query = Armor.query()
 query.whereKey("rupees", lessThanOrEqualTo: PFUser.currentUser()["rupees"])
 query.findObjectsInBackgroundWithBlock { (objects: [PFObject]?, error: NSError?) -> Void in
   if error == nil {
-    if let objects = objects as? [PFObject], firstArmor = objects.first {
+    if let objects = objects as? [Armor], firstArmor = objects.first {
       //...
     }
   }


### PR DESCRIPTION
I feel like the whole point of subclassing is to treat our PFClasses like first class types in Swift; therefore, why not cast the returned results as the specific PFObject type they are? In this case 'Armor' class.
