### PR TITLE
Remove bytes[] references

### DIFF
--- a/en/android/objects.mdown
+++ b/en/android/objects.mdown
@@ -311,7 +311,7 @@ ParseQuery<ParseObject> query = relation.getQuery();
 
 ## Data Types
 
-So far we've used values with type `String`, `int`, `bool`, and `ParseObject`. Parse also supports `java.util.Date`, `byte[]`, and `JSONObject.NULL`.
+So far we've used values with type `String`, `int`, `bool`, and `ParseObject`. Parse also supports `java.util.Date`, and `JSONObject.NULL`.
 
 You can nest `JSONObject` and `JSONArray` objects to store more structured data within a single `ParseObject`.
 
@@ -330,13 +330,10 @@ JSONObject myObject = new JSONObject();
 myObject.put("number", myNumber);
 myObject.put("string", myString);
 
-byte[] myData = { 4, 8, 16, 32 };
-
 ParseObject bigObject = new ParseObject("BigObject");
 bigObject.put("myNumber", myNumber);
 bigObject.put("myString", myString);
 bigObject.put("myDate", myDate);
-bigObject.put("myData", myData);
 bigObject.put("myArray", myArray);
 bigObject.put("myObject", myObject);
 bigObject.put("myNull", JSONObject.NULL);

--- a/en/dotnet/objects.mdown
+++ b/en/dotnet/objects.mdown
@@ -43,7 +43,6 @@ So far we've used values with type `string` and `int` assigned to fields of a `P
 
 *   other primitive numeric values such as `double`s, `long`s, or `float`s
 *   `DateTime` objects
-*   `byte[]` objects
 *   objects that implement `IDictionary<string, T>`
 *   objects that implement `IList<T>`
 *   other `ParseObject`
@@ -56,7 +55,6 @@ Some examples:
 int number = 42;
 string str = "the number is " + number;
 DateTime date = DateTime.Now;
-byte[] data = System.Text.Encoding.UTF8.GetBytes("foo");
 IList<object> list = new List<object> { str, number };
 IDictionary<string, object> dictionary = new Dictionary<string, object>
 {
@@ -68,7 +66,6 @@ var bigObject = new ParseObject("BigObject");
 bigObject["myNumber"] = number;
 bigObject["myString"] = str;
 bigObject["myDate"] = date;
-bigObject["myData"] = data;
 bigObject["myList"] = list;
 bigObject["myDictionary"] = dictionary;
 await bigObject.SaveAsync();

--- a/en/ios/objects.mdown
+++ b/en/ios/objects.mdown
@@ -496,7 +496,7 @@ For more details on `PFQuery` please look at the query portion of this guide.  A
 
 ## Data Types
 
-So far we've used values with type `NSString`, `NSNumber`, and `%{ParseObject}`. Parse also supports `NSDate`, `NSData`, and `NSNull`.
+So far we've used values with type `NSString`, `NSNumber`, and `%{ParseObject}`. Parse also supports `NSDate`, and `NSNull`.
 
 You can nest `NSDictionary` and `NSArray` objects to store more structured data within a single `%{ParseObject}`.
 
@@ -506,7 +506,6 @@ Some examples:
 NSNumber *number = @42;
 NSString *string = [NSString stringWithFormat:@"the number is %@", number];
 NSDate *date = [NSDate date];
-NSData *data = [@"foo" dataUsingEncoding:NSUTF8StringEncoding];
 NSArray *array = @[string, number];
 NSDictionary *dictionary = @{@"number": number,      @"string": string};
 NSNull *null = [NSNull null];
@@ -516,7 +515,6 @@ PFObject *bigObject = [PFObject objectWithClassName:@"BigObject"];
 bigObject[@"myNumberKey"] = number;
 bigObject[@"myStringKey"] = string;
 bigObject[@"myDateKey"] = date;
-bigObject[@"myBytesKey"] = data; // shows up as 'bytes' in the Data Browser
 bigObject[@"myArrayKey"] = array;
 bigObject[@"myObjectKey"] = dictionary; // shows up as 'object' in the Data Browser
 bigObject[@"myNullKey"] = null;
@@ -527,7 +525,6 @@ bigObject[@"myPointerKey"] = pointer; // shows up as Pointer <MyClassName> in th
 let number = 42
 let string = "the number is \(number)"
 let date = NSDate()
-let data = "foo".dataUsingEncoding(NSUTF8StringEncoding)
 let array = [string, number]
 let dictionary = ["number": number, "string": string]
 let null = NSNull()
@@ -537,7 +534,6 @@ var bigObject = PFObject(className:"BigObject")
 bigObject["myNumberKey"] = number
 bigObject["myStringKey"] = string
 bigObject["myDateKey"] = date
-bigObject["myBytesKey"] = data // shows up as 'bytes' in the Data Browser
 bigObject["myArrayKey"] = array
 bigObject["myObjectKey"] = dictionary // shows up as 'object' in the Data Browser
 bigObject["myNullKey"] = null

--- a/en/js/objects.mdown
+++ b/en/js/objects.mdown
@@ -69,11 +69,11 @@ class Monster extends Parse.Object {
     // All other initialization
     this.sound = 'Rawr';
   }
-  
+
   hasSuperHumanStrength() {
     return this.get('strength') > 18;
   }
-  
+
   static spawn(strength) {
     var monster = new Monster();
     monster.set('strength', strength);
@@ -416,6 +416,6 @@ bigObject.set("myNull", null);
 bigObject.save();
 ```
 
-`Parse.Object`s should not exceed 128 kilobytes in size.
+`Parse.Object`s should not exceed 128 kilobytes in size. To store more, we recommend you use `Parse.File`. See [Files](#files) for more details.
 
 For more information about how Parse handles data, check out our documentation on [Data](#data).

--- a/en/php/objects.mdown
+++ b/en/php/objects.mdown
@@ -276,7 +276,7 @@ $bigObject->set("myNull", null);
 $bigObject->save();
 ```
 
-`ParseObject`s should not exceed 128 kilobytes in size.
+`ParseObject`s should not exceed 128 kilobytes in size. To store more, we recommend you use `Parse.File`. See [Files](#files) for more details.
 
 For more information about how Parse handles data, check out our documentation on [Data](#data).
 
@@ -325,7 +325,7 @@ class Monster extends ParseObject
 $monster = Monster::spawn(200);
 echo monster->strength();  // Displays 200.
 echo monster->hasSuperHumanStrength();  // Displays true.
-``` 
+```
 
 If you want to override the __construct method, make sure the first three params are exactly as same as the parent ParseObject constructor:
 
@@ -333,7 +333,7 @@ If you want to override the __construct method, make sure the first three params
 class GameScore extends ParseObject
 {
   public static $parseClassName = "GameScore";
-  
+
   public function __construct($className = null, $objectId = null, $isPointer = false, $another_param) {
     parent::__construct("GameScore", $objectId, $isPointer);
     // ...

--- a/en/unity/objects.mdown
+++ b/en/unity/objects.mdown
@@ -42,7 +42,6 @@ So far we've used values with type `string` and `int` assigned to fields of a `P
 
 *   other primitive numeric values such as `double`s, `long`s, or `float`s
 *   `DateTime` objects
-*   `byte[]` objects
 *   objects that implement `IDictionary<string, T>`
 *   objects that implement `IList<T>`
 *   other `ParseObject`
@@ -55,7 +54,6 @@ Some examples:
 int number = 42;
 string str = "the number is " + number;
 DateTime date = DateTime.Now;
-byte[] data = System.Text.Encoding.UTF8.GetBytes("foo");
 IList<object> list = new List<object> { str, number };
 IDictionary<string, object> dictionary = new Dictionary<string, object>
 {
@@ -67,13 +65,13 @@ var bigObject = new ParseObject("BigObject");
 bigObject["myNumber"] = number;
 bigObject["myString"] = str;
 bigObject["myDate"] = date;
-bigObject["myData"] = data;
 bigObject["myList"] = list;
 bigObject["myDictionary"] = dictionary;
 Task saveTask = bigObject.SaveAsync();
 ```
 
-We do not recommend storing large pieces of binary data like images or documents using `byte[]` fields on `ParseObject`. `ParseObject`s should not exceed 128 kilobytes in size.
+We do not recommend storing large pieces of binary data like images or documents using `byte[]` fields on `ParseObject`. `ParseObject`s should not exceed 128 kilobytes in size. To store more, we recommend you use `ParseFile`. See [Files](#files) for more details.
+
 
 For more information about how Parse handles data, check out our documentation on [Data](#data).
 


### PR DESCRIPTION
The Data Browser does not allow the creation of new byte[] columns. These can only be created via API. This is a legacy data type introduced a couple of months before Parse.File was released, and is only available in the SDKs for legacy reasons. Binary data should not be stored in the database.
