### PR TITLE
correct Android sample of Using Parse SDKs with Parse Server

### DIFF
--- a/en/server/using-sdks.mdown
+++ b/en/server/using-sdks.mdown
@@ -23,7 +23,7 @@ To use a Parse SDK with Parse Server, change the server URL to your Parse API UR
 Parse.initialize(new Parse.Configuration.Builder(myContext)
     .applicationId("YOUR_APP_ID")
     .clientKey("YOUR_APP_CLIENT_KEY")
-    .server("http://localhost:1337/parse")
+    .server("http://localhost:1337/parse/")
 
 
     ...


### PR DESCRIPTION
default server value is end with "/" (Parse.java:54)
but the doc init sample is miss a "/"
