### PR TITLE
Modifies a typo in the afterDelete trigger example

### DIFF
--- a/en/cloudcode/cloud-code.mdown
+++ b/en/cloudcode/cloud-code.mdown
@@ -259,7 +259,7 @@ In some cases, you may want to perform some action, such as a push, after an obj
 ```js
 Parse.Cloud.afterDelete("Post", function(request) {
   query = new Parse.Query("Comment");
-  query.equalTo("post", request.object);
+  query.equalTo("post", request.object.id);
   query.find({
     success: function(comments) {
       Parse.Object.destroyAll(comments, {


### PR DESCRIPTION
'.id' was missing.
