### PR TITLE
beforeSave does not update modified object

### DIFF
--- a/en/cloudcode/cloud-code.mdown
+++ b/en/cloudcode/cloud-code.mdown
@@ -193,7 +193,7 @@ Parse.Cloud.beforeSave("Review", function(request, response) {
     // Truncate and add a ...
     request.object.set("comment", comment.substring(0, 137) + "...");
   }
-  response.success();
+  response.success(request.object);
 });
 ```
 


### PR DESCRIPTION
When modifying an object in the beforeSave trigger, it needs to be specified when calling response.success(). Otherwise parse does not notice that the object has been modefied.
This error occoured when running the cloud code local or on heroku (maybe it does not happen when running the code on the parse cloud code platform).

When calling `response.success();`, the HTTP response looks like this (even if the object has been modified):

```
{
    "success": true
}
```

Whenn calling `response.success(request.object);`, the response looks something like this:

```
{
    "success": {
        ** the modified object here **
    }
}
```

When returning the modified object, parse will save the modified object.
