### PR TITLE
Codefix - ReferenceError: SendGrid is not defined

### DIFF
--- a/en/cloudcode/cloud-code-modules.mdown
+++ b/en/cloudcode/cloud-code-modules.mdown
@@ -387,7 +387,7 @@ The SendGrid module allows you to send attachments to multiple recipients and al
 var sendgrid = require("sendgrid");
 
 sendgrid.initialize("sendgrid_username", "sendgrid_password");
-sendGrid.sendEmail({
+sendgrid.sendEmail({
   to: ["email@example.com (mailto:email@example.com)", "email+1@example.com"],
   from: "SendGrid@CloudCode.com (mailto:SendGrid@CloudCode.com)",
   subject: "Hello from Cloud Code!",

--- a/en/cloudcode/cloud-code-modules.mdown
+++ b/en/cloudcode/cloud-code-modules.mdown
@@ -387,7 +387,7 @@ The SendGrid module allows you to send attachments to multiple recipients and al
 var sendgrid = require("sendgrid");
 
 sendgrid.initialize("sendgrid_username", "sendgrid_password");
-SendGrid.sendEmail({
+sendGrid.sendEmail({
   to: ["email@example.com (mailto:email@example.com)", "email+1@example.com"],
   from: "SendGrid@CloudCode.com (mailto:SendGrid@CloudCode.com)",
   subject: "Hello from Cloud Code!",


### PR DESCRIPTION
In your Parse documentation.
https://parse.com/docs/cloudcode/guide#cloud-code-modules-sendgrid

Search for "SendGrid.sendEmail("

(I think) that should be a lowercase "S", rewritten as "sendGrid.sendEmail("

Thats it...
Sagan