### PR TITLE
Missing commas in swift code samples for channels

### DIFF
--- a/en/ios/push-notifications.mdown
+++ b/en/ios/push-notifications.mdown
@@ -99,7 +99,7 @@ PFInstallation *currentInstallation = [PFInstallation currentInstallation];
 ```swift
 // When users indicate they are Giants fans, we subscribe them to that channel.
 let currentInstallation = PFInstallation.currentInstallation()
-currentInstallation.addUniqueObject("Giants" forKey: "channels")
+currentInstallation.addUniqueObject("Giants", forKey: "channels")
 currentInstallation.saveInBackground()
 ```
 
@@ -118,7 +118,7 @@ PFInstallation *currentInstallation = [PFInstallation currentInstallation];
 ```swift
 // When users indicate they are Giants fans, we subscribe them to that channel.
 let currentInstallation = PFInstallation.currentInstallation()
-currentInstallation.removeObject("Giants" forKey: "channels")
+currentInstallation.removeObject("Giants", forKey: "channels")
 currentInstallation.saveInBackground()
 ```
 


### PR DESCRIPTION
Added the missing commas for the two code samples for adding/removing channels
