### PR TITLE
Typo in select example

### DIFF
--- a/en/php/queries.mdown
+++ b/en/php/queries.mdown
@@ -131,7 +131,7 @@ You can restrict the fields returned by calling `select` with an array of keys. 
 
 ```php
 $query = new ParseQuery("GameScore");
-$query->select("score", "playerName");
+$query->select(["score", "playerName"]);
 $results = $query->find();
 // each of results will only have the selected fields available.
 ```


### PR DESCRIPTION
Added the missing square brackets to the select example.

https://twitter.com/geoffroymorel/status/690277503336857600