### PR TITLE
Fix photoId

### DIFF
--- a/en/ios/push-notifications.mdown
+++ b/en/ios/push-notifications.mdown
@@ -576,7 +576,7 @@ func application(application: UIApplication, didFinishLaunchingWithOptions launc
 
       // Create a pointer to the Photo object
       let photoId = notificationPayload["p"] as? NSString
-      let targetPhoto = PFObject(withoutDataWithClassName: "Photo", objectId: "xWMyZ4YEGZ")
+      let targetPhoto = PFObject(withoutDataWithClassName: "Photo", objectId: photoId)
 
       // Fetch photo object
       targetPhoto.fetchIfNeededInBackgroundWithBlock {


### PR DESCRIPTION
For Push Notification, in Obj-C guide, responding to the payout code example is:
```objc
  NSString *photoId = [notificationPayload objectForKey:@"p"];
  PFObject *targetPhoto = [PFObject objectWithoutDataWithClassName:@"Photo"   objectId:photoId];
```

But in swift it is:
```swift
let photoId = notificationPayload["p"] as? NSString
let targetPhoto = PFObject(withoutDataWithClassName: "Photo", objectId: "xWMyZ4YEGZ")
```

Which should be using ```photoId``` as well.