### PR TITLE
Updated UIUserNotificationType and println to swift 2 syntax

### DIFF
--- a/en/ios/push-notifications.mdown
+++ b/en/ios/push-notifications.mdown
@@ -23,7 +23,7 @@ UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTy
 [application registerForRemoteNotifications];
 ```
 ```swift
-let userNotificationTypes = (UIUserNotificationType.Alert |  UIUserNotificationType.Badge |  UIUserNotificationType.Sound);
+let userNotificationTypes: UIUserNotificationType = [.Alert, .Badge, .Sound]
 
 let settings = UIUserNotificationSettings(forTypes: userNotificationTypes, categories: nil)
 application.registerUserNotificationSettings(settings)

--- a/es/ios/config.mdown
+++ b/es/ios/config.mdown
@@ -18,7 +18,7 @@ Despues de eso te sera posible obtener el `PFConfig` en el cliente, como en este
 PFConfig.getConfigInBackgroundWithBlock {
   (config: PFConfig?, error: NSError?) -> Void in
   let number = config?["winningNumber"] as? Int
-  println("Yay! The number is \(number)!")
+  print("Yay! The number is \(number)!")
 }
 ```
 
@@ -45,21 +45,21 @@ NSLog(@"Getting the latest config...");
 }];
 ```
 ```swift
-println("Getting the latest config...");
+print("Getting the latest config...");
 PFConfig.getConfigInBackgroundWithBlock {
   (var config: PFConfig?, error: NSError?) -> Void in
   if error == nil {
-    println("Yay! Config was fetched from the server.")
+    print("Yay! Config was fetched from the server.")
   } else {
-    println("Failed to fetch. Using Cached Config.")
+    print("Failed to fetch. Using Cached Config.")
     config = PFConfig.currentConfig()
   }
 
   var welcomeMessage: NSString? = config?["welcomeMessage"] as? NSString
   if let welcomeMessage = welcomeMessage {
-    println("Welcome Message = \(welcomeMessage)!")
+    print("Welcome Message = \(welcomeMessage)!")
   } else {
-    println("Falling back to default message.")
+    print("Falling back to default message.")
     welcomeMessage = "Welcome!";
   }
 };


### PR DESCRIPTION
I have changed some syntax and wanted to explain my decision for line 26 in the file en/ios/push-notifications.mdown

For it to build without errors in swift 2, the '|' operator is not used. Instead it is an array of UIUserNotificationType's that gets set into one UIUserNotificationType. This can not be inferred, so it is important to define the type of the constant. Now defined, I thought we could drop the 'UIUserNotificationType' before every value of the enum we specify. What are the thoughts on this? @hramos does this help with #136 
