### PR TITLE
Syntax fix in sessions.md

### DIFF
--- a/en/common/sessions.mdown
+++ b/en/common/sessions.mdown
@@ -171,7 +171,7 @@ public class ParseErrorHandler {
     //
     // startActivityForResult(new ParseLoginBuilder(getActivity()).build(), 0);
   }
-});
+}
  
 // In all API requests, call the global error handler, e.g.
 query.findInBackground(new FindCallback<ParseObject>() {


### PR DESCRIPTION
The 'pseudo' implementation of the ParseErrorHandler class ends with '});' which is nice if it were an inner class somewhere but it isn't in this example, so it should really end with just '}'.