### PR TITLE
Fixes <code><pre> to use markdown

### DIFF
--- a/_includes/common/performance.md
+++ b/_includes/common/performance.md
@@ -50,7 +50,7 @@ PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 let query = PFQuery.queryWithClassName("GameScore")
 query.whereKey("score", equalTo: 50)
 query.whereKey("playerName", containedIn: ["Jonathan Walsh", "Dario Wunsch", "Shawn Simon"])
@@ -96,7 +96,7 @@ query.equalTo("cheatMode", false);
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 query.whereKey("cheatMode", equalTo: false)
 ```
 {: .common-lang-block .swift }
@@ -172,7 +172,7 @@ PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 let query = PFQuery.queryWithClassName("GameScore")
 query.whereKey("playerName", notEqualTo: "Michael Yabuti")
 query.findObjectsInBackgroundWithBlock {
@@ -233,7 +233,7 @@ PFQuery *query = [PFUser query];
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 var query = PFUser.query()
 query.whereKey("state", notEqualTo: "Invited")
 ```
@@ -274,7 +274,7 @@ query.containedIn("state", ["SignedUp", "Verified"]);
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 query.whereKey("state", containedIn: ["SignedUp", "Verified"])
 ```
 {: .common-lang-block .swift }
@@ -324,7 +324,7 @@ PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 let query = PFQuery.queryWithClassName("GameScore")
 // Previously retrieved highScore for Michael Yabuti
 query.whereKey("score", greaterThan: highScore)
@@ -388,7 +388,7 @@ PFQuery *query = [PFUser query];
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 var query = PFUser.query()
 query.whereKey("state", notContainedIn: ["Invited", "Blocked"])
 ```
@@ -428,7 +428,7 @@ query.containedIn("state", ["SignedUp", "Verified"]);
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 query.whereKey("state", containedIn: ["SignedUp", "Verified"])
 ```
 {: .common-lang-block .swift }
@@ -471,7 +471,7 @@ query.matches("playerName", "Michael", “i”);
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 query.whereKey("playerName", matchesRegex: "Michael", modifiers: "i")
 ```
 {: .common-lang-block .swift }
@@ -508,7 +508,7 @@ query.contains("playerName", "Michael");
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 query.whereKey("playerName", containsString: "Michael")
 ```
 {: .common-lang-block .swift }
@@ -545,7 +545,7 @@ query.startsWith("playerName", "Michael");
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 query.whereKey("playerName", hasPrefix: "Michael")
 ```
 {: .common-lang-block .swift }
@@ -584,7 +584,7 @@ query.matches("playerName", "^Michael");
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 query.whereKey("playerName", matchesRegex: "^Michael")
 ```
 {: .common-lang-block .swift }
@@ -627,7 +627,7 @@ query.limit = 10; // limit to at most 10 results
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 query.limit = 10 // limit to at most 10 results
 ```
 {: .common-lang-block .swift }
@@ -674,7 +674,7 @@ PFQuery *query = [PFQuery queryWithClassName:@"Place"];
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 let query = PFQuery.queryWithClassName("Place")
 query.whereKey("location", nearGeoPoint: userGeoPoint, withinMiles: 10.0)
 query.findObjectsInBackgroundWithBlock {
@@ -740,7 +740,7 @@ PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 let query = PFQuery.queryWithClassName("GameScore")
 query.selectKeys(["score", "playerName"])
 query.findObjectsInBackgroundWithBlock {
@@ -835,7 +835,7 @@ Parse.Cloud.run("averageStars", { "movie": "The Matrix" }).then(function(ratings
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 PFCloud.callFunctionInBackground("averageStars", withParameters: ["movie": "The Matrix"]) {
   (ratings, error) in
   if !error {
@@ -913,7 +913,7 @@ PFQuery *query = [PFQuery queryWithClassName:@"Review"];
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 let query = PFQuery.queryWithClassName("Review")
 // movieId corresponds to a given movie's id
 query.whereKey("movie", equalTo: movieId)
@@ -1001,7 +1001,7 @@ PFQuery *query = [PFQuery queryWithClassName:@"Movie"];
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 let query = PFQuery.queryWithClassName("Movie")
 query.findObjectsInBackgroundWithBlock {
   (objects, error) in
@@ -1098,7 +1098,7 @@ PFQuery *query = [PFQuery queryWithClassName:@"Post"];
 ```
 {: .common-lang-block .objc }
 
-<pre><code class="swift">
+````swift
 let query = PFQuery.queryWithClassName("Post")
 query.whereKey("hashtags", containsAllObjectsInArray: ["#parse", "#ftw"])
 query.findObjectsInBackgroundWithBlock {

--- a/_includes/common/relations.md
+++ b/_includes/common/relations.md
@@ -20,16 +20,16 @@ game.put("createdBy", ParseUser.getCurrentUser());
 ```
 {: .common-lang-block .java }
 
-<pre><code class="objectivec">
+````objectivec
 PFObject *game= [PFObject objectWithClassName:@"Game"];
 [game setObject:[PFUser currentUser] forKey:@"createdBy"];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 let game = PFObject(className:"Game")
 game["createdBy"] = PFUser.currentUser()
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```php
@@ -68,18 +68,18 @@ gameQuery.whereEqualTo("createdBy", ParseUser.getCurrentUser());
 ```
 {: .common-lang-block .java }
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *gameQuery = [PFQuery queryWithClassName:@"Game"];
 [gameQuery whereKey:@"createdBy" equalTo:[PFUser currentUser]];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 let gameQuery = PFQuery(className:"Game")
 if let user = PFUser.currentUser() {
   gameQuery.whereKey("createdBy", equalTo: user)
 }
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```php
@@ -120,22 +120,22 @@ ParseUser createdBy = game.getUser("createdBy");
 ```
 {: .common-lang-block .java }
 
-<pre><code class="objectivec">
+````objectivec
 // say we have a Game object
 PFObject *game = ...
 
 // getting the user who created the Game
 PFUser *createdBy = [game objectForKey@"createdBy"];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 // say we have a Game object
 let game = ...
 
 // getting the user who created the Game
 let createdBy = game["createdBy"]
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```php
@@ -206,7 +206,7 @@ ParseUser.getCurrentUser().put("weaponsList", weapons);
 ```
 {: .common-lang-block .java }
 
-<pre><code class="objectivec">
+````objectivec
 // let's say we have four weapons
 PFObject *scimitar = ...
 PFObject *plasmaRifle = ...
@@ -218,10 +218,10 @@ NSArray *weapons = @[scimitar, plasmaRifle, grenade, bunnyRabbit];
 
 // store the weapons for the user
 [[PFUser currentUser] setObject:weapons forKey:@weaponsList"];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 // let's say we have four weapons
 let scimitar = ...
 let plasmaRifle = ...
@@ -234,7 +234,7 @@ let weapons = [scimitar, plasmaRifle, grenade, bunnyRabbit]
 // store the weapons for the user
 let user = PFUser.currentUser()
 user["weaponsList"] = weapons
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```php
@@ -306,12 +306,12 @@ ArrayList<ParseObject> weapons = ParseUser.getCurrentUser().get("weaponsList");
 ```
 {: .common-lang-block .java }
 
-<pre><code class="objectivec">
+````objectivec
 NSArray *weapons = [[PFUser currentUser] objectForKey:@"weaponsList"];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 let weapons = PFUser.currentUser()?.objectForKey("weaponsList")
 ```
 {: .common-lang-block .swift }
@@ -362,7 +362,7 @@ userQuery.findInBackground(new FindCallback<ParseUser>() {
 ```
 {: .common-lang-block .java }
 
-<pre><code class="objectivec">
+````objectivec
 // set up our query for a User object
 PFQuery *userQuery = [PFUser query];
 
@@ -377,10 +377,10 @@ PFQuery *userQuery = [PFUser query];
 [userQuery findObjectsInBackgroundWithBlock:^(NSArray *objects, NSError *error) {
     // objects contains all of the User objects, and their associated Weapon objects, too
 }];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 // set up our query for a User object
 let userQuery = PFUser.query();
 
@@ -396,7 +396,7 @@ userQuery?.findObjectsInBackgroundWithBlock {
     (objects: [AnyObject]?, error: NSError?) -> Void in
     // objects contains all of the User objects, and their associated Weapon objects, too
 }
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```php
@@ -474,22 +474,22 @@ userQuery.whereEqualTo("weaponsList", arrayOfWeapons);
 ```
 {: .common-lang-block .java }
 
-<pre><code class="objectivec">
+````objectivec
 // add a constraint to query for whenever a specific Weapon is in an array
 [userQuery whereKey:@"weaponsList" equalTo:scimitar];
 
 // or query using an array of Weapon objects...
 [userQuery whereKey:@"weaponsList" containedIn:arrayOfWeapons];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 // add a constraint to query for whenever a specific Weapon is in an array
 userQuery?.whereKey("weaponsList", equalTo: scimitar);
 
 // or query using an array of Weapon objects...
 userQuery?.whereKey("weaponsList", containedIn: arrayOfWeapons)
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```php
@@ -564,7 +564,7 @@ book.saveInBackground();
 ```
 {: .common-lang-block .java }
 
-<pre><code class="objectivec">
+````objectivec
 // let’s say we have a few objects representing Author objects
 PFObject *authorOne = …
 PFObject *authorTwo = …
@@ -582,10 +582,10 @@ PFRelation *relation = [book relationForKey:@"authors"];
 
 // now save the book object
 [book saveInBackground];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 // let’s say we have a few objects representing Author objects
 let authorOne = ...
 let authorTwo = ...
@@ -603,7 +603,7 @@ relation.addObject(authorThree)
 
 // now save the book object
 book.saveInBackground()
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```php
@@ -695,7 +695,7 @@ ParseQuery query = relation.getQuery();
 ```
 {: .common-lang-block .java }
 
-<pre><code class="objectivec">
+````objectivec
 // suppose we have a book object
 PFObject *book = ...
 
@@ -706,10 +706,10 @@ PFRelation *relation = [book relationForKey:@"authors"];
 PFQuery *query = [relation query];
 
 // now execute the query
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 // suppose we have a book object
 let book = ...
 
@@ -720,7 +720,7 @@ let relation = book.relationForKey("authors")
 let query = relation.query()
 
 // now execute the query
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```php
@@ -790,7 +790,7 @@ query.whereEqualTo("authors", author);
 ```
 {: .common-lang-block .java }
 
-<pre><code class="objectivec">
+````objectivec
 // suppose we have a author object, for which we want to get all books
 PFObject *author = ...
 
@@ -800,10 +800,10 @@ PFQuery *query = [PFQuery queryWithClassName:@"Book"];
 // now we will query the authors relation to see if the author object
 // we have is contained therein
 [query whereKey:@"authors" equalTo:author];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 // suppose we have a author object, for which we want to get all books
 let author = ...
 
@@ -813,7 +813,7 @@ let query = PFQuery(className: "Book")
 // now we will query the authors relation to see if the author object
 // we have is contained therein
 query?.whereKey("authors", equalTo: author)
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```php
@@ -884,7 +884,7 @@ follow.saveInBackground();
 ```
 {: .common-lang-block .java }
 
-<pre><code class="objectivec">
+````objectivec
 // suppose we have a user we want to follow
 PFUser *otherUser = ...
 
@@ -894,10 +894,10 @@ PFObject *follow = [PFObject objectWithClassName:@"Follow"];
 [follow setObject:otherUser forKey:@"to"];
 [follow setObject:[NSDate date] forKey@"date"];
 [follow saveInBackground];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 // suppose we have a user we want to follow
 let otherUser = ...
 
@@ -907,7 +907,7 @@ follow.setObject(PFUser.currentUser()!, forKey: "from")
 follow.setObject(otherUser, forKey: "to")
 follow.setObject(NSDate(), forKey: "date")
 follow.saveInBackground()
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```php
@@ -974,7 +974,7 @@ query.findInBackground(newFindCallback<ParseObject>() {
 ```
 {: .common-lang-block .java }
 
-<pre><code class="objectivec">
+````objectivec
 // set up the query on the Follow table
 PFQuery *query = [PFQuery queryWithClassName:@"Follow"];
 [query whereKey:@"from" equalTo:[PFUser currentUser]];
@@ -990,10 +990,10 @@ PFQuery *query = [PFQuery queryWithClassName:@"Follow"];
     PFObject *when = [o objectForKey@"date"];
   }
 }];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 // set up the query on the Follow table
 let query = PFQuery(className: "Follow")
 query.whereKey("from", equalTo: PFUser.currentUser()!)
@@ -1012,7 +1012,7 @@ query.findObjectsInBackgroundWithBlock{
         }
     }
 }
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```php
@@ -1072,7 +1072,7 @@ query.findInBackground(newFindCallback<ParseObject>() {
 ```
 {: .common-lang-block .java }
 
-<pre><code class="objectivec">
+````objectivec
 // set up the query on the Follow table
 PFQuery *query = [PFQuery queryWithClassName:@"Follow"];
 [query whereKey:@"to" equalTo:[PFUser currentUser]];
@@ -1087,10 +1087,10 @@ PFQuery *query = [PFQuery queryWithClassName:@"Follow"];
     PFObject *when = [o objectForKey@"date"];
   }
 }];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 // set up the query on the Follow table
 let query = PFQuery(className: "Follow")
 query.whereKey("to", equalTo: PFUser.currentUser()!)
@@ -1109,7 +1109,7 @@ query.findObjectsInBackgroundWithBlock{
 
     }
 }
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```php
@@ -1170,7 +1170,7 @@ book.put("authors", author);
 ```
 {: .common-lang-block .java }
 
-<pre><code class="objectivec">
+````objectivec
 // let's say we have an author
 PFObject *author = ...
 
@@ -1179,10 +1179,10 @@ PFObject *book = ...
 
 // add the author to the authors list for the book
 [book addObject:author forKey:@"authors"];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 // let's say we have an author
 let author = ...
 
@@ -1191,7 +1191,7 @@ let book = ...
 
 // add the author to the authors list for the book
 book.addObject(author, forKey: "authors")
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```php
@@ -1258,7 +1258,7 @@ bookQuery.findInBackground(newFindCallback<ParseObject>() {
 ```
 {: .common-lang-block .java }
 
-<pre><code class="objectivec">
+````objectivec
 // set up our query for the Book object
 PFQuery *bookQuery = [PFQuery queryWithClassName:@"Book"];
 
@@ -1271,10 +1271,10 @@ PFQuery *bookQuery = [PFQuery queryWithClassName:@"Book"];
     // objects is all of the Book objects, and their associated
     // Author objects, too
 }];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 // set up our query for the Book object
 let bookQuery = PFQuery(className: "Book")
 
@@ -1288,7 +1288,7 @@ bookQuery.findObjectsInBackgroundWithBlock{
     // objects is all of the Book objects, and their associated
     // Author objects, too
 }
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```php
@@ -1351,14 +1351,14 @@ ArrayList<ParseObject> authorList = book.getList("authors");
 ```
 {: .common-lang-block .java }
 
-<pre><code class="objectivec">
+````objectivec
 NSArray *authorList = [book objectForKey@"authors"];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 let authorList = book.objectForKey("authors") as? NSArray
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```php
@@ -1407,7 +1407,7 @@ bookQuery.findInBackground(newFindCallback<ParseObject>() {
 ```
 {: .common-lang-block .java }
 
-<pre><code class="objectivec">
+````objectivec
 // suppose we have an Author object
 PFObject *author = ...
 
@@ -1424,10 +1424,10 @@ PFQuery *bookQuery = [PFQuery queryWithClassName:@"Book"];
 [bookQuery findObjectsInBackgroundWithBlock:^(NSArray *objects, NSError *error) {
     // objects is all of the Book objects, and their associated Author objects, too
 }];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 // suppose we have an Author object
 let author = ...
 
@@ -1445,7 +1445,7 @@ bookQuery.findObjectsInBackgroundWithBlock{
 	(objects: [AnyObject]?, error: NSError?) -> Void in
     // objects is all of the Book objects, and their associated Author objects, too
 }
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```php

--- a/_includes/common/security.md
+++ b/_includes/common/security.md
@@ -74,17 +74,17 @@ The easiest way to control who can access which data is through access control l
 
 Once you have a User, you can start using ACLs. Remember: Users can be created through traditional username/password signup, through a third-party login system like Facebook or Twitter, or even by using Parse's [automatic anonymous users](/docs/ios/guide#users-anonymous-users) functionality. To set an ACL on the current user's data to not be publicly readable, all you have to do is:
 
-<pre><code class="objectivec">
+````objectivec
 PFUser *user = [PFUser currentUser];
 user.ACL = [PFACL ACLWithUser:user];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 if let user = PFUser.currentUser() {
     user.ACL = PFACL(user: user)
 }
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```java
@@ -125,14 +125,14 @@ Most apps should do this. If you store any sensitive user data, such as email ad
 
 To make it super easy to create user-private ACLs for every object, we have a way to set a default ACL that will be used for every new object you create:
 
-<pre><code class="objectivec">
+````objectivec
 [PFACL setDefaultACL:[PFACL ACL] withAccessForCurrentUser:YES];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 PFACL.setDefaultACL(PFACL(), withAccessForCurrentUser: true)
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```java
@@ -167,23 +167,23 @@ ParseACL::setDefaultACL(new ParseACL(), true);
 
 If you want the user to have some data that is public and some that is private, it's best to have two separate objects. You can add a pointer to the private data from the public one.
 
-<pre><code class="objectivec">
+````objectivec
 PFObject *privateData = [PFObject objectWithClassName:@"PrivateUserData"];
 privateData.ACL = [PFACL ACLWithUser:[PFUser currentUser]];
 [privateData setObject:@"555-5309" forKey:@"phoneNumber"];
 
 [[PFUser currentUser] setObject:privateData forKey:@"privateData"];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 if let currentUser = PFUser.currentUser() {
     let privateData = PFObject(className: "PrivateUserData")
     privateData.ACL = PFACL(user: currentUser)
     privateData.setObject("555-5309", forKey: "phoneNumber")
     currentUser.setObject(privateData, forKey: "privateData")
 }
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```java
@@ -234,20 +234,20 @@ ParseUser::getCurrentUser()->set("privateData", $privateData);
 
 Of course, you can set different read and write permissions on an object. For example, this is how you would create an ACL for a public post by a user, where anyone can read it:
 
-<pre><code class="objectivec">
+````objectivec
 PFACL *acl = [PFACL ACL];
 [acl setPublicReadAccess:true];
 [acl setWriteAccess:true forUser:[PFUser currentUser]];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 let acl = PFACL()
 acl.setPublicReadAccess(true)
 if let currentUser = PFUser.currentUser() {
     acl.setWriteAccess(true, forUser: currentUser)
 }
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```java
@@ -290,19 +290,19 @@ $acl->setWriteAccess(ParseUser::getCurrentUser(), true);
 
 Sometimes it's inconvenient to manage permissions on a per-user basis, and you want to have groups of users who get treated the same (like a set of admins with special powers). Roles are are a special kind of object that let you create a group of users that can all be assigned to the ACL. The best thing about roles is that you can add and remove users from a role without having to update every single object that is restricted to that role. To create an object that is writeable only by admins:
 
-<pre><code class="objectivec">
+````objectivec
 // Assuming you've already created a role called "admins"...
 PFACL *acl = [PFACL ACL];
 [acl setPublicReadAccess:true];
 [acl setWriteAccess:true forRoleWithName:@"admins"];
-</code></pre>
+````
 {: .common-lang-block .objectivec }
 
-<pre><code class="swift">
+````swift
 let acl = PFACL()
 acl.setPublicReadAccess(true)
 acl.setWriteAccess(true, forRoleWithName: "admins")
-</code></pre>
+````
 {: .common-lang-block .swift }
 
 ```java

--- a/_includes/ios/analytics.md
+++ b/_includes/ios/analytics.md
@@ -15,20 +15,20 @@ Without having to implement any client-side logic, you can view real-time graphs
 
 Our initial analytics hook allows you to track your application being launched. By adding the following line to `applicationDidFinishLaunching:`, you'll begin to collect data on when and how often your application is opened.
 
-<pre><code class="objectivec">
+````objectivec
 // in iOS
 [PFAnalytics trackAppOpenedWithLaunchOptions:launchOptions];
 
 // in OS X
 [PFAnalytics trackAppOpenedWithLaunchOptions:nil];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // in iOS
 PFAnalytics.trackAppOpenedWithLaunchOptions(launchOptions)
 
 // in OS X
 PFAnalytics.trackAppOpenedWithLaunchOptions(nil)
-</code></pre>
+````
 
 Graphs and breakdowns of your statistics are accessible from your app's Dashboard.
 
@@ -40,7 +40,7 @@ Further analytics are available around push notification delivery and open rates
 
 Say your app offers search functionality for apartment listings, and you want to track how often the feature is used, with some additional metadata.
 
-<pre><code class="objectivec">
+````objectivec
 NSDictionary *dimensions = @{
   // Define ranges to bucket data points into meaningful segments
   @"priceRange": @"1000-1500",
@@ -51,8 +51,8 @@ NSDictionary *dimensions = @{
 };
 // Send the dimensions to Parse along with the 'search' event
 [PFAnalytics trackEvent:@"search" dimensions:dimensions];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let dimensions = [
   // Define ranges to bucket data points into meaningful segments
   "priceRange": "1000-1500",
@@ -63,17 +63,17 @@ let dimensions = [
 ]
 // Send the dimensions to Parse along with the 'search' event
 PFAnalytics.trackEvent("search", dimensions:dimensions)
-</code></pre>
+````
 
 `PFAnalytics` can even be used as a lightweight error tracker — simply invoke the following and you'll have access to an overview of the rate and frequency of errors, broken down by error code, in your application:
 
-<pre><code class="objectivec">
+````objectivec
 NSString *codeString = [NSString stringWithFormat:@"%d", [error code]];
 [PFAnalytics trackEvent:@"error" dimensions:@{ @"code": codeString }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let codeString = NSString(format:"%@", error.code)
 PFAnalytics.trackEvent("error", dimensions:["code": codeString])
-</code></pre>
+````
 
 Note that Parse currently only stores the first eight dimension pairs per call to `trackEvent:dimensions:`.

--- a/_includes/ios/config.md
+++ b/_includes/ios/config.md
@@ -8,25 +8,25 @@
 
 After that you will be able to fetch the `PFConfig` on the client, like in this example:
 
-<pre><code class="objectivec">
+````objectivec
 [PFConfig getConfigInBackgroundWithBlock:^(PFConfig *config, NSError *error) {
   NSNumber *number = config[@"winningNumber"];
   NSLog(@"Yay! The number is %@!", [number stringValue]);
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFConfig.getConfigInBackgroundWithBlock {
   (config: PFConfig?, error: NSError?) -> Void in
   let number = config?["winningNumber"] as? Int
   print("Yay! The number is \(number)!")
 }
-</code></pre>
+````
 
 ## Retrieving Config
 
 `PFConfig` is built to be as robust and reliable as possible, even in the face of poor internet connections. Caching is used by default to ensure that the latest successfully fetched config is always available. In the below example we use `getConfigInBackgroundWithBlock` to retrieve the latest version of config from the server, and if the fetch fails we can simply fall back to the version that we successfully fetched before via `currentConfig`.
 
-<pre><code class="objectivec">
+````objectivec
 NSLog(@"Getting the latest config...");
 [PFConfig getConfigInBackgroundWithBlock:^(PFConfig *config, NSError *error) {
   if (!error) {
@@ -43,8 +43,8 @@ NSLog(@"Getting the latest config...");
   }
   NSLog(@"Welcome Messsage = %@", welcomeMessage);
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 print("Getting the latest config...");
 PFConfig.getConfigInBackgroundWithBlock {
   (var config: PFConfig?, error: NSError?) -> Void in
@@ -63,7 +63,7 @@ PFConfig.getConfigInBackgroundWithBlock {
     welcomeMessage = "Welcome!";
   }
 };
-</code></pre>
+````
 
 ## Current Config
 
@@ -71,7 +71,7 @@ Every `PFConfig` instance that you get is always immutable. When you retrieve a 
 
 It might be troublesome to retrieve the config from the server every time you want to use it. You can avoid this by simply using the cached `currentConfig` object and fetching the config only once in a while.
 
-<pre><code class="objectivec">
+````objectivec
 // Fetches the config at most once every 12 hours per app runtime
 const NSTimeInterval configRefreshInterval = 12.0 * 60.0 * 60.0;
 static NSDate *lastFetchedDate;
@@ -80,8 +80,8 @@ if (lastFetchedDate == nil ||
   [PFConfig getConfigInBackgroundWithBlock:nil];
   lastFetchedDate = [NSDate date];
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Fetches the config at most once every 12 hours per app runtime
 let configRefreshInterval: NSTimeInterval  = 12.0 * 60.0 * 60.0
 struct DateSingleton {
@@ -93,7 +93,7 @@ if date == nil ||
   PFConfig.getConfigInBackgroundWithBlock(nil);
   DateSingleton.lastFetchedDate = NSDate();
 }
-</code></pre>
+````
 
 
 ## Parameters

--- a/_includes/ios/extensions.md
+++ b/_includes/ios/extensions.md
@@ -26,36 +26,36 @@ To share your local data between app and extensions you need to do the following
     ![](https://parse.com/images/docs/extensions/capabilities.png)
 *   Add the following before you initialize Parse in your Main App:
 
-<pre><code class="objectivec">
+````objectivec
 // Enable data sharing in main app.
 [Parse enableDataSharingWithApplicationGroupIdentifier:@"group.com.parse.parseuidemo"];
 // Setup Parse
 [Parse setApplicationId:@"<ParseAppId>" clientKey:@"<ClientKey>"];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 // Enable data sharing in main app.
 Parse.enableDataSharingWithApplicationGroupIdentifier("group.com.parse.parseuidemo")
 // Setup Parse
 Parse.setApplicationId("<ParseAppId>", clientKey: "<ClientKey>")
-</code></pre>
+````
 
 *   Add the following before you initialize Parse in your App Extension:
 
-<pre><code class="objectivec">
+````objectivec
 // Enable data sharing in app extensions.
 [Parse enableDataSharingWithApplicationGroupIdentifier:@"group.com.parse.parseuidemo"
                                  containingApplication:@"com.parse.parseuidemo"];
 // Setup Parse
 [Parse setApplicationId:@"<ParseAppId>" clientKey:@"<ClientKey>"];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Enable data sharing in main app.
 Parse.enableDataSharingWithApplicationGroupIdentifier("group.com.parse.parseuidemo",
                             containingApplicaiton: "com.parse.parseuidemo")
 // Setup Parse
 Parse.setApplicationId("<ParseAppId>", clientKey: "<ClientKey>")
-</code></pre>
+````
 
 As you might have noticed - there are few pieces of information that need to be in sync for this to work and be enabled:
 

--- a/_includes/ios/files.md
+++ b/_includes/ios/files.md
@@ -6,15 +6,15 @@
 
 Getting started with `PFFile` is easy. First, you'll need to have the data in `NSData` form and then create a `PFFile` with it. In this example, we'll just use a string:
 
-<pre><code class="objectivec">
+````objectivec
 NSData *data = [@"Working at Parse is great!" dataUsingEncoding:NSUTF8StringEncoding];
 PFFile *file = [PFFile fileWithName:@"resume.txt" data:data];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let str = "Working at Parse is great!"
 let data = str.dataUsingEncoding(NSUTF8StringEncoding)
 let file = PFFile(name:"resume.txt", data:data)
-</code></pre>
+````
 
 Notice in this example that we give the file a name of `resume.txt`. There's two things to note here:
 
@@ -23,38 +23,38 @@ Notice in this example that we give the file a name of `resume.txt`. There's two
 
 Next you'll want to save the file up to the cloud. As with `PFObject`, there are many variants of the `save` method you can use depending on what sort of callback and error handling suits you.
 
-<pre><code class="objectivec">
+````objectivec
 [file saveInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 file.saveInBackground()
-</code></pre>
+````
 
 Finally, after the save completes, you can associate a `PFFile` onto a `PFObject` just like any other piece of data:
 
-<pre><code class="objectivec">
+````objectivec
 PFObject *jobApplication = [PFObject objectWithClassName:@"JobApplication"]
 jobApplication[@"applicantName"] = @"Joe Smith";
 jobApplication[@"applicantResumeFile"] = file;
 [jobApplication saveInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var jobApplication = PFObject(className:"JobApplication")
 jobApplication["applicantName"] = "Joe Smith"
 jobApplication["applicantResumeFile"] = file
 jobApplication.saveInBackground()
-</code></pre>
+````
 
 Retrieving it back involves calling one of the `getData` variants on the `PFFile`. Here we retrieve the resume file off another JobApplication object:
 
-<pre><code class="objectivec">
+````objectivec
 PFFile *applicantResume = anotherApplication[@"applicantResumeFile"];
 NSData *resumeData = [applicantResume getData];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let applicantResume = annotherApplication["applicationResumeFile"] as PFFile
 let resumeData = applicantResume.getData()
-</code></pre>
+````
 
 Just like on `PFObject`, you will most likely want to use the background version of `getData`.
 
@@ -62,7 +62,7 @@ Just like on `PFObject`, you will most likely want to use the background version
 
 You can easily store images by converting them to `NSData` and then using `PFFile`. Suppose you have a `UIImage` named `image` that you want to save as a `PFFile`:
 
-<pre><code class="objectivec">
+````objectivec
 NSData *imageData = UIImagePNGRepresentation(image);
 PFFile *imageFile = [PFFile fileWithName:@"image.png" data:imageData];
 
@@ -70,8 +70,8 @@ PFObject *userPhoto = [PFObject objectWithClassName:@"UserPhoto"];
 userPhoto[@"imageName"] = @"My trip to Hawaii!";
 userPhoto[@"imageFile"] = imageFile;
 [userPhoto saveInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let imageData = UIImagePNGRepresentation(image)
 let imageFile = PFFile(name:"image.png", data:imageData)
 
@@ -79,21 +79,21 @@ var userPhoto = PFObject(className:"UserPhoto")
 userPhoto["imageName"] = "My trip to Hawaii!"
 userPhoto["imageFile"] = imageFile
 userPhoto.saveInBackground()
-</code></pre>
+````
 
 Your `PFFile` will be uploaded as part of the save operation on the `userPhoto` object. It's also possible to track a `PFFile`'s [upload and download progress](#files-progress).
 
 Retrieving the image back involves calling one of the `getData` variants on the `PFFile`. Here we retrieve the image file off another `UserPhoto` named `anotherPhoto`:
 
-<pre><code class="objectivec">
+````objectivec
 PFFile *userImageFile = anotherPhoto[@"imageFile"];
 [userImageFile getDataInBackgroundWithBlock:^(NSData *imageData, NSError *error) {
     if (!error) {
         UIImage *image = [UIImage imageWithData:imageData];
     }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let userImageFile = anotherPhoto["imageFile"] as PFFile
 userImageFile.getDataInBackgroundWithBlock {
   (imageData: NSData?, error: NSError?) -> Void in
@@ -104,13 +104,13 @@ userImageFile.getDataInBackgroundWithBlock {
   }
 }
 
-</code></pre>
+````
 
 ## Progress
 
 It's easy to get the progress of both uploads and downloads using `PFFile` using `saveInBackgroundWithBlock:progressBlock:` and `getDataInBackgroundWithBlock:progressBlock:` respectively. For example:
 
-<pre><code class="objectivec">
+````objectivec
 NSData *data = [@"Working at Parse is great!" dataUsingEncoding:NSUTF8StringEncoding];
 PFFile *file = [PFFile fileWithName:@"resume.txt" data:data];
 [file saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
@@ -118,8 +118,8 @@ PFFile *file = [PFFile fileWithName:@"resume.txt" data:data];
 } progressBlock:^(int percentDone) {
   // Update your progress spinner here. percentDone will be between 0 and 100.
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let str = "Working at Parse is great!"
 let data = str.dataUsingEncoding(NSUTF8StringEncoding)
 let file = PFFile(name:"resume.txt", data:data)
@@ -130,7 +130,7 @@ file.saveInBackgroundWithBlock({
   (percentDone: Int32) -> Void in
   // Update your progress spinner here. percentDone will be between 0 and 100.
 })
-</code></pre>
+````
 
 You can delete files that are referenced by objects using the [REST API](/docs/rest/guide#files-deleting-files). You will need to provide the master key in order to be allowed to delete a file.
 

--- a/_includes/ios/geopoints.md
+++ b/_includes/ios/geopoints.md
@@ -6,21 +6,21 @@ Parse allows you to associate real-world latitude and longitude coordinates with
 
 To associate a point with an object you first need to create a `PFGeoPoint`. For example, to create a point with latitude of 40.0 degrees and -30.0 degrees longitude:
 
-<pre><code class="objectivec">
+````objectivec
 PFGeoPoint *point = [PFGeoPoint geoPointWithLatitude:40.0 longitude:-30.0];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let point = PFGeoPoint(latitude:40.0, longitude:-30.0)
-</code></pre>
+````
 
 This point is then stored in the object as a regular field.
 
-<pre><code class="objectivec">
+````objectivec
 placeObject[@"location"] = point;
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 placeObject["location"] = point
-</code></pre>
+````
 
 Note: Currently only one key in a class may be a `PFGeoPoint`.
 
@@ -28,21 +28,21 @@ Note: Currently only one key in a class may be a `PFGeoPoint`.
 
 `PFGeoPoint` also provides a helper method for fetching the user's current location. This is accomplished via `geoPointForCurrentLocationInBackground`:
 
-<pre><code class="objectivec">
+````objectivec
 [PFGeoPoint geoPointForCurrentLocationInBackground:^(PFGeoPoint *geoPoint, NSError *error) {
     if (!error) {
         // do something with the new geoPoint
     }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFGeoPoint.geoPointForCurrentLocationInBackground {
   (geoPoint: PFGeoPoint?, error: NSError?) -> Void in
   if error == nil {
     // do something with the new geoPoint
   }
 }
-</code></pre>
+````
 
 When this code is run, the following happens:
 
@@ -56,7 +56,7 @@ For those who choose to use `CLLocationManager` directly, we also provide a `+ge
 
 Now that you have a bunch of objects with spatial coordinates, it would be nice to find out which objects are closest to a point. This can be done by adding another restriction to `PFQuery` using `whereKey:nearGeoPoint:`. Getting a list of ten places that are closest to a user may look something like:
 
-<pre><code class="objectivec">
+````objectivec
 // User's location
 PFGeoPoint *userGeoPoint = userObject[@"location"];
 // Create a query for places
@@ -67,8 +67,8 @@ PFQuery *query = [PFQuery queryWithClassName:@"PlaceObject"];
 query.limit = 10;
 // Final list of objects
 placesObjects = [query findObjects];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // User's location
 let userGeoPoint = userObject["location"] as PFGeoPoint
 // Create a query for places
@@ -79,7 +79,7 @@ query.whereKey("location", nearGeoPoint:userGeoPoint)
 query.limit = 10
 // Final list of objects
 placesObjects = query.findObjects()
-</code></pre>
+````
 
  At this point `placesObjects` will be an array of objects ordered by distance (nearest to farthest) from `userGeoPoint`. Note that if an additional `orderByAscending:`/`orderByDescending:` constraint is applied, it will take precedence over the distance ordering.
 
@@ -87,20 +87,20 @@ placesObjects = query.findObjects()
 
 It's also possible to query for the set of objects that are contained within a particular area. To find the objects in a rectangular bounding box, add the `whereKey:withinGeoBoxFromSouthwest:toNortheast:` restriction to your `PFQuery`.
 
-<pre><code class="objectivec">
+````objectivec
 PFGeoPoint *swOfSF = [PFGeoPoint geoPointWithLatitude:37.708813 longitude:-122.526398];
 PFGeoPoint *neOfSF = [PFGeoPoint geoPointWithLatitude:37.822802 longitude:-122.373962];
 PFQuery *query = [PFQuery queryWithClassName:@"PizzaPlaceObject"];
 [query whereKey:@"location" withinGeoBoxFromSouthwest:swOfSF toNortheast:neOfSF];
 NSArray *pizzaPlacesInSF = [query findObjects];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let swOfSF = PFGeoPoint(latitude:37.708813, longitude:-122.526398)
 let neOfSF = PFGeoPoint(latitude:37.822802, longitude:-122.373962)
 var query = PFQuery(className:"PizzaPlaceObject")
 query.whereKey("location", withinGeoBoxFromSouthwest:swOfSF, toNortheast:neOfSF)
 var pizzaPlacesInSF = query.findObjects()
-</code></pre>
+````
 
 ## Caveats
 

--- a/_includes/ios/handling-errors.md
+++ b/_includes/ios/handling-errors.md
@@ -4,37 +4,37 @@ Parse has a few simple patterns for surfacing errors and handling them in your c
 
 There are two types of errors you may encounter. The first is those dealing with logic errors in the way you're using the SDK. These types of errors result in an `NSException` being raised. For an example take a look at the following code:
 
-<pre><code class="objectivec">
+````objectivec
 PFUser *user = [PFUser user];
 [user signUp];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let user = PFUser()
 user.signUp
-</code></pre>
+````
 
 This will throw an `NSInternalInconsistencyException` because `signUp` was called without first setting the required properties (`username` and `password`).
 
 The second type of error is one that occurs when interacting with the Parse Cloud over the network. These errors are either related to problems connecting to the cloud or problems performing the requested operation. Let's take a look at another example:
 
-<pre><code class="objectivec">
+````objectivec
 - (void)getMyNote {
     PFQuery *query = [PFQuery queryWithClassName:@"Note"];
     [query getObjectInBackgroundWithId:@"thisObjectIdDoesntExist"
                                 target:self
                               selector:@selector(callbackForGet:error:)];
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 func getMyNote() -> Void {
     let query = PFQuery(className: "Note")
     query.getObjectInBackgroundWithId("thisObjectIdDoesntExist", target: self, selector: Selector("callbackForGet:error:"))
 }
-</code></pre>
+````
 
 In the above code, we try to fetch an object with a non-existent `objectId`. The Parse Cloud will return an error with an error code set in `code` and message in the error's `userInfo`. Here's how to handle it properly in your callback:
 
-<pre><code class="objectivec">
+````objectivec
 - (void)callbackForGet:(PFObject *)result error:(NSError *)error {
     if (result) {
         NSLog(@"Everything went fine!");
@@ -46,8 +46,8 @@ In the above code, we try to fetch an object with a non-existent `objectId`. The
         }
     }
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 func callbackForGet(result: PFObject?, error: NSError?) -> Void {
     if let result = result {
         print("Everything went fine!")
@@ -62,11 +62,11 @@ func callbackForGet(result: PFObject?, error: NSError?) -> Void {
         }
     }
 }
-</code></pre>
+````
 
 The query might also fail because the device couldn't connect to the Parse Cloud. Here's the same callback but with a bit of extra code to handle that scenario explicitly:
 
-<pre><code class="objectivec">
+````objectivec
 - (void)callbackForGet:(PFObject *)result error:(NSError *)error {
     if (result) {
         NSLog(@"Everything went fine!");
@@ -81,8 +81,8 @@ The query might also fail because the device couldn't connect to the Parse Cloud
         }
     }
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 func callbackForGet(result: PFObject?, error: NSError?) -> Void {
     if let result = result {
         print("Everything went fine!")
@@ -100,11 +100,11 @@ func callbackForGet(result: PFObject?, error: NSError?) -> Void {
         }
     }
 }
-</code></pre>
+````
 
 When the callback expects a `NSNumber`, its `boolValue` tells you whether the operation succeeded or not. For example, this is how you might implement the callback for `PFObject`'s `saveInBackgroundWithTarget:selector:` method:
 
-<pre><code class="objectivec">
+````objectivec
 - (void)callbackForSave:(NSNumber *)result error:(NSError *)error {
     if ([result boolValue]) {
         NSLog(@"Everything went fine!");
@@ -116,8 +116,8 @@ When the callback expects a `NSNumber`, its `boolValue` tells you whether the op
         }
     }
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 func callbackForSave(result: NSNumber?, error: NSError?) -> Void {
     if result?.boolValue == true {
         print("Everything went fine!")
@@ -132,7 +132,7 @@ func callbackForSave(result: NSNumber?, error: NSError?) -> Void {
         }
     }
 }
-</code></pre>
+````
 
 For synchronous (non-background) methods, error handling is mostly the same except that instead of a `NSNumber` representing success or failure you'll get an actual `BOOL` directly.
 

--- a/_includes/ios/in-app-purchases.md
+++ b/_includes/ios/in-app-purchases.md
@@ -17,24 +17,24 @@ Note that this is a tricky setup process so please ensure you follow Apple's doc
 Once the setup above is complete, you can begin working with in-app purchases.
 
 On the main thread, register the handlers for the products:
-<pre><code class="objectivec">
+````objectivec
 // Use the product identifier from iTunes to register a handler.
 [PFPurchase addObserverForProduct:@"Pro" block:^(SKPaymentTransaction *transaction) {
     // Write business logic that should run once this product is purchased.
     isPro = YES;
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Use the product identifier from iTunes to register a handler.
 PFPurchase.addObserverForProduct("Pro") {
     (transaction: SKPaymentTransaction?) -> Void in
     // Write business logic that should run once this product is purchased.
     isPro = YES;
 }
-</code></pre>
+````
 Note that this does not make the purchase, but simply registers a block to be run if a purchase is made later. This registration must be done on the main thread, preferably as soon as the app is launched, i.e. in `application:didFinishLaunchingWithOptions:`. If there are multiple products, we recommend registering all product handlers in the same method, such as `application:didFinishLaunchingWithOptions`:
 
-<pre><code class="objectivec">
+````objectivec
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     ...
     [PFPurchase addObserverForProduct:@"Pro" block:^(SKPaymentTransaction *transaction) {
@@ -44,8 +44,8 @@ Note that this does not make the purchase, but simply registers a block to be ru
         isVip = YES;
     }];
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFPurchase.addObserverForProduct("Pro") {
     (transaction: SKPaymentTransaction?) -> Void in
     isPro = YES;
@@ -54,24 +54,24 @@ PFPurchase.addObserverForProduct("VIP") {
     (transaction: SKPaymentTransaction?) -> Void in
     isVip = YES;
 }
-</code></pre>
+````
 
 To initiate a purchase, use the `+[PFPurchase buyProduct:block:]` method:
-<pre><code class="objectivec">
+````objectivec
 [PFPurchase buyProduct:@"Pro" block:^(NSError *error) {
     if (!error) {
         // Run UI logic that informs user the product has been purchased, such as displaying an alert view.
     }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFPurchase.buyProduct("Pro") {
     (error: NSError?) -> Void in
     if error == nil {
         // Run UI logic that informs user the product has been purchased, such as displaying an alert view.
     }
 }
-</code></pre>
+````
 
 The call to `buyProduct:block:` brings up a dialogue that asks users to enter their Apple credentials. When the user's identity is verified, the product will be purchased. If the product is non-consumable and has been purchased by the user before, the user will not be charged.
 
@@ -88,7 +88,7 @@ Many IAP products such as books and movies have associated content files that sh
  5.  `order`: the order this product should appear in `PFProductTableViewController`. This is used only in `PFProductTableViewController`; fill in 0 if the order is not important,
  6.  `download`: the downloadable content file. Note that the file uploaded in `download` is not publicly accessible, and only becomes available for download when a purchase is made. `downloadName` is the name of the file on disk once downloaded. You don't need to fill this in.
 3.  Next, you need to register the product handler:
-<pre><code class="objectivec">
+````objectivec
 [PFPurchase addObserverForProduct:@"Pro" block:^(SKPaymentTransaction *transaction) {
     [PFPurchase downloadAssetForTransaction:transaction completion:^(NSString *filePath, NSError *error) {
         if (!error) {
@@ -96,8 +96,8 @@ Many IAP products such as books and movies have associated content files that sh
         }
     }];
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFPurchase.addObserverForProduct("Pro") {
     (transaction: SKPaymentTransaction?) -> Void in
     if let transaction = transaction {
@@ -109,24 +109,24 @@ PFPurchase.addObserverForProduct("Pro") {
         }
     }
 }
-</code></pre>
+````
 Note that this does not make the purchase, but simply registers a block to be run if a purchase is made later. The call to `downloadAssetForTransaction:completion:` passes the receipt of the purchase to the Parse Cloud, which then verifies with Apple that the purchase was made. Once the receipt is verified, the purchased file is downloaded.
 
 To make the purchase:
-<pre><code class="objectivec">
+````objectivec
 [PFPurchase buyProduct:@"Pro" block:^(NSError *error) {
     if (!error) {
         // run UI logic that informs user the product has been purchased, such as displaying an alert view.
     }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFPurchase.buyProduct("Pro") {(error: NSError?) -> Void in
     if error == nil {
         // run UI logic that informs user the product has been purchased, such as displaying an alert view.
     }
 }
-</code></pre>
+````
 
 The call to `buyProduct:block:` brings up a dialogue that asks users to enter their Apple credentials. When the user's identity is verified, the product will be purchased.
 
@@ -136,17 +136,17 @@ You can query the product objects created in the data browser using `PFProduct`.
 
 For example, here's a simple query to get a product:
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *productQuery = [PFProduct query];
 PFProduct *product = [[productQuery findObjects] lastObject];
 NSLog(@"%@, %@", product.productIdentifier, product.title);
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let productQuery = PFProduct.query()
 if let product = productQuery.findObjects.lastObject as? PFProduct {}
   print(product.productIdentifier, product.title)
 }
-</code></pre>
+````
 
 ## PFProductTableViewController
 

--- a/_includes/ios/local-datastore.md
+++ b/_includes/ios/local-datastore.md
@@ -2,7 +2,7 @@
 
 The Parse iOS/OS X SDK provides a local datastore which can be used to store and retrieve `PFObject`s, even when the network is unavailable. To enable this functionality, add `libsqlite3.dylib` and call `[Parse enableLocalDatastore]` before your call to `setApplicationId:clientKey:`.
 
-<pre><code class="objectivec">
+````objectivec
 @implementation AppDelegate
 
 - (void)application:(UIApplication *)application didFinishLaunchWithOptions:(NSDictionary *)options {
@@ -11,8 +11,8 @@ The Parse iOS/OS X SDK provides a local datastore which can be used to store and
 }
 
 @end
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
@@ -21,7 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     Parse.setApplicationId("parseAppId", clientKey: "parseClientKey")
   }
 }
-</code></pre>
+````
 
 There are a couple of side effects of enabling the local datastore that you should be aware of. When enabled, there will only be one instance of any given `PFObject`. For example, imagine you have an instance of the `"GameScore"` class with an `objectId` of `"xWMyZ4YEGZ"`, and then you issue a `PFQuery` for all instances of `"GameScore"` with that `objectId`. The result will be the same instance of the object you already have in memory.
 
@@ -33,35 +33,35 @@ Calling the `saveEventually` method on a `PFObject` will cause the object to be 
 
 You can store a `PFObject` in the local datastore by pinning it. Pinning a `PFObject` is recursive, just like saving, so any objects that are pointed to by the one you are pinning will also be pinned. When an object is pinned, every time you update it by fetching or saving new data, the copy in the local datastore will be updated automatically. You don't need to worry about it at all.
 
-<pre><code class="objectivec">
+````objectivec
 PFObject *gameScore = [PFObject objectWithClassName:@"GameScore"];
 gameScore[@"score"] = @1337;
 gameScore[@"playerName"] = @"Sean Plott";
 gameScore[@"cheatMode"] = @NO;
 [gameScore pinInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let gameScore = PFObject(className:"GameScore")
 gameScore["score"] = 1337
 gameScore["playerName"] = "Sean Plott"
 gameScore["cheatMode"] = false
 gameScore.pinInBackground()
-</code></pre>
+````
 
 If you have multiple objects, you can pin them all at once with the `pinAllInBackground` convenience method.
 
-<pre><code class="objectivec">
+````objectivec
 [PFObject pinAllInBackground:listOfObjects];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFObject.pinAllInBackground(listOfObjects)
-</code></pre>
+````
 
 ## Retrieving Objects
 
 Storing objects is great, but it's only useful if you can then get the objects back out later. Retrieving an object from the local datastore works just like retrieving one over the network. The only difference is calling the `fromLocalDatastore` method to tell the `PFQuery` where to look for its results.
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 [query fromLocalDatastore];
 [[query getObjectInBackgroundWithId:@"xWMyZ4YE"] continueWithBlock:^id(BFTask *task) {
@@ -73,8 +73,8 @@ PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
   // task.result will be your game score
   return task;
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let query = PFQuery(className: "GameScore")
 query.fromLocalDatastore()
 query.getObjectInBackgroundWithId("xWMyZ4YE").continueWithBlock {
@@ -87,13 +87,13 @@ query.getObjectInBackgroundWithId("xWMyZ4YE").continueWithBlock {
     // task.result will be your game score
     return task;
 }
-</code></pre>
+````
 
 ## Querying
 
 Often, you'll want to find a whole list of objects that match certain criteria, instead of getting a single object by id. To do that, you can use a [PFQuery](#queries). Any `PFQuery` can be used with the local datastore just as with the network. The results will include any object you have pinned that matches the query. Any unsaved changes you have made to the object will be considered when evaluating the query. So you can find a local object that matches, even if it was never returned from the server for this particular query.
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 [query fromLocalDatastore];
 [query whereKey:@"playerName" equalTo:@"Joe Bob"];
@@ -106,8 +106,8 @@ PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
   NSLog(@"Retrieved %d", task.result.count);
   return task;
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let query = PFQuery(className: "GameScore")
 query.fromLocalDatastore()
 query.whereKey("playerName", equalTo: "Joe Bob")
@@ -121,7 +121,7 @@ query.findObjectsInBackground().continueWithBlock {
     print("Retrieved \(task.result.count)")
     return task
 }
-</code></pre>
+````
 
 ## Security
 
@@ -129,65 +129,65 @@ The same security model that applies to objects in Parse applies to objects in t
 
 The only difference is that you won't be able to access any data protected by Role based ACLs due to the fact that the Roles are stored on the server. To access this data protected by Role based ACLs, you will need to ignore ACLs when executing a Local Datastore query:
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [[[PFQuery queryWithClassName:@"Note"]
                    fromLocalDatastore]
                   ignoreACLs];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let query = PFQuery(className: "Note")
     .fromLocalDatastore
     .ignoreACLs
-</code></pre>
+````
 
 
 ## Unpinning
 
 When you are done with an object and no longer need it to be in the local datastore, you can simply unpin it. This will free up disk space on the device and keep your queries on the local datastore running quickly.
 
-<pre><code class="objectivec">
+````objectivec
 [gameScore unpinInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 gameScore.unpinInBackground()
-</code></pre>
+````
 
 There's also a method to unpin several objects at once.
 
-<pre><code class="objectivec">
+````objectivec
 [PFObject unpinAllInBackground:listOfObjects];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFObject.unpinAllInBackground(listOfObjects)
-</code></pre>
+````
 
 ## Pinning with Labels
 
 Manually pinning and unpinning each object individual is a bit like using `malloc` and `free`. It is a very powerful tool, but it can be difficult to manage what objects get stored in complex scenarios. For example, imagine you are making a game with separate high score lists for global high scores and your friends' high scores. If one of your friends happens to have a globally high score, you need to make sure you don't unpin them completely when you remove them from one of the cached queries. To make these scenarios easier, you can also pin with a label. Labels indicate a group of objects that should be stored together.
 
-<pre><code class="objectivec">
+````objectivec
 // Add several objects with a label.
 [PFObject pinAllInBackground:someGameScores withName:@"MyScores"];
 
 // Add another object with the same label.
 [anotherGameScore pinInBackgroundWithName:@"MyScores"];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Add several objects with a label.
 PFObject.pinAllInBackground(objects:someGameScores withName:"MyScores")
 
 // Add another object with the same label.
 anotherGameScore.pinInBackgroundWithName("MyScores")
-</code></pre>
+````
 
 To unpin all of the objects with the same label at the same time, you can pass a label to the unpin methods. This saves you from having to manually track which objects are in each group you care about.
 
-<pre><code class="objectivec">
+````objectivec
 [PFObject unpinAllObjectsInBackgroundWithName:@"MyScores"];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFObject.unpinAllObjectsInBackgroundWithName("MyScores")
-</code></pre>
+````
 
 Any object will stay in the datastore as long as it is pinned with any label. In other words, if you pin an object with two different labels, and then unpin it with one label, the object will stay in the datastore until you also unpin it with the other label.
 
@@ -195,7 +195,7 @@ Any object will stay in the datastore as long as it is pinned with any label. In
 
 Pinning with labels makes it easy to cache the results of queries. You can use one label to pin the results of each different query. To get new results from the network, just do a query and update the pinned objects.
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 [query orderByDescending:@"score"];
 
@@ -207,8 +207,8 @@ PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
     return [PFObject pinAllInBackground:scores withName:@"HighScores"];
   }];
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let query = PFQuery(className:"GameScore")
 query.orderByDescending("score")
 
@@ -224,12 +224,12 @@ query.findObjectsInBackground().continueWithSuccessBlock({
         return PFObject.pinAllInBackground(scores as [AnyObject], withName: "HighScores")
     })
 })
-</code></pre>
+````
 
 When you want to get the cached results for the query, you can then
       run the same query against the local datastore.
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 [query fromLocalDatastore];
 [query orderByDescending:@"score"];
@@ -243,8 +243,8 @@ PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
   // Yay! Cached scores!
   return task;
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let query = PFQuery(className:"GameScore")
 query.fromLocalDatastore()
 query.orderByDescending("score")
@@ -259,22 +259,22 @@ query.findObjectsInBackground().continueWithBlock({
     // Yay! Cached scores!
     return task
 })
-</code></pre>
+````
 
 ## Syncing Local Changes
 
 Once you've saved some changes locally, there are a few different ways you can save those changes back to Parse over the network. The easiest way to do this is with `saveEventually`. When you call `saveEventually` on a `PFObject`, it will be pinned until it can be saved. The SDK will make sure to save the object the next time the network is available.
 
-<pre><code class="objectivec">
+````objectivec
 [gameScore saveEventually];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 gameScore.saveEventually()
-</code></pre>
+````
 
 If you'd like to have more control over the way objects are synced, you can keep them in the local datastore until you are ready to save them yourself using `saveInBackground`. To manage the set of objects that need to be saved, you can again use a label. The `fromPinWithName:` method on `PFQuery` makes it easy to fetch just the objects you care about.
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 [query fromPinWithName:@"MyChanges"];
 [[query findObjectsInBackground] continueWithBlock:^id(BFTask *task) {
@@ -286,8 +286,8 @@ PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
   }
   return task;
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let query = PFQuery(className:"GameScore")
 query.fromPinWithName("MyChanges")
 query.findObjectsInBackground().continueWithBlock({
@@ -301,4 +301,4 @@ query.findObjectsInBackground().continueWithBlock({
   }
   return task
 })
-</code></pre>
+````

--- a/_includes/ios/objects.md
+++ b/_includes/ios/objects.md
@@ -6,9 +6,9 @@ Storing data on Parse is built around the `PFObject`. Each `PFObject` contains k
 
 For example, let's say you're tracking high scores for a game. A single `PFObject` could contain:
 
-<pre><code class="javascript">
+````javascript
 score: 1337, playerName: "Sean Plott", cheatMode: false
-</code></pre>
+````
 
 
 Keys must be alphanumeric strings. Values can be strings, numbers, booleans, or even arrays and dictionaries - anything that can be JSON-encoded.
@@ -19,7 +19,7 @@ Each `PFObject` has a class name that you can use to distinguish different sorts
 
 Let's say you want to save the `GameScore` described above to the Parse Cloud. The interface is similar to a `NSMutableDictionary`, plus the `saveInBackground` method:
 
-<pre><code class="objc">
+````objc
 PFObject *gameScore = [PFObject objectWithClassName:@"GameScore"];
 gameScore[@"score"] = @1337;
 gameScore[@"playerName"] = @"Sean Plott";
@@ -31,9 +31,9 @@ gameScore[@"cheatMode"] = @NO;
     // There was a problem, check error.description
   }
 }];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 var gameScore = PFObject(className:"GameScore")
 gameScore["score"] = 1337
 gameScore["playerName"] = "Sean Plott"
@@ -46,14 +46,14 @@ gameScore.saveInBackgroundWithBlock {
     // There was a problem, check error.description
   }
 }
-</code></pre>
+````
 
 After this code runs, you will probably be wondering if anything really happened. To make sure the data was saved, you can look at the Data Browser in your app on Parse. You should see something like this:
 
-<pre><code class="javascript">
+````javascript
 objectId: "xWMyZ4YEGZ", score: 1337, playerName: "Sean Plott", cheatMode: false,
 createdAt:"2011-06-10T18:33:42Z", updatedAt:"2011-06-10T18:33:42Z"
-</code></pre>
+````
 
 There are two things to note here. You didn't have to configure or set up a new Class called `GameScore` before running this code. Your Parse app lazily creates this Class for you when it first encounters it.
 
@@ -65,7 +65,7 @@ Note: You can use the `saveInBackgroundWithBlock` method to provide additional l
 
 Saving data to the cloud is fun, but it's even more fun to get that data out again. If you have the `objectId`, you can retrieve the whole `PFObject` using a `PFQuery`.  This is an asynchronous method, with variations for using either blocks or callback methods:
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 [query getObjectInBackgroundWithId:@"xWMyZ4YEGZ" block:^(PFObject *gameScore, NSError *error) {
     // Do something with the returned PFObject in the gameScore variable.
@@ -74,9 +74,9 @@ PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 // The InBackground methods are asynchronous, so any code after this will run
 // immediately.  Any code that depends on the query result should be moved
 // inside the completion block above.
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 var query = PFQuery(className:"GameScore")
 query.getObjectInBackgroundWithId("xWMyZEGZ") {
   (gameScore: PFObject?, error: NSError?) -> Void in
@@ -86,46 +86,46 @@ query.getObjectInBackgroundWithId("xWMyZEGZ") {
     print(error)
   }
 }
-</code></pre>
+````
 
 To get the values out of the `PFObject`, you can use either the `objectForKey:` method or the `[]` subscripting operator:
 
-<pre><code class="objectivec">
+````objectivec
 int score = [[gameScore objectForKey:@"score"] intValue];
 NSString *playerName = gameScore[@"playerName"];
 BOOL cheatMode = [gameScore[@"cheatMode"] boolValue];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 let score = gameScore["score"] as Int
 let playerName = gameScore["playerName"] as String
 let cheatMode = gameScore["cheatMode"] as Bool
-</code></pre>
+````
 
 The three special values are provided as properties:
 
-<pre><code class="objectivec">
+````objectivec
 NSString *objectId = gameScore.objectId;
 NSDate *updatedAt = gameScore.updatedAt;
 NSDate *createdAt = gameScore.createdAt;
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 let objectId = gameScore.objectId
 let updatedAt = gameScore.updatedAt
 let createdAt = gameScore.createdAt
-</code></pre>
+````
 
 If you need to refresh an object you already have with the latest data that
     is in the Parse Cloud, you can call the `fetch` method like so:
 
-<pre><code class="objectivec">
+````objectivec
 [myObject fetch];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 myObject.fetch()
-</code></pre>
+````
 
 Note: In a similar way to the `save` methods, you can use the `fetchInBackgroundWithBlock` or `fetchInBackgroundWithTarget:selector:` methods to provide additional logic which will run after fetching the object.
 
@@ -133,21 +133,21 @@ Note: In a similar way to the `save` methods, you can use the `fetchInBackground
 
 Parse also lets you store objects in a [local datastore](#local-datastore) on the device itself. You can use this for data that doesn't need to be saved to the cloud, but this is especially useful for temporarily storing data so that it can be synced later. To enable the datastore, add `libsqlite3.dylib` and call `[Parse enableLocalDatastore]` in your `AppDelegate` `application:didFinishLaunchWithOptions:` before calling `[Parse setApplicationId:clientKey:]`. Once the local datastore is enabled, you can store an object by pinning it.
 
-<pre><code class="objectivec">
+````objectivec
 PFObject *gameScore = [PFObject objectWithClassName:@"GameScore"];
 gameScore[@"score"] = 1337;
 gameScore[@"playerName"] = @"Sean Plott";
 gameScore[@"cheatMode"] = @NO;
 [gameScore pinInBackground];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 let gameScore = PFObject(className:"GameScore")
 gameScore["score"] = 1337
 gameScore["playerName"] = "Sean Plott"
 gameScore["cheatMode"] = false
 gameScore.pinInBackground()
-</code></pre>
+````
 
 As with saving, this recursively stores every object and file that `gameScore` points to, if it has been fetched from the cloud. Whenever you save changes to the object, or fetch new changes from Parse, the copy in the datastore will be automatically updated, so you don't have to worry about it.
 
@@ -155,7 +155,7 @@ As with saving, this recursively stores every object and file that `gameScore` p
 
 Storing an object is only useful if you can get it back out. To get the data for a specific object, you can use a `PFQuery` just like you would while on the network, but using the `fromLocalDatastore` method to tell it where to get the data.
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 [query fromLocalDatastore];
 [[query getObjectInBackgroundWithId:@"xWMyZ4YEGZ"] continueWithBlock:^id(BFTask *task) {
@@ -167,9 +167,9 @@ PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
   // task.result will be your game score
   return task;
 }];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 let query = PFQuery(className:"GameScore")
 query.fromLocalDatastore()
 query.getObjectInBackgroundWithId("xWMyZ4YEGZ").continueWithBlock({
@@ -182,11 +182,11 @@ query.getObjectInBackgroundWithId("xWMyZ4YEGZ").continueWithBlock({
   // task.result will be your game score
   return task
 })
-</code></pre>
+````
 
 If you already have an instance of the object, you can instead use the `fetchFromLocalDatastoreInBackground` method.
 
-<pre><code class="objectivec">
+````objectivec
 PFObject *object = [PFObject objectWithoutDataWithClassName:@"GameScore" objectId:@"xWMyZ4YEGZ"];
 [[object fetchFromLocalDatastoreInBackground] continueWithBlock:^id(BFTask *task) {
   if (task.error) {
@@ -197,9 +197,9 @@ PFObject *object = [PFObject objectWithoutDataWithClassName:@"GameScore" objectI
   // task.result will be your game score
   return task;
 }];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 let object = PFObject(withoutDataWithClassName:"GameScore", objectId:"xWMyZ4YEGZ")
 object.fetchFromLocalDatastoreInBackground().continueWithBlock({
   (task: BFTask!) -> AnyObject! in
@@ -211,46 +211,46 @@ object.fetchFromLocalDatastoreInBackground().continueWithBlock({
   // task.result will be your game score
   return task
 })
-</code></pre>
+````
 
 ### Unpinning Objects
 
 When you are done with the object and no longer need to keep it on the device, you can release it with `unpinInBackground`.
 
-<pre><code class="objectivec">
+````objectivec
 [gameScore unpinInBackground];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 gameScore.unpinInBackground()
-</code></pre>
+````
 
 ## Saving Objects Offline
 
 Most save functions execute immediately, and inform your app when the save is complete. If you don't need to know when the save has finished, you can use `saveEventually` instead. The advantage is that if the user currently doesn't have a network connection, `saveEventually` will store the update on the device until a network connection is re-established. If your app is closed before the connection is back, Parse will try again the next time the app is opened. All calls to `saveEventually` (and `deleteEventually`) are executed in the order they are called, so it is safe to call `saveEventually` on an object multiple times.
 
-<pre><code class="objectivec">
+````objectivec
 // Create the object.
 PFObject *gameScore = [PFObject objectWithClassName:@"GameScore"];
 gameScore[@"score"] = @1337;
 gameScore[@"playerName"] = @"Sean Plott";
 gameScore[@"cheatMode"] = @NO;
 [gameScore saveEventually];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 var gameScore = PFObject(className:"GameScore")
 gameScore["score"] = 1337
 gameScore["playerName"] = "Sean Plott"
 gameScore["cheatMode"] = false
 gameScore.saveEventually()
-</code></pre>
+````
 
 ## Updating Objects
 
 Updating an object is simple. Just set some new data on it and call one of the save methods. Assuming you have saved the object and have the `objectId`, you can retrieve the `PFObject` using a `PFQuery` and update its data:
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 
 // Retrieve the object by id
@@ -262,9 +262,9 @@ PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
     gameScore[@"score"] = @1338;
     [gameScore saveInBackground];
 }];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 var query = PFQuery(className:"GameScore")
 query.getObjectInBackgroundWithId("xWMyZEGZ") {
   (gameScore: PFObject?, error: NSError?) -> Void in
@@ -276,7 +276,7 @@ query.getObjectInBackgroundWithId("xWMyZEGZ") {
     gameScore.saveInBackground()
   }
 }
-</code></pre>
+````
 
 The client automatically figures out which data has changed so only "dirty" fields will be sent to Parse. You don't need to worry about squashing data that you didn't intend to update.
 
@@ -286,7 +286,7 @@ The above example contains a common use case. The "score" field is a counter tha
 
 To help with storing counter-type data, Parse provides methods that atomically increment (or decrement) any number field. So, the same update can be rewritten as:
 
-<pre><code class="objectivec">
+````objectivec
 [gameScore incrementKey:@"score"];
 [gameScore saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
   if (succeeded) {
@@ -295,9 +295,9 @@ To help with storing counter-type data, Parse provides methods that atomically i
     // There was a problem, check error.description
   }
 }];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 gameScore.incrementKey("score")
 gameScore.saveInBackgroundWithBlock {
   (success: Bool, error: NSError?) -> Void in
@@ -307,7 +307,7 @@ gameScore.saveInBackgroundWithBlock {
     // There was a problem, check error.description
   }
 }
-</code></pre>
+````
 
 You can also increment by any amount using `incrementKey:byAmount:`.
 
@@ -321,15 +321,15 @@ To help with storing array data, there are three operations that can be used to 
 
 For example, we can add items to the set-like "skills" field like so:
 
-<pre><code class="objectivec">
+````objectivec
 [gameScore addUniqueObjectsFromArray:@[@"flying", @"kungfu"] forKey:@"skills"];
 [gameScore saveInBackground];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 gameScore.addUniqueObjectsFromArray(["flying", "kungfu"], forKey:"skills")
 gameScore.saveInBackground()
-</code></pre>
+````
 
 Note that it is not currently possible to atomically add and remove items from an array in the same save.
     You will have to call `save` in between every different kind of array operation.
@@ -338,33 +338,33 @@ Note that it is not currently possible to atomically add and remove items from a
 
 To delete an object from the cloud:
 
-<pre><code class="objectivec">
+````objectivec
 [gameScore deleteInBackground];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 gameScore.deleteInBackground()
-</code></pre>
+````
 
 If you want to run a callback when the delete is confirmed, you can use the `deleteInBackgroundWithBlock:` or `deleteInBackgroundWithTarget:selector:` methods. If you want to block the calling thread, you can use the `delete` method.
 
 You can delete a single field from an object with the `removeObjectForKey` method:
 
-<pre><code class="objectivec">
+````objectivec
 // After this, the playerName field will be empty
 [gameScore removeObjectForKey:@"playerName"];
 
 // Saves the field deletion to the Parse Cloud
 [gameScore saveInBackground];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 // After this, the playerName field will be empty
 gameScore.removeObjectForKey("playerName")
 
 // Saves the field deletion to the Parse Cloud
 gameScore.saveInBackground()
-</code></pre>
+````
 
 ## Relational Data
 
@@ -372,7 +372,7 @@ Objects can have relationships with other objects. To model this behavior, any `
 
 For example, each `Comment` in a blogging app might correspond to one `Post`. To create a new `Post` with a single `Comment`, you could write:
 
-<pre><code class="objectivec">
+````objectivec
 // Create the post
 PFObject *myPost = [PFObject objectWithClassName:@"Post"];
 myPost[@"title"] = @"I'm Hungry";
@@ -387,9 +387,9 @@ myComment[@"parent"] = myPost;
 
 // This will save both myPost and myComment
 [myComment saveInBackground];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 // Create the post
 var myPost = PFObject(className:"Post")
 myPost["title"] = "I'm Hungry"
@@ -404,42 +404,42 @@ myComment["parent"] = myPost
 
 // This will save both myPost and myComment
 myComment.saveInBackground()
-</code></pre>
+````
 
 You can also link objects using just their `objectId`s like so:
 
-<pre><code class="objectivec">
+````objectivec
 // Add a relation between the Post with objectId "1zEcyElZ80" and the comment
 myComment[@"parent"] = [PFObject objectWithoutDataWithClassName:@"Post" objectId:@"1zEcyElZ80"];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 // Add a relation between the Post with objectId "1zEcyElZ80" and the comment
 myComment["parent"] = PFObject(withoutDataWithClassName:"Post", objectId:"1zEcyElZ80")
-</code></pre>
+````
 
 By default, when fetching an object, related `PFObject`s are not fetched.  These objects' values cannot be retrieved until they have been fetched like so:
 
-<pre><code class="objectivec">
+````objectivec
 PFObject *post = fetchedComment[@"parent"];
 [post fetchIfNeededInBackgroundWithBlock:^(PFObject *post, NSError *error) {
   NSString *title = post[@"title"];
   // do something with your title variable
 }];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 var post = myComment["parent"] as PFObject
 post.fetchIfNeededInBackgroundWithBlock {
   (post: PFObject?, error: NSError?) -> Void in
   let title = post?["title"] as? NSString
   // do something with your title variable
 }
-</code></pre>
+````
 
 You can also model a many-to-many relation using the `PFRelation` object.  This works similar to an `NSArray` of `PFObjects`, except that you don't need to download all the Objects in a relation at once.  This allows `PFRelation` to scale to many more objects than the `NSArray` of `PFObject` approach.  For example, a `User` may have many `Post`s that they might like.  In this case, you can store the set of `Post`s that a `User` likes using `relationForKey:`.  In order to add a post to the list, the code would look something like:
 
-<pre><code class="objectivec">
+````objectivec
 PFUser *user = [PFUser currentUser];
 PFRelation *relation = [user relationForKey:@"likes"];
 [relation addObject:post];
@@ -450,9 +450,9 @@ PFRelation *relation = [user relationForKey:@"likes"];
     // There was a problem, check error.description
   }
 }];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 var user = PFUser.currentUser()
 var relation = user.relationForKey("likes")
 relation.addObject(post)
@@ -464,21 +464,21 @@ user.saveInBackgroundWithBlock {
     // There was a problem, check error.description
   }
 }
-</code></pre>
+````
 
 You can remove a post from the `PFRelation` with something like:
 
-<pre><code class="objectivec">
+````objectivec
 [relation removeObject:post];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 relation.removeObject(post)
-</code></pre>
+````
 
 By default, the list of objects in this relation are not downloaded.  You can get the list of `Post`s by using calling `findObjectsInBackgroundWithBlock:` on the `PFQuery` returned by `query`.  The code would look like:
 
-<pre><code class="objectivec">
+````objectivec
 [[relation query] findObjectsInBackgroundWithBlock:^(NSArray *objects, NSError *error) {
   if (error) {
      // There was an error
@@ -486,9 +486,9 @@ By default, the list of objects in this relation are not downloaded.  You can ge
     // objects has all the Posts the current user liked.
   }
 }];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 relation.query().findObjectsInBackgroundWithBlock {
   (objects: [PFObject]?, error: NSError?) -> Void in
   if let error = error {
@@ -497,19 +497,19 @@ relation.query().findObjectsInBackgroundWithBlock {
     // objects has all the Posts the current user liked.
   }
 }
-</code></pre>
+````
 
 If you want only a subset of the `Post`s you can add extra constraints to the `PFQuery` returned by `query` like this:
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [relation query];
 // Add other query constraints.
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 var query = relation.query()
 // Add other query constraints.
-</code></pre>
+````
 
 For more details on `PFQuery` please look at the query portion of this guide.  A `PFRelation` behaves similar to an `NSArray` of `PFObject`, so any queries you can do on arrays of objects (other than `includeKey:`) you can do on `PFRelation`.
 
@@ -530,7 +530,7 @@ So far we've used values with type `NSString`, `NSNumber`, and `PFObject`. Parse
 
 Some examples:
 
-<pre><code class="objectivec">
+````objectivec
 NSNumber *number = @42;
 NSNumber *bool = @NO;
 NSString *string = [NSString stringWithFormat:@"the number is %@", number];
@@ -550,9 +550,9 @@ bigObject[@"myObjectKey"] = dictionary; // shows up as 'object' in the Data Brow
 bigObject[@"anyKey"] = null; // this value can only be saved to an existing key
 bigObject[@"myPointerKey"] = pointer; // shows up as Pointer MyClassName in the Data Browser
 [bigObject saveInBackground];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 let number = 42
 let bool = false
 let string = "the number is \(number)"
@@ -572,7 +572,7 @@ bigObject["myObjectKey"] = dictionary // shows up as 'object' in the Data Browse
 bigObject["anyKey"] = null // this value can only be saved to an existing key
 bigObject["myPointerKey"] = pointer // shows up as Pointer MyClassName in the Data Browser
 bigObject.saveInBackground()
-</code></pre>
+````
 
 We do not recommend storing large pieces of binary data like images or documents on `PFObject`. `PFObject`s should not exceed 128 kilobytes in size. We recommend you use `PFFile`s to store images, documents, and other types of files. You can do so by instantiating a `PFFile` object and setting it on a field. See [Files](#files) for more details.
 
@@ -582,35 +582,35 @@ For more information about how Parse handles data, check out our documentation o
 
 Parse is designed to get you up and running as quickly as possible. You can access all of your data using the `PFObject` class and access any field with `objectForKey:` or the `[]` subscripting operator. In mature codebases, subclasses have many advantages, including terseness, extensibility, and support for autocomplete. Subclassing is completely optional, but can transform this code:
 
-<pre><code class="objectivec">
+````objectivec
 PFObject *shield = [PFObject objectWithClassName:@"Armor"];
 shield[@"displayName"] = @"Wooden Shield";
 shield[@"fireProof"] = @NO;
 shield[@"rupees"] = @50;
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 var shield = PFObject(className:"Armor")
 shield["displayName"] = "Wooden Shield"
 shield["fireProof"] = false
 shield["rupees"] = 50
-</code></pre>
+````
 
 Into this:
 
-<pre><code class="objectivec">
+````objectivec
 Armor *shield = [Armor object];
 shield.displayName = @"Wooden Shield";
 shield.fireProof = NO;
 shield.rupees = 50;
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 var shield = Armor()
 shield.displayName = "Wooden Shield"
 shield.fireProof = false
 shield.rupees = 50
-</code></pre>
+````
 
 ### Subclassing PFObject
 
@@ -641,21 +641,21 @@ You can access the displayName property using `armor.displayName` or `[armor dis
 
 `NSNumber` properties can be implemented either as `NSNumber`s or as their primitive counterparts. Consider the following example:
 
-<pre><code class="objectivec">
+````objectivec
 @property BOOL fireProof;
 @property int rupees;
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 @NSManaged var fireProof: Boolean
 @NSManaged var rupees: Int
-</code></pre>
+````
 
 In this case, `game[@"fireProof"]` will return an `NSNumber` which is accessed using `boolValue` and `game[@"rupees"]` will return an `NSNumber` which is accessed using `intValue`, but the `fireProof` property is an actual `BOOL` and the `rupees` property is an actual `int`. The dynamic getter will automatically extract the `BOOL` or `int` value and the dynamic setter will automatically wrap the value in an `NSNumber`. You are free to use either format. Primitive property types are easier to use but `NSNumber` property types support nil values more clearly.
 
 If you need more complicated logic than simple property access, you can declare your own methods as well:
 
-<pre><code class="objectivec">
+````objectivec
 @dynamic iconFile;
 
 - (UIImageView *)iconView {
@@ -664,9 +664,9 @@ If you need more complicated logic than simple property access, you can declare 
   [view loadInBackground];
   return view;
 }
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 @NSManaged var iconFile: PFFile
 
 func iconView() -> UIImageView {
@@ -675,7 +675,7 @@ func iconView() -> UIImageView {
   view.loadInBackground()
   return view
 }
-</code></pre>
+````
 
 ### Initializing Subclasses
 

--- a/_includes/ios/push-notifications.md
+++ b/_includes/ios/push-notifications.md
@@ -16,38 +16,38 @@ In iOS or OS X, `Installation` objects are available through the `PFInstallation
 
 First, make your app register for remote notifications by adding the following in your `application:didFinishLaunchingWithOptions:` method (if you haven't already):
 
-<pre><code class="objectivec">
+````objectivec
 UIUserNotificationType userNotificationTypes = (UIUserNotificationTypeAlert | UIUserNotificationTypeBadge | UIUserNotificationTypeSound);
 UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:userNotificationTypes  categories:nil];
 [application registerUserNotificationSettings:settings];
 [application registerForRemoteNotifications];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let userNotificationTypes: UIUserNotificationType = [.Alert, .Badge, .Sound]
 
 let settings = UIUserNotificationSettings(forTypes: userNotificationTypes, categories: nil)
 application.registerUserNotificationSettings(settings)
 application.registerForRemoteNotifications()
-</code></pre>
+````
 
 We will then update our `PFInstallation` with the `deviceToken` once the device is registered for push notifications:
 
-<pre><code class="objectivec">
+````objectivec
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
   // Store the deviceToken in the current Installation and save it to Parse
   PFInstallation *currentInstallation = [PFInstallation currentInstallation];
   [currentInstallation setDeviceTokenFromData:deviceToken];
   [currentInstallation saveInBackground];
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 func application(application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: NSData) {
   // Store the deviceToken in the current Installation and save it to Parse
   let installation = PFInstallation.currentInstallation()
   installation.setDeviceTokenFromData(deviceToken)
   installation.saveInBackground()
 }
-</code></pre>
+````
 
 While it is possible to modify a `PFInstallation` just like you would a `PFObject`, there are several special fields that help manage and target devices.
 
@@ -90,18 +90,18 @@ A channel is identified by a string that starts with a letter and consists of al
 
 Adding a channel subscription can be done using the `addUniqueObject:` method in `PFObject`. For example, in a baseball score app, we could do:
 
-<pre><code class="objectivec">
+````objectivec
 // When users indicate they are Giants fans, we subscribe them to that channel.
 PFInstallation *currentInstallation = [PFInstallation currentInstallation];
 [currentInstallation addUniqueObject:@"Giants" forKey:@"channels"];
 [currentInstallation saveInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // When users indicate they are Giants fans, we subscribe them to that channel.
 let currentInstallation = PFInstallation.currentInstallation()
 currentInstallation.addUniqueObject("Giants", forKey: "channels")
 currentInstallation.saveInBackground()
-</code></pre>
+````
 
 Once subscribed to the "Giants" channel, your `Installation` object should have an updated `channels` field.
 
@@ -109,27 +109,27 @@ Once subscribed to the "Giants" channel, your `Installation` object should have 
 
 Unsubscribing from a channel is just as easy:
 
-<pre><code class="objectivec">
+````objectivec
 // When users indicate they are no longer Giants fans, we unsubscribe them.
 PFInstallation *currentInstallation = [PFInstallation currentInstallation];
 [currentInstallation removeObject:@"Giants" forKey:@"channels"];
 [currentInstallation saveInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // When users indicate they are Giants fans, we subscribe them to that channel.
 let currentInstallation = PFInstallation.currentInstallation()
 currentInstallation.removeObject("Giants", forKey: "channels")
 currentInstallation.saveInBackground()
-</code></pre>
+````
 
 The set of subscribed channels is cached in the `currentInstallation` object:
 
-<pre><code class="objectivec">
+````objectivec
 NSArray *subscribedChannels = [PFInstallation currentInstallation].channels;
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let subscribedChannels = PFInstallation.currentInstallation().channels
-</code></pre>
+````
 
 If you plan on changing your channels from Cloud Code or the data browser, note that you'll need to call some form of `fetch` prior to this line in order to get the most recent channels.
 
@@ -137,24 +137,24 @@ If you plan on changing your channels from Cloud Code or the data browser, note 
 
 In the iOS/OS X SDK, the following code can be used to alert all subscribers of the "Giants" channel that their favorite team just scored. This will display a notification center alert to iOS/OS X users and a system tray notification to Android users.
 
-<pre><code class="objectivec">
+````objectivec
 // Send a notification to all devices subscribed to the "Giants" channel.
 PFPush *push = [[PFPush alloc] init];
 [push setChannel:@"Giants"];
 [push setMessage:@"The Giants just scored!"];
 [push sendPushInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Send a notification to all devices subscribed to the "Giants" channel.
 let push = PFPush()
 push.setChannel("Giants")
 push.setMessage("The Giants just scored!")
 push.sendPushInBackground()
-</code></pre>
+````
 
 If you want to target multiple channels with a single push notification, you can use an `NSArray` of channels.
 
-<pre><code class="objectivec">
+````objectivec
 NSArray *channels = [NSArray arrayWithObjects:@"Giants", @"Mets", nil];
 PFPush *push = [[PFPush alloc] init];
 
@@ -162,8 +162,8 @@ PFPush *push = [[PFPush alloc] init];
 [push setChannels:channels];
 [push setMessage:@"The Giants won against the Mets 2-3."];
 [push sendPushInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let channels = [ "Giants", "Mets" ];
 let push = PFPush()
 
@@ -171,7 +171,7 @@ let push = PFPush()
 push.setChannels(channels)
 push.setMessage("The Giants won against the Mets 2-3.")
 push.sendPushInBackground()
-</code></pre>
+````
 
 ### Using Advanced Targeting
 
@@ -183,43 +183,43 @@ Since `PFInstallation` is a subclass of `PFObject`, you can save any data you wa
 
 Storing data on an `Installation` object is just as easy as storing [any other data](#objects) on Parse. In our Baseball app, we could allow users to get pushes about game results, scores and injury reports.
 
-<pre><code class="objectivec">
+````objectivec
 // Store app language and version
 PFInstallation *installation = [PFInstallation currentInstallation];
 [installation setObject:@YES forKey:@"scores"];
 [installation setObject:@YES forKey:@"gameResults"];
 [installation setObject:@YES forKey:@"injuryReports"];
 [installation saveInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Store app language and version
 let installation = PFInstallation.currentInstallation()
 installation["scores"] = true
 installation["gameResults"] = true
 installation["injuryReports"] = true
 installation.saveInBackground()
-</code></pre>
+````
 
 You can even create relationships between your `Installation` objects and other classes saved on Parse. To associate a PFInstallation with a particular user, for example, you can simply store the current user on the `PFInstallation`.
 
-<pre><code class="objectivec">
+````objectivec
 // Associate the device with a user
 PFInstallation *installation = [PFInstallation currentInstallation];
 installation[@"user"] = [PFUser currentUser];
 [installation saveInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Associate the device with a user
 let installation = PFInstallation.currentInstallation()
 installation["user"] = PFUser.currentUser()
 installation.saveInBackground()
-</code></pre>
+````
 
 #### Sending Pushes to Queries
 
 Once you have your data stored on your `Installation` objects, you can use a `PFQuery` to target a subset of these devices. `Installation` queries work just like any other [Parse query](#queries), but we use the special static method `[PFInstallation query]` to create it. We set this query on our `PFPush` object, before sending the notification.
 
-<pre><code class="objectivec">
+````objectivec
 // Create our Installation query
 PFQuery *pushQuery = [PFInstallation query];
 [pushQuery whereKey:@"injuryReports" equalTo:@YES];
@@ -229,8 +229,8 @@ PFPush *push = [[PFPush alloc] init];
 [push setQuery:pushQuery]; // Set our Installation query
 [push setMessage:@"Willie Hayes injured by own pop fly."];
 [push sendPushInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Create our Installation query
 let pushQuery = PFInstallation.query()
 pushQuery.whereKey("injuryReports", equalTo: true)
@@ -240,11 +240,11 @@ let push = PFPush()
 push.setQuery(pushQuery) // Set our Installation query
 push.setMessage("Willie Hayes injured by own pop fly.")
 push.sendPushInBackground()
-</code></pre>
+````
 
 We can even use channels with our query. To send a push to all subscribers of the "Giants" channel but filtered by those who want score update, we can do the following:
 
-<pre><code class="objectivec">
+````objectivec
 // Create our Installation query
 PFQuery *pushQuery = [PFInstallation query];
 [pushQuery whereKey:@"channels" equalTo:@"Giants"]; // Set channel
@@ -255,8 +255,8 @@ PFPush *push = [[PFPush alloc] init];
 [push setQuery:pushQuery];
 [push setMessage:@"Giants scored against the A's! It's now 2-2."];
 [push sendPushInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Create our Installation query
 let pushQuery = PFInstallation.query()
 pushQuery.whereKey("channels", equalTo:"Giants") // Set channel
@@ -267,11 +267,11 @@ let push = PFPush()
 push.setQuery(pushQuery) // Set our Installation query
 push.setMessage("Giants scored against the A's! It's now 2-2.")
 push.sendPushInBackground()
-</code></pre>
+````
 
 If we store relationships to other objects in our `Installation` class, we can also use those in our query. For example, we could send a push notification to all users near a given location like this.
 
-<pre><code class="objectivec">
+````objectivec
 // Find users near a given location
 PFQuery *userQuery = [PFUser query];
 [userQuery whereKey:@"location"    nearGeoPoint:stadiumLocation withinMiles:@1]
@@ -285,8 +285,8 @@ PFPush *push = [[PFPush alloc] init];
 [push setQuery:pushQuery]; // Set our Installation query
 [push setMessage:@"Free hotdogs at the Parse concession stand!"];
 [push sendPushInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Find users near a given location
 let userQuery = PFUser.query()
 userQuery.whereKey("location", nearGeoPoint: stadiumLocation, withinMiles: 1)
@@ -300,7 +300,7 @@ let push = PFPush()
 push.setQuery(pushQuery) // Set our Installation query
 push.setMessage("Free hotdogs at the Parse concession stand!")
 push.sendPushInBackground()
-</code></pre>
+````
 
 ## Sending Options
 
@@ -320,7 +320,7 @@ If you want to send more than just a message, you will need to use an `NSDiction
 
 For example, to send a notification that increases the current badge number by 1 and plays a custom sound, you can do the following:
 
-<pre><code class="objectivec">
+````objectivec
 NSDictionary *data = @{
   @"alert" : @"The Mets scored! The game is now tied 1-1!",
   @"badge" : @"Increment",
@@ -330,8 +330,8 @@ PFPush *push = [[PFPush alloc] init];
 [push setChannels:@[ @"Mets" ]];
 [push setData:data];
 [push sendPushInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let data = [
   "alert" : "The Mets scored! The game is now tied 1-1!",
   "badge" : "Increment",
@@ -341,11 +341,11 @@ let push = PFPush()
 push.setChannels(["Mets"])
 push.setData(data)
 push.sendPushInBackground()
-</code></pre>
+````
 
 It is also possible to specify your own data in this dictionary. As we'll see in the [Receiving Notifications](#push-notifications-receiving-pushes) section, you will have access to this data only when the user opens your app via the notification. This can be useful for displaying a different view controller when a user opens certain notifications.
 
-<pre><code class="objectivec">
+````objectivec
 NSDictionary *data = @{
   @"alert" : @"Ricky Vaughn was injured in last night's game!",
   @"name" : @"Vaughn",
@@ -356,8 +356,8 @@ PFPush *push = [[PFPush alloc] init];
 [push setChannel:@"Indians"];
 [push setData:data];
 [push sendPushInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let data = [
   "alert" : "Ricky Vaughn was injured in last night's game!",
   "name" : "Vaughn",
@@ -368,7 +368,7 @@ push.setQuery(injuryReportsdata)
 push.setChannel("Indians")
 push.setData(data)
 push.sendPushInBackground()
-</code></pre>
+````
 
 Whether your push notifications increment the app's badge or set it to a specific value, your app will eventually need to clear its badge. This is covered in [Clearing the Badge](#push-notifications-receiving-pushes).
 
@@ -378,7 +378,7 @@ When a user's device is turned off or not connected to the internet, push notifi
 
 There are two methods provided by the `PFPush` class to allow setting an expiration date for your notification. The first is `expireAtDate:` which simply takes an `NSDate` specifying when Parse should stop trying to send the notification.
 
-<pre><code class="objectivec">
+````objectivec
 // Create date object for tomorrow
 NSDateComponents *comps = [[NSDateComponents alloc] init];
 [comps setYear:2015];
@@ -394,8 +394,8 @@ PFPush *push = [[PFPush alloc] init];
 [push setQuery:everyoneQuery];
 [push setMessage:@"Season tickets on sale until August 8th!"];
 [push sendPushInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Create date object for tomorrow
 let comps = NSDateComponents()
 comps.year = 2015
@@ -410,11 +410,11 @@ push.expireAtDate(date)
 push.setQuery(everyoneQuery)
 push.setMessage("Season tickets on sale until August 8th!")
 push.sendPushInBackground()
-</code></pre>
+````
 
 There is however a caveat with this method. Since device clocks are not guaranteed to be accurate, you may end up with inaccurate results. For this reason, the `PFPush` class also provides the `expireAfterTimeInterval:` method which accepts an `NSTimeInterval` object. The notification will expire after the specified interval has elapsed.
 
-<pre><code class="objectivec">
+````objectivec
 // Create time interval
 NSTimeInterval interval = 60*60*24*7; // 1 week
 
@@ -424,8 +424,8 @@ PFPush *push = [[PFPush alloc] init];
 [push setQuery:everyoneQuery];
 [push setMessage:@"Season tickets on sale until next week!"];
 [push sendPushInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Create time interval
 let interval = 60*60*24*7; // 1 week
 
@@ -436,7 +436,7 @@ push.expireAfterTimeInterval(interval)
 push.setQuery(everyoneQuery)
 push.setMessage("Season tickets on sale until next week!")
 push.sendPushInBackground()
-</code></pre>
+````
 
 ### Targeting by Platform
 
@@ -444,7 +444,7 @@ If you build a cross platform app, it is possible you may only want to target de
 
 The following example would send a different notification to Android, iOS, and Windows users.
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [PFInstallation query];
 [query whereKey:@"channels" equalTo:@"suitcaseOwners"];
 
@@ -476,8 +476,8 @@ PFPush *wpPush = [[PFPush alloc] init];
 [wpPush setMessage:@"Your suitcase is very hip; very metro."];
 [wpPush setQuery:query];
 [wpPush sendPushInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let query = PFInstallation.query()
 if let query = query {
     query.whereKey("channels", equalTo: "suitcaseOwners")
@@ -511,7 +511,7 @@ if let query = query {
     wpPush.setQuery(query)
     wpPush.sendPushInBackground()
 }
-</code></pre>
+````
 
 ## Scheduling Pushes
 
@@ -523,7 +523,7 @@ As we saw in the [Customizing Your Notification](#push-notifications-sending-opt
 
 Due to the package size restrictions imposed by Apple, you need to be careful in managing the amount of extra data sent, since it will cut down on the maximum size of your message. For this reason, it is recommended that you keep your extra keys and values as small as possible.
 
-<pre><code class="objectivec">
+````objectivec
 NSDictionary *data = @{
   @"alert" : @"James commented on your photo!",
   @"p" : @"vmRZXZ1Dvo" // Photo's object id
@@ -532,8 +532,8 @@ PFPush *push = [[PFPush alloc] init];
 [push setQuery:photoOwnerQuery];
 [push setData:data];
 [push sendPushInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let data = [
   "alert" : "James commented on your photo!",
   "p" : "vmRZXZ1Dvo" // Photo's object id
@@ -542,13 +542,13 @@ let push = PFPush()
 push.setQuery(photoOwnerQuery)
 push.setData(data)
 push.sendPushInBackground()
-</code></pre>
+````
 
 ### Responding to the Payload
 
 When an app is opened from a notification, the data is made available in the `application:didFinishLaunchingWithOptions:` methods through the `launchOptions` dictionary.
 
-<pre><code class="objectivec">
+````objectivec
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   . . .
   // Extract the notification data
@@ -567,8 +567,8 @@ When an app is opened from a notification, the data is made available in the `ap
     }
   }];
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
   . . .
   // Extract the notification data
@@ -589,11 +589,11 @@ func application(application: UIApplication, didFinishLaunchingWithOptions launc
       }
   }
 }
-</code></pre>
+````
 
 If your app is already running when the notification is received, the data is made available in the `application:didReceiveRemoteNotification:fetchCompletionHandler:` method through the `userInfo` dictionary.
 
-<pre><code class="objectivec">
+````objectivec
 - (void)application:(UIApplication *)application
   didReceiveRemoteNotification:(NSDictionary *)userInfo  fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))handler {
   // Create empty photo object
@@ -614,8 +614,8 @@ If your app is already running when the notification is received, the data is ma
     }
   }];
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 func application(application: UIApplication,  didReceiveRemoteNotification userInfo: [NSObject : AnyObject],  fetchCompletionHandler completionHandler: (UIBackgroundFetchResult) -> Void) {
   if let photoId: String = userInfo["p"] as? String {
     let targetPhoto = PFObject(withoutDataWithClassName: "Photo", objectId: photoId)
@@ -634,7 +634,7 @@ func application(application: UIApplication,  didReceiveRemoteNotification userI
   }
   handler(UIBackgroundFetchResult.NoData)
 }
-</code></pre>
+````
 
 You can read more about handling push notifications in Apple's [Local and Push Notification Programming Guide](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Introduction.html).
 
@@ -646,7 +646,7 @@ This section assumes that you've already set up your application to [save the In
 
 First, add the following to your `application:didFinishLaunchingWithOptions:` method to collect information about when your application was launched, and what triggered it. The extra checks ensure that, even with iOS 7's more advanced background push features, a single logical app-open or push-open event is counted as such.
 
-<pre><code class="objectivec">
+````objectivec
 if (application.applicationState != UIApplicationStateBackground) {
   // Track an app open here if we launch with a push, unless
   // "content_available" was used to trigger a background push (introduced
@@ -659,8 +659,8 @@ if (application.applicationState != UIApplicationStateBackground) {
     [PFAnalytics trackAppOpenedWithLaunchOptions:launchOptions];
   }
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 if application.applicationState != UIApplicationState.Background {
   // Track an app open here if we launch with a push, unless
   // "content_available" was used to trigger a background push (introduced
@@ -672,11 +672,11 @@ if application.applicationState != UIApplicationState.Background {
     PFAnalytics.trackAppOpenedWithLaunchOptions(launchOptions)
   }
 }
-</code></pre>
+````
 
 Second, if your application is running or backgrounded, the `application:didReceiveRemoteNotification:` method handles the push payload instead. If the user acts on a push notification while the application is backgrounded, the application will be brought to the foreground. To track this transition as the application being "opened from a push notification," perform one more check before calling any tracking code:
 
-<pre><code class="objectivec">
+````objectivec
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo {
   if (application.applicationState == UIApplicationStateInactive) {
     // The application was just brought from the background to the foreground,
@@ -684,8 +684,8 @@ Second, if your application is running or backgrounded, the `application:didRece
     [PFAnalytics trackAppOpenedWithRemoteNotificationPayload:userInfo];
   }
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 func application(application: UIApplication, didReceiveRemoteNotification userInfo: [NSObject : AnyObject]) {
     if application.applicationState == .Inactive  {
         // The application was just brought from the background to the foreground,
@@ -693,41 +693,41 @@ func application(application: UIApplication, didReceiveRemoteNotification userIn
         PFAnalytics.trackAppOpenedWithRemoteNotificationPayload(userInfo)
     }
 }
-</code></pre>
+````
 
 Finally, if using iOS 7 any of its new push features (including the new "content-available" push functionality), be sure to also implement the iOS 7-only handler:
 
-<pre><code class="objectivec">
+````objectivec
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
   if (application.applicationState == UIApplicationStateInactive) {
     [PFAnalytics trackAppOpenedWithRemoteNotificationPayload:userInfo];
   }
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 func application(application: UIApplication,  didReceiveRemoteNotification userInfo: [NSObject : AnyObject],  fetchCompletionHandler completionHandler: (UIBackgroundFetchResult) -> Void) {
   if application.applicationState == .Inactive {
     PFAnalytics.trackAppOpenedWithRemoteNotificationPayload(userInfo)
   }
 }
-</code></pre>
+````
 
 #### Tracking on OS X
 
 If your OS X application supports receiving push notifications and you'd like to track application opens related to pushes, add hooks to the `application:didReceiveRemoteNotification:` method (as in iOS) and the following to `applicationDidFinishLaunching:`
 
-<pre><code class="objectivec">
+````objectivec
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
   // ... other Parse setup logic here
   [PFAnalytics trackAppOpenedWithRemoteNotificationPayload:[notification userInfo]];
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 func applicationDidFinishLaunching(notification: NSNotification) {
   // ... other Parse setup logic here
   PFAnalytics.trackAppOpenedWithRemoteNotificationPayload(notification.userInfo)
 }
-</code></pre>
+````
 
 #### Tracking Local Notifications (iOS only)
 
@@ -737,7 +737,7 @@ To track analytics around local notifications, note that `application:didReceive
 
 A good time to clear your app's badge is usually when your app is opened. Setting the badge property on the current installation will update the application icon badge number and ensure that the latest badge value  will be persisted to the server on the next save. All you need to do is:
 
-<pre><code class="objectivec">
+````objectivec
 - (void)applicationDidBecomeActive:(UIApplication *)application {
   PFInstallation *currentInstallation = [PFInstallation currentInstallation];
   if (currentInstallation.badge != 0) {
@@ -746,8 +746,8 @@ A good time to clear your app's badge is usually when your app is opened. Settin
   }
   // ...
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 func applicationDidBecomeActive(application: UIApplication) {
   let currentInstallation = PFInstallation.currentInstallation()
   if currentInstallation.badge != 0 {
@@ -756,7 +756,7 @@ func applicationDidBecomeActive(application: UIApplication) {
   }
   // ...
 }
-</code></pre>
+````
 
 The [UIApplicationDelegate documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/index.html) contains more information on hooks into an app’s life cycle; the ones which are most relevant for resetting the badge count are  `applicationDidBecomeActive:`,  `application:didFinishLaunchingWithOptions:`,  and `application:didReceiveRemoteNotification:`.
 
@@ -831,7 +831,7 @@ Having everything set up correctly in your Parse app won't help if your request 
 
 If the push notification campaign is not showing up on that list, the issue is quite simple to resolve. Go back to your push notification sending code and make sure to check for any error responses. If you're using any of the client SDKs, make sure to listen for and catch any errors that may be returned. For example, you could log errors like so:
 
-<pre><code class="objectivec">
+````objectivec
 [push sendPushInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
   if (success) {
     NSLog(@"The push campaign has been created.");
@@ -841,8 +841,8 @@ If the push notification campaign is not showing up on that list, the issue is q
     NSLog(@"Error sending push: %@", error.description);
   }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 push.sendPushInBackgroundWithBlock {
     (success: Bool , error: NSError?) -> Void in
     if (success) {
@@ -853,7 +853,7 @@ push.sendPushInBackgroundWithBlock {
         print("Error sending push: \(error!.description).");
     }
 }
-</code></pre>
+````
 
 Please note that SDKs that use a Client Key, such as the iOS/OS X SDKs, can only send push notifications if Client Push is enabled in your Parse app's Push Notification settings. Otherwise, you'll only be able to send pushes from the web console, the REST API, or by using the JavaScript SDK from Cloud Code. We strongly encourage developers to turn off Client Push before releasing their app publicly unless your use case allows for any amount of arbitrary pushes to be sent by any of your users. You can read our security guide for more information.
 
@@ -869,7 +869,7 @@ Basically, you will need to run the same push query you're using for your target
 
 The REST API is quite easy to use for this sort of purpose as you can easily recreate the push query using the information provided in your push notification logs. If you look closely at the “Full Target” value in your push campaign log item, you may notice that it matches the query format for a REST API query. You can grab an example of what a [REST API query](/docs/rest#queries-constraints) over Installations would look like from the REST API docs. Don't forget to use the `X-Parse-Master-Key` header to ensure that the Master Key is used to run this query.
 
-<pre><code class="bash">
+````bash
 # Query over installations
 curl -X GET \
 -H "X-Parse-Application-Id: {YOUR_APPLICATION_ID}" \
@@ -878,11 +878,11 @@ curl -X GET \
 --data-urlencode 'limit=1000' \
 --data-urlencode 'where={ "city": "San Francisco", "deviceType": { "$in": [ "ios", "android", "winphone", "embedded" ] } }' \
 https://api.parse.com/1/installations
-</code></pre>
+````
 
 If you type the above into a console, you should be able to see the first 1,000 objects that match your query. Note that constraints are always ANDed, so if you want to further reduce the search scope, you can add a constraint that matches the specific installation for your device:
 
-<pre><code class="bash">
+````bash
 # Query over installations
 curl -X GET \
 -H "X-Parse-Application-Id: {YOUR_APPLICATION_ID}" \
@@ -891,7 +891,7 @@ curl -X GET \
 --data-urlencode 'limit=1' \
 --data-urlencode 'where={ “objectId”: {YOUR_INSTALLATION_OBJECT_ID}, "city": "San Francisco", "deviceType": { "$in": [ "ios", "android", "winphone", "embedded" ] } }' \
 https://api.parse.com/1/installations
-</code></pre>
+````
 
 If the above query returns no results, it is likely that your installation does not meet the targeting criteria for your campaign.
 

--- a/_includes/ios/queries.md
+++ b/_includes/ios/queries.md
@@ -8,7 +8,7 @@ In many cases, `getObjectInBackgroundWithId:block:` isn't powerful enough to spe
 
 The general pattern is to create a `PFQuery`, put conditions on it, and then retrieve a `NSArray` of matching `PFObject`s using either `findObjectsInBackgroundWithBlock:` or `findObjectsInBackgroundWithTarget:selector:`. For example, to retrieve scores with a particular `playerName`, use the `whereKey:equalTo:` method to constrain the value for a key.
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 [query whereKey:@"playerName" equalTo:@"Dan Stemkoski"];
 [query findObjectsInBackgroundWithBlock:^(NSArray *objects, NSError *error) {
@@ -24,8 +24,8 @@ PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
     NSLog(@"Error: %@ %@", error, [error userInfo]);
   }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var query = PFQuery(className:"GameScore")
 query.whereKey("playerName", equalTo:"Sean Plott")
 query.findObjectsInBackgroundWithBlock {
@@ -45,11 +45,11 @@ query.findObjectsInBackgroundWithBlock {
     print("Error: \(error!) \(error!.userInfo)")
   }
 }
-</code></pre>
+````
 
 Both `findObjectsInBackgroundWithBlock:` and `findObjectsInBackgroundWithTarget:selector:` work similarly in that they assure the network request is done without blocking, and run the block/callback in the main thread. There is a corresponding `findObjects` method that blocks the calling thread, if you are already in a background thread:
 
-<pre><code class="objectivec">
+````objectivec
 // Only use this code if you are already running it in a background
 // thread, or for testing purposes!
 
@@ -62,9 +62,9 @@ NSArray* scoreArray = [query findObjects];
 NSPredicate *predicate = [NSPredicate predicateWithFormat:@"playerName = 'Dan Stemkosk'"];
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore" predicate:predicate];
 NSArray* scoreArray = [query findObjects];
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 // Only use this code if you are already running it in a background
 // thread, or for testing purposes!
 
@@ -77,20 +77,20 @@ let scoreArray = query.findObjects()
 let predicate = NSPredicate(format:"playerName = 'Dan Stemkosk'")
 let query = PFQuery(className: "GameScore", predicate: predicate)
 let scoreArray = query.findObjects()
-</code></pre>
+````
 
 ## Specifying Constraints with NSPredicate
 
 To get the most out of `PFQuery` we recommend using its methods listed below to add constraints. However, if you prefer using `NSPredicate`, a subset of the constraints can be specified by providing an `NSPredicate` when creating your `PFQuery`.
 
-<pre><code class="objectivec">
+````objectivec
 NSPredicate *predicate = [NSPredicate predicateWithFormat:@"playerName = 'Dan Stemkosk'"];
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore" predicate:predicate];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let predicate = NSPredicate(format: "playerName = 'Dan Stemkosk'")
 var query = PFQuery(className: "GameScore", predicate: predicate)
-</code></pre>
+````
 
 These features are supported:
 
@@ -112,26 +112,26 @@ The following types of predicates are **not** supported:
 
 There are several ways to put constraints on the objects found by a `PFQuery`. You can filter out objects with a particular key-value pair with `whereKey:notEqualTo`:
 
-<pre><code class="objectivec">
+````objectivec
 // Using PFQuery
 [query whereKey:@"playerName" notEqualTo:@"Michael Yabuti"];
 
 // Using NSPredicate
 NSPredicate *predicate = [NSPredicate predicateWithFormat:   @"playerName != 'Michael Yabuti'"];
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore" predicate:predicate];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Using PFQuery
 query.whereKey("playerName", notEqualTo: "Michael Yabuti")
 
 // Using NSPredicate
 let predicate = NSPredicate(format:"playerName != 'Michael Yabuti'")
 let query = PFQuery(className: "GameScore", predicate: predicate)
-</code></pre>
+````
 
 You can give multiple constraints, and objects will only be in the results if they match all of the constraints.  In other words, it's like an AND of constraints.
 
-<pre><code class="objectivec">
+````objectivec
 // Using PFQuery
 [query whereKey:@"playerName" notEqualTo:@"Michael Yabuti"];
 [query whereKey:@"playerAge" greaterThan:@18];
@@ -139,8 +139,8 @@ You can give multiple constraints, and objects will only be in the results if th
 // Using NSPredicate
 NSPredicate *predicate = [NSPredicate predicateWithFormat:   @"playerName != 'Michael Yabuti' AND playerAge > 18"];
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore" predicate:predicate];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Using PFQuery
 query.whereKey("playerName", notEqualTo: "Michael Yabuti")
 query.whereKey("playerAge", greaterThan: 18)
@@ -148,20 +148,20 @@ query.whereKey("playerAge", greaterThan: 18)
 // Using NSPredicate
 let predicate = NSPredicate(format:"playerName != 'Michael Yabuti' AND playerAge > 18")
 let query = PFQuery(className: "GameScore", predicate: predicate)
-</code></pre>
+````
 
 You can limit the number of results by setting `limit`. By default, results are limited to 100, but anything from 1 to 1000 is a valid limit:
 
-<pre><code class="objectivec">
+````objectivec
 query.limit = 10; // limit to at most 10 results
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 query.limit = 10 // limit to at most 10 results
-</code></pre>
+````
 
 If you want exactly one result, a more convenient alternative may be to use `getFirstObject` or `getFirstObjectInBackground` instead of using `findObject`.
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 [query whereKey:@"playerEmail" equalTo:@"dstemkoski@example.com"];
 [query getFirstObjectInBackgroundWithBlock:^(PFObject *object, NSError *error) {
@@ -172,8 +172,8 @@ PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
     NSLog(@"Successfully retrieved the object.");
   }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var query = PFQuery(className: "GameScore")
 query.whereKey("playerEmail", equalTo: "dstemkoski@example.com")
 query.getFirstObjectInBackgroundWithBlock {
@@ -185,54 +185,54 @@ query.getFirstObjectInBackgroundWithBlock {
     print("Successfully retrieved the object.")
   }
 }
-</code></pre>
+````
 
 You can skip the first results by setting `skip`. This can be useful for pagination:
 
-<pre><code class="objectivec">
+````objectivec
 query.skip = 10; // skip the first 10 results
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 query.skip = 10
-</code></pre>
+````
 
 For sortable types like numbers and strings, you can control the order in which results are returned:
 
-<pre><code class="objectivec">
+````objectivec
 // Sorts the results in ascending order by the score field
 [query orderByAscending:@"score"];
 
 // Sorts the results in descending order by the score field
 [query orderByDescending:@"score"];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Sorts the results in ascending order by the score field
 query.orderByAscending("score")
 
 // Sorts the results in descending order by the score field
 query.orderByDescending("score")
-</code></pre>
+````
 
 You can add more sort keys to the query as follows:
 
-<pre><code class="objectivec">
+````objectivec
 // Sorts the results in ascending order by the score field if the previous sort keys are equal.
 [query addAscendingOrder:@"score"];
 
 // Sorts the results in descending order by the score field if the previous sort keys are equal.
 [query addDescendingOrder:@"score"];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Sorts the results in ascending order by the score field if the previous sort keys are equal.
 query.addAscendingOrder("score")
 
 // Sorts the results in descending order by the score field if the previous sort keys are equal.
 query.addDescendingOrder("score")
-</code></pre>
+````
 
 For sortable types, you can also use comparisons in queries:
 
-<pre><code class="objectivec">
+````objectivec
 // Restricts to wins < 50
 [query whereKey:@"wins" lessThan:@50];
 // Or with NSPredicate
@@ -256,8 +256,8 @@ query = [PFQuery queryWithClassName:@"GameScore" predicate:predicate];
 // Or with NSPredicate
 predicate = [NSPredicate predicateWithFormat:@"wins >= 50"];
 query = [PFQuery queryWithClassName:@"GameScore" predicate:predicate];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Restricts to wins < 50
 query.whereKey("wins", lessThan: 50)
 // Or with NSPredicate
@@ -281,11 +281,11 @@ query.whereKey("wins", greaterThanOrEqualTo: 50)
 // Or with NSPredicate
 let predicate = NSPredicate(format: "wins >= 50")
 let query = PFQuery(className: "GameScore", predicate: predicate)
-</code></pre>
+````
 
 If you want to retrieve objects matching several different values, you can use `whereKey:containedIn:`, providing an array of acceptable values. This is often useful to replace multiple queries with a single query. For example, if you want to retrieve scores made by any player in a particular list:
 
-<pre><code class="objectivec">
+````objectivec
 // Finds scores from any of Jonathan, Dario, or Shawn
 // Using PFQuery
 NSArray *names = @[@"Jonathan Walsh", @"Dario Wunsch", @"Shawn Simon"];
@@ -295,8 +295,8 @@ NSArray *names = @[@"Jonathan Walsh", @"Dario Wunsch", @"Shawn Simon"];
 NSArray *names = @[@"Jonathan Walsh", @"Dario Wunsch", @"Shawn Simon"];
 NSPredicate *pred = [NSPredicate predicateWithFormat: @"playerName IN %@", names];
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore" predicate:pred];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Finds scores from any of Jonathan, Dario, or Shawn
 // Using PFQuery
 let names = ["Jonathan Walsh", "Dario Wunsch", "Shawn Simon"]
@@ -306,11 +306,11 @@ query.whereKey("playerName", containedIn: names)
 let names = ["Jonathan Walsh", "Dario Wunsch", "Shawn Simon"]
 let pred = NSPredicate(format: "playerName IN %@", names)
 let query = PFQuery(className: "GameScore", predicate: predicate)
-</code></pre>
+````
 
 If you want to retrieve objects that do not match any of several values you can use `whereKey:notContainedIn:`, providing an array of acceptable values. For example, if you want to retrieve scores from players besides those in a list:
 
-<pre><code class="objectivec">
+````objectivec
 // Finds scores from anyone who is neither Jonathan, Dario, nor Shawn
 // Using PFQuery
 NSArray *names = @[@"Jonathan Walsh", @"Dario Wunsch", @"Shawn Simon"];
@@ -320,8 +320,8 @@ NSArray *names = @[@"Jonathan Walsh", @"Dario Wunsch", @"Shawn Simon"];
 NSArray *names = @[@"Jonathan Walsh", @"Dario Wunsch", @"Shawn Simon"];
 NSPredicate *pred = [NSPredicate predicateWithFormat: @"NOT (playerName IN %@)", names];
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore" predicate:pred];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Finds scores from anyone who is neither Jonathan, Dario, nor Shawn
 // Using PFQuery
 let names = ["Jonathan Walsh", "Dario Wunsch", "Shawn Simon"]
@@ -331,11 +331,11 @@ query.whereKey("playerName", notContainedIn: names)
 let names = ["Jonathan Walsh", "Dario Wunsch", "Shawn Simon"]
 let pred = NSPredicate(format: "NOT (playerName IN %@)", names)
 let query = PFQuery(className: "GameScore", predicate: predicate)
-</code></pre>
+````
 
 If you want to retrieve objects that have a particular key set, you can use `whereKeyExists`. Conversely, if you want to retrieve objects without a particular key set, you can use `whereKeyDoesNotExist`.
 
-<pre><code class="objectivec">
+````objectivec
 // Finds objects that have the score set
 [query whereKeyExists:@"score"];
 // Or using NSPredicate
@@ -347,8 +347,8 @@ PFQuery *query = [PFQuery queryWithClassName:@"GameScore" predicate:predicate];
 // Or using NSPredicate
 NSPredicate *predicate = [NSPredicate predicateWithFormat:@"NOT (score IN SELF)"];
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore" predicate:predicate];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Finds objects that have the score set
 query.whereKeyExists("score")
 // Or using NSPredicate
@@ -360,11 +360,11 @@ query.whereKeyDoesNotExist("score")
 // Or using NSPredicate
 let predicate = NSPredicate(format: "NOT (score IN SELF)")
 let query = PFQuery(className: "GameScore", predicate: predicate)
-</code></pre>
+````
 
 You can use the `whereKey:matchesKey:inQuery:` method to get objects where a key matches the value of a key in a set of objects resulting from another query.  For example, if you have a class containing sports teams and you store a user's hometown in the user class, you can issue one query to find the list of users whose hometown teams have winning records.  The query would look like:
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *teamQuery = [PFQuery queryWithClassName:@"Team"];
 [teamQuery whereKey:@"winPct" greaterThan:@(0.5)];
 PFQuery *userQuery = [PFQuery queryForUser];
@@ -372,8 +372,8 @@ PFQuery *userQuery = [PFQuery queryForUser];
 [userQuery findObjectsInBackgroundWithBlock:^(NSArray *results, NSError *error) {
     // results will contain users with a hometown team with a winning record
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var teamQuery = PFQuery(className:"Team")
 teamQuery.whereKey("winPct", greaterThan:0.5)
 var userQuery = PFUser.query()
@@ -384,36 +384,36 @@ userQuery!.findObjectsInBackgroundWithBlock {
     // results will contain users with a hometown team with a winning record
   }
 }
-</code></pre>
+````
 
 Conversely, to get objects where a key does not match the value of a key in a set of objects resulting from another query, use `whereKey:doesNotMatchKey:inQuery:`.  For example, to find users whose hometown teams have losing records:
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *losingUserQuery = [PFQuery queryForUser];
 [losingUserQuery whereKey:@"hometown" doesNotMatchKey:@"city" inQuery:teamQuery];
 [losingUserQuery findObjectsInBackgroundWithBlock:^(NSArray *results, NSError *error) {
     // results will contain users with a hometown team with a losing record
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var losingUserQuery = PFUser.query()
 losingUserQuery!.whereKey("hometown", doesNotMatchKey:"city", inQuery:teamQuery)
 losingUserQuery!.findObjectsInBackgroundWithBlock {
   (results: [PFObject]?, error: NSError?) -> Void in
   // results will contain users with a hometown team with a losing records
 }
-</code></pre>
+````
 
 You can restrict the fields returned by calling `selectKeys:` with an `NSArray` of keys. To retrieve documents that contain only the `score` and `playerName` fields (and also special built-in fields such as `objectId`, `createdAt`, and `updatedAt`):
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 [query selectKeys:@[@"playerName", @"score"]];
 [query findObjectsInBackgroundWithBlock:^(NSArray *results, NSError *error) {
     // objects in results will only contain the playerName and score fields
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var query = PFQuery(className:"GameScore")
 query.selectKeys(["playerName", "score"])
 query.findObjectsInBackgroundWithBlock {
@@ -422,29 +422,29 @@ query.findObjectsInBackgroundWithBlock {
     // objects in results will only contain the playerName and score fields
   }
 }
-</code></pre>
+````
 
 The remaining fields can be fetched later by calling one of the `fetchIfNeeded` variants on the returned objects:
 
-<pre><code class="objectivec">
+````objectivec
 PFObject *object = (PFObject*)results[0];
 [object fetchIfNeededInBackgroundWithBlock:^(PFObject *object, NSError *error) {
   // all fields of the object will now be available here.
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var object = results[0] as PFObject!
 object.fetchIfNeededInBackgroundWithBlock {
   (object: PFObject?, error: NSError?) -> Void in
   // all fields of the object will now be available here.
 }
-</code></pre>
+````
 
 ## Queries on Array Values
 
 For keys with an array type, you can find objects where the key's array value contains 2 by:
 
-<pre><code class="objectivec">
+````objectivec
 // Find objects where the array in arrayKey contains 2.
 // Using PFQuery
 [query whereKey:@"arrayKey" equalTo:@2];
@@ -452,8 +452,8 @@ For keys with an array type, you can find objects where the key's array value co
 // Or using NSPredicate
 NSPredicate *predicate = [NSPredicate predicateWithFormat:@"2 IN arrayKey"];
 PFQuery *query = [PFQuery queryWithClassName:@"MyClass" predicate:predicate];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Find objects where the array in arrayKey contains 2.
 // Using PFQuery
 query.whereKey("arrayKey", equalTo: 2)
@@ -461,20 +461,20 @@ query.whereKey("arrayKey", equalTo: 2)
 // Or using NSPredicate
 let predicate = NSPredicate(format: "2 IN arrayKey")
 let query = PFQuery(className: "MyClass", predicate: predicate)
-</code></pre>
+````
 
 You can also find objects where the key's array value contains each of the values 2, 3, and 4 with the following:
 
-<pre><code class="objectivec">
+````objectivec
 // Find objects where the array in arrayKey contains each of the
 // elements 2, 3, and 4.
 [query whereKey:@"arrayKey" containsAllObjectsInArray:@[@2, @3, @4]];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Find objects where the array in arrayKey contains each of the
 // elements 2, 3, and 4.
 query.whereKey("arrayKey", containsAllObjectsInArray:[2, 3, 4])
-</code></pre>
+````
 
 ## Queries on String Values
 
@@ -484,7 +484,7 @@ query.whereKey("arrayKey", containsAllObjectsInArray:[2, 3, 4])
 
 Use `whereKey:hasPrefix:` to restrict to string values that start with a particular string. Similar to a MySQL LIKE operator, this is indexed so it is efficient for large datasets:
 
-<pre><code class="objectivec">
+````objectivec
 // Finds barbecue sauces that start with "Big Daddy".
 // Using PFQuery
 PFQuery *query = [PFQuery queryWithClassName:@"BarbecueSauce"];
@@ -493,8 +493,8 @@ PFQuery *query = [PFQuery queryWithClassName:@"BarbecueSauce"];
 // Using NSPredicate
 NSPredicate *pred = [NSPredicate predicateWithFormat:@"name BEGINSWITH 'Big Daddy"];
 PFQuery *query = [PFQuery queryWithClassName:@"BarbecueSauce" predicate:pred];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Finds barbecue sauces that start with "Big Daddy".
 // Using PFQuery
 let query = PFQuery("BarbecueSauce")
@@ -503,7 +503,7 @@ query.whereKey("name", hasPrefix: "Big Daddy's")
 // Using NSPredicate
 let pred = NSPredicate(format: "name BEGINSWITH 'Big Daddy")
 let query = PFQuery(className: "BarbecueSauce", predicate: predicate)
-</code></pre>
+````
 
 The above example will match any `BarbecueSauce` objects where the value in the "name" String key starts with "Big Daddy's". For example, both "Big Daddy's" and "Big Daddy's BBQ" will match, but "big daddy's" or "BBQ Sauce: Big Daddy's" will not.
 
@@ -514,7 +514,7 @@ Queries that have regular expression constraints are very expensive. Refer to th
 
 There are several ways to issue queries for relational data. If you want to retrieve objects where a field matches a particular `PFObject`, you can use `whereKey:equalTo:` just like for other data types. For example, if each `Comment` has a `Post` object in its `post` field, you can fetch comments for a particular `Post`:
 
-<pre><code class="objectivec">
+````objectivec
 // Assume PFObject *myPost was previously created.
 // Using PFQuery
 PFQuery *query = [PFQuery queryWithClassName:@"Comment"];
@@ -531,8 +531,8 @@ PFQuery *query = [PFQuery queryWithClassName:@"Comment" predicate:predicate];
 [query findObjectsInBackgroundWithBlock:^(NSArray *comments, NSError *error) {
     // comments now contains the comments for myPost
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Assume PFObject *myPost was previously created.
 // Using PFQuery
 let query = PFQuery(className: "Comment")
@@ -550,29 +550,29 @@ query.findObjectsInBackgroundWithBlock {
     (comments: [PFObject]?, error: NSError?) -> Void in
     // comments now contains the comments for myPost
 }
-</code></pre>
+````
 
 You can also do relational queries by `objectId`:
 
-<pre><code class="objectivec">
+````objectivec
 // Using PFQuery
 [query whereKey:@"post" equalTo:[PFObject objectWithoutDataWithClassName:@"Post" objectId:@"1zEcyElZ80"]];
 
 // Using NSPredicate
 [NSPredicate predicateWithFormat:@"post = %@",
     [PFObject objectWithoutDataWithClassName:@"Post" objectId:@"1zEcyElZ80"]];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Using PFQuery
 query.whereKey("post", equalTo: PFObject(withoutDataWithClassName: "Post", objectId: "1zEcyElZ80"))
 
 // Using NSPredicate
 NSPredicate(format: "post = %@", PFObject(withoutDataWithClassName: "Post", objectId: "1zEcyElZ80"))
-</code></pre>
+````
 
 If you want to retrieve objects where a field contains a `PFObject` that match a different query, you can use `whereKey:matchesQuery`. Note that the default limit of 100 and maximum limit of 1000 apply to the inner query as well, so with large data sets you may need to construct queries carefully to get the desired behavior. In order to find comments for posts with images, you can do:
 
-<pre><code class="objectivec">
+````objectivec
 // Using PFQuery
 PFQuery *innerQuery = [PFQuery queryWithClassName:@"Post"];
 [innerQuery whereKeyExists:@"image"];
@@ -592,8 +592,8 @@ PFQuery *query = [PFQuery queryWithClassName:@"Comment" predicate:pred];
 [query findObjectsInBackgroundWithBlock:^(NSArray *comments, NSError *error) {
     // comments now contains the comments for posts with images
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Using PFQuery
 let innerQuery = PFQuery(className: "Post")
 innerQuery.whereKeyExists("image")
@@ -615,11 +615,11 @@ query.findObjectsInBackgroundWithBlock {
     (comments: [PFObject]?, error: NSError?) -> Void in
     // comments now contains the comments for posts with images
 }
-</code></pre>
+````
 
 If you want to retrieve objects where a field contains a `PFObject` that does not match a different query, you can use `whereKey:doesNotMatchQuery`.  In order to find comments for posts without images, you can do:
 
-<pre><code class="objectivec">
+````objectivec
 // Using PFQuery
 PFQuery *innerQuery = [PFQuery queryWithClassName:@"Post"];
 [innerQuery whereKeyExists:@"image"];
@@ -639,8 +639,8 @@ PFQuery *query = [PFQuery queryWithClassName:@"Comment" predicate:pred];
 [query findObjectsInBackgroundWithBlock:^(NSArray *comments, NSError *error) {
     // comments now contains the comments for posts without images
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Using PFQuery
 let innerQuery = PFQuery(className: "Post")
 innerQuery.whereKeyExists("image")
@@ -662,11 +662,11 @@ query.findObjectsInBackgroundWithBlock {
     (comments: [PFObject]?, error: NSError?) -> Void in
     // comments now contains the comments for posts with images
 }
-</code></pre>
+````
 
 In some situations, you want to return multiple types of related objects in one query. You can do this with the `includeKey:` method. For example, let's say you are retrieving the last ten comments, and you want to retrieve their related posts at the same time:
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [PFQuery queryWithClassName:@"Comment"];
 
 // Retrieve the most recent ones
@@ -687,8 +687,8 @@ query.limit = 10;
          NSLog(@"retrieved related post: %@", post);
     }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var query = PFQuery(className:"Comment")
 
 // Retrieve the most recent ones
@@ -713,16 +713,16 @@ query.findObjectsInBackgroundWithBlock {
       }
   }
 }
-</code></pre>
+````
 
 You can also do multi level includes using dot notation.  If you wanted to include the post for a comment and the post's author as well you can do:
 
-<pre><code class="objectivec">
+````objectivec
 [query includeKey:@"post.author"];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 query.includeKey("post.author")
-</code></pre>
+````
 
 You can issue a query with multiple fields included by calling `includeKey:` multiple times. This functionality also works with PFQuery helpers like `getFirstObject` and `getObjectInBackground`
 
@@ -730,7 +730,7 @@ You can issue a query with multiple fields included by calling `includeKey:` mul
 
 If you have enabled the local datastore by calling `[Parse enableLocalDatastore]` before your call to `[Parse setApplicationId:clientKey:]`, then you can also query against the objects stored locally on the device. To do this, call the `fromLocalDatastore` method on the query.
 
-<pre><code class="objectivec">
+````objectivec
 [query fromLocalDatastore];
 [[query findObjectsInBackground] continueWithBlock:^id(BFTask *task) {
   if (!task.error) {
@@ -741,8 +741,8 @@ If you have enabled the local datastore by calling `[Parse enableLocalDatastore]
   // Results were successfully found from the local datastore.
   return task;
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 query.fromLocalDatastore()
 query.findObjectsInBackground().continueWithBlock({
   (task: BFTask?) -> AnyObject! in
@@ -755,7 +755,7 @@ query.findObjectsInBackground().continueWithBlock({
 
   return task
 })
-</code></pre>
+````
 
 You can query from the local datastore using exactly the same kinds of queries you use over the network. The results will include every object that matches the query that's been pinned to your device. The query even takes into account any changes you've made to the object that haven't yet been saved to the cloud. For example, if you call `deleteEventually`, on an object, it will no longer be returned from these queries.
 
@@ -765,7 +765,7 @@ It's often useful to cache the result of a query on disk. This lets you show dat
 
 The default query behavior doesn't use the cache, but you can enable caching by setting `query.cachePolicy`. For example, to try the network and then fall back to cached data if the network is not available:
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 query.cachePolicy = kPFCachePolicyNetworkElseCache;
 [query findObjectsInBackgroundWithBlock:^(NSArray *objects, NSError *error) {
@@ -777,8 +777,8 @@ query.cachePolicy = kPFCachePolicyNetworkElseCache;
     // this query.
   }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var query = PFQuery(className:"GameScore")
 query.cachePolicy = .CacheElseNetwork
 query.findObjectsInBackgroundWithBlock {
@@ -791,7 +791,7 @@ query.findObjectsInBackgroundWithBlock {
     // this query.
   }
 }
-</code></pre>
+````
 
 Parse provides several different cache policies:
 
@@ -805,26 +805,26 @@ Parse provides several different cache policies:
 If you need to control the cache's behavior, you can use methods provided in PFQuery to interact with the cache.  You can do the following operations on the cache:
 
 *   Check to see if there is a cached result for the query with:
-<pre><code class="objectivec">
+````objectivec
 BOOL isInCache = [query hasCachedResult];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let isInCache = query.hasCachedResult()
-</code></pre>
+````
 *   Remove any cached results for a query with:
-<pre><code class="objectivec">
+````objectivec
 [query clearCachedResult];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 query.clearCachedResult()
-</code></pre>
+````
 *   Remove cached results for queries with:
-<pre><code class="objectivec">
+````objectivec
 [PFQuery clearAllCachedResults];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFQuery.clearAllCachedResults()
-</code></pre>
+````
 
 Query caching also works with PFQuery helpers including `getFirstObject` and `getObjectInBackground`.
 
@@ -834,7 +834,7 @@ Caveat: Count queries are rate limited to a maximum of 160 requests per minute. 
 
 If you just need to count how many objects match a query, but you do not need to retrieve the objects that match, you can use `countObjects` instead of `findObjects`. For example, to count how many games have been played by a particular player:
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
 [query whereKey:@"playername" equalTo:@"Sean Plott"];
 [query countObjectsInBackgroundWithBlock:^(int count, NSError *error) {
@@ -845,8 +845,8 @@ PFQuery *query = [PFQuery queryWithClassName:@"GameScore"];
     // The request failed
   }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var query = PFQuery(className:"GameScore")
 query.whereKey("playerName", equalTo:"Sean Plott")
 query.countObjectsInBackgroundWithBlock {
@@ -855,7 +855,7 @@ query.countObjectsInBackgroundWithBlock {
     print("Sean has played \(count) games")
   }
 }
-</code></pre>
+````
 
 If you want to block the calling thread, you can also use the synchronous `countObjects` method.
 
@@ -863,7 +863,7 @@ If you want to block the calling thread, you can also use the synchronous `count
 
 If you want to find objects that match one of several queries, you can use `orQueryWithSubqueries:` method.  For instance, if you want to find players with either have a lot of wins or a few wins, you can do:
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *lotsOfWins = [PFQuery queryWithClassName:@"Player"];
 [lotsOfWins whereKey:@"wins" greaterThan:@150];
 
@@ -873,8 +873,8 @@ PFQuery *query = [PFQuery orQueryWithSubqueries:@[fewWins,lotsOfWins]];
 [query findObjectsInBackgroundWithBlock:^(NSArray *results, NSError *error) {
   // results contains players with lots of wins or only a few wins.
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var lotsOfWins = PFQuery(className:"Player")
 lotsOfWins.whereKey("wins", greaterThan:150)
 
@@ -888,7 +888,7 @@ query.findObjectsInBackgroundWithBlock {
     // results contains players with lots of wins or only a few wins.
   }
 }
-</code></pre>
+````
 
 You can add additional constraints to the newly created `PFQuery` that act as an 'and' operator.
 
@@ -898,7 +898,7 @@ Note that we do not, however, support GeoPoint or non-filtering constraints (e.g
 
 You can get a query for objects of a particular subclass using the class method `query`. The following example queries for armors that the user can afford:
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [Armor query];
 [query whereKey:@"rupees" lessThanOrEqualTo:[PFUser currentUser][@"rupees"]];
 [query findObjectsInBackgroundWithBlock:^(NSArray *objects, NSError *error) {
@@ -907,8 +907,8 @@ PFQuery *query = [Armor query];
     // ...
   }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let query = Armor.query()
 query.whereKey("rupees", lessThanOrEqualTo: PFUser.currentUser()["rupees"])
 query.findObjectsInBackgroundWithBlock { (objects: [PFObject]?, error: NSError?) -> Void in
@@ -918,4 +918,4 @@ query.findObjectsInBackgroundWithBlock { (objects: [PFObject]?, error: NSError?)
     }
   }
 }
-</code></pre>
+````

--- a/_includes/ios/roles.md
+++ b/_includes/ios/roles.md
@@ -21,24 +21,24 @@ The `PFRole` uses the same security scheme (ACLs) as all other objects on Parse,
 
 To create a new `PFRole`, you would write:
 
-<pre><code class="objectivec">
+````objectivec
 // By specifying no write privileges for the ACL, we can ensure the role cannot be altered.
 PFACL *roleACL = [PFACL ACL];
 [roleACL setPublicReadAccess:YES];
 PFRole *role = [PFRole roleWithName:@"Administrator" acl:roleACL];
 [role saveInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // By specifying no write privileges for the ACL, we can ensure the role cannot be altered.
 var roleACL = PFACL.ACL()
 roleACL.setPublicReadAccess(true)
 var role = PFRole.roleWithName("Administrator", acl:roleACL)
 role.saveInBackground()
-</code></pre>
+````
 
 You can add users and roles that should inherit your new role's permissions through the "users" and "roles" relations on `PFRole`:
 
-<pre><code class="objectivec">
+````objectivec
 PFRole *role = [PFRole roleWithName:roleName acl:roleACL];
 for (PFUser *user in usersToAddToRole) {
   [role.users addObject:user];
@@ -47,8 +47,8 @@ for (PFRole *childRole in rolesToAddToRole) {
   [role.roles addObject:childRole];
 }
 [role saveInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var role = PFRole.roleWithName(roleName, acl:roleACL)
 for user in usersToAddToRole {
   role.users.addObject(user)
@@ -57,7 +57,7 @@ for childRole in rolesToAddToRole {
   role.roles.addObject(childRole)
 }
 role.saveInBackground()
-</code></pre>
+````
 
 Take great care when assigning ACLs to your roles so that they can only be modified by those who should have permissions to modify them.
 
@@ -68,43 +68,43 @@ Now that you have created a set of roles for use in your application, you can us
 
 Giving a role read or write permission to an object is straightforward.  You can either use the `PFRole`:
 
-<pre><code class="objectivec">
+````objectivec
 PFRole *moderators = /* Query for some PFRole */;
 PFObject *wallPost = [PFObject objectWithClassName:@"WallPost"];
 PFACL *postACL = [PFACL ACL];
 [postACL setWriteAccess:YES forRole:moderators];
 wallPost.ACL = postACL;
 [wallPost saveInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var moderators = /* Query for some PFRole */
 var wallPost = PFObject(className:"WallPost")
 var postACL = PFACL.ACL()
 postACL.setWriteAccess(true, forRole:moderators)
 wallPost.ACL = postACL
 wallPost.saveInBackground()
-</code></pre>
+````
 
 You can avoid querying for a role by specifying its name for the ACL:
 
-<pre><code class="objectivec">
+````objectivec
 PFObject *wallPost = [PFObject objectWithClassName:@"WallPost"];
 PFACL *postACL = [PFACL ACL];
 [postACL setWriteAccess:YES forRoleWithName:@"Moderators"];
 wallPost.ACL = postACL;
 [wallPost saveInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var wallPost = PFObject(className:"WallPost")
 var postACL = PFACL.ACL()
 postACL.setWriteAccess(true, forRoleWithName:"Moderators")
 wallPost.ACL = postACL
 wallPost.saveInBackground()
-</code></pre>
+````
 
 Role-based `PFACL`s can also be used when specifying default ACLs for your application, making it easy to protect your users' data while granting access to users with additional privileges.  For example, a moderated forum application might specify a default ACL like this:
 
-<pre><code class="objectivec">
+````objectivec
 PFACL *defaultACL = [PFACL ACL];
 // Everybody can read objects created by this user
 [defaultACL setPublicReadAccess:YES];
@@ -112,8 +112,8 @@ PFACL *defaultACL = [PFACL ACL];
 [defaultACL setWriteAccess:YES forRoleWithName:@"Moderators"];
 // And the user can read and modify its own objects
 [PFACL setDefaultACL:defaultACL withAccessForCurrentUser:YES];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var defaultACL = PFACL.ACL()
 // Everybody can read objects created by this user
 defaultACL.setPublicReadAccess(true)
@@ -121,7 +121,7 @@ defaultACL.setPublicReadAccess(true)
 defaultACL.setWriteAccess(true, forRoleWithName:"Moderators")
 // And the user can read and modify its own objects
 PFACL.setDefaultACL(defaultACL, withAccessForCurrentUser:true)
-</code></pre>
+````
 
 ## Role Hierarchy
 
@@ -129,15 +129,15 @@ As described above, one role can contain another, establishing a parent-child re
 
 These types of relationships are commonly found in applications with user-managed content, such as forums. Some small subset of users are "Administrators", with the highest level of access to tweaking the application's settings, creating new forums, setting global messages, and so on. Another set of users are "Moderators", who are responsible for ensuring that the content created by users remains appropriate. Any user with Administrator privileges should also be granted the permissions of any Moderator. To establish this relationship, you would make your "Administrators" role a child role of "Moderators", like this:
 
-<pre><code class="objectivec">
+````objectivec
 PFRole *administrators = /* Your "Administrators" role */;
 PFRole *moderators = /* Your "Moderators" role */;
 [moderators.roles addObject:administrators];
 [moderators saveInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var administrators = /* Your "Administrators" role */
 var moderators = /* Your "Moderators" role */
 moderators.roles.addObject(administrators)
 moderators.saveInBackground()
-</code></pre>
+````

--- a/_includes/ios/user-interface.md
+++ b/_includes/ios/user-interface.md
@@ -14,16 +14,16 @@ If you are using Parse to manage users in your mobile app, you are already famil
 
 You use the `PFLogInViewController` class by instantiating it and presenting it modally:
 
-<pre><code class="objectivec">
+````objectivec
 PFLogInViewController *logInController = [[PFLogInViewController alloc] init];
 logInController.delegate = self;
 [self presentViewController:logInController animated:YES completion:nil];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var logInController = PFLogInViewController()
 logInController.delegate = self
 self.presentViewController(logInController, animated:true, completion: nil)
-</code></pre>
+````
 
 ### Configuring the Log In Elements
 
@@ -39,20 +39,20 @@ self.presentViewController(logInController, animated:true, completion: nil)
 
 Any of the above features can be turned on or off. The options can be set using the `fields` property on `PFLogInViewController`:
 
-<pre><code class="objectivec">
+````objectivec
   logInController.fields = (PFLogInFieldsUsernameAndPassword
                            | PFLogInFieldsLogInButton
                            | PFLogInFieldsSignUpButton
                            | PFLogInFieldsPasswordForgotten
                            | PFLogInFieldsDismissButton);
-</code></pre>
-<pre><code class="swift">
+````
+````swift
   logInController.fields = [PFLogInFields.UsernameAndPassword,
                             PFLogInFields.LogInButton,
                             PFLogInFields.SignUpButton,
                             PFLogInFields.PasswordForgotten,
                             PFLogInFields.DismissButton]
-</code></pre>
+````
 
 Essentially, you create an array of all the options you want to include in the log in screen, and assign the value to `fields`.
 
@@ -63,37 +63,37 @@ In addition, there are a number of other options that can be turned on, includin
 
 Similarly, you can turn on Facebook or Twitter log in as such:
 
-<pre><code class="objectivec">
+````objectivec
 logInController.fields = (PFLogInFieldsUsernameAndPassword
                           | PFLogInFieldsFacebook
                           | PFLogInFieldsTwitter);
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 logInController.fields = [PFLogInFields.UsernameAndPassword,
                            PFLogInFields.Facebook,
                            PFLogInFields.Twitter]
-</code></pre>
+````
 
 The above code would produce a log in screen that includes username, password, Facebook and Twitter buttons. Facebook log in permissions can be set via the `facebookPermissions`.
 
-<pre><code class="objectivec">
+````objectivec
 PFLogInViewController *logInController = [[PFLogInViewController alloc] init];
 logInController.delegate = self;
 logInController.facebookPermissions = @[ @"friends_about_me" ];
 [self presentViewController:logInController animated:YES completion:nil];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var logInController = PFLogInViewController()
 logInController.delegate = self
 logInController.facebookPermissions = [ "friends_about_me" ]
 self.presentViewController(logInController, animated:true, completion:nil)
-</code></pre>
+````
 
 ### Responding to Log In Success, Failure or Cancellation
 
 When the user signs in or cancels, the `PFLogInViewController` notifies the delegate of the event. Upon receiving this callback, the delegate should, at a minimum, dismiss `PFLogInViewController`. Additionally, the delegate could possibly update its own views or forward the message to the other components that need to know about the `PFUser`.
 
-<pre><code class="objectivec">
+````objectivec
 - (void)logInViewController:(PFLogInViewController *)controller
                didLogInUser:(PFUser *)user {
     [self dismissViewControllerAnimated:YES completion:nil];
@@ -102,8 +102,8 @@ When the user signs in or cancels, the `PFLogInViewController` notifies the dele
 - (void)logInViewControllerDidCancelLogIn:(PFLogInViewController *)logInController {
     [self dismissViewControllerAnimated:YES completion:nil];
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 func logInViewController(controller: PFLogInViewController, didLogInUser user: PFUser!) -> Void {
   self.dismissViewControllerAnimated(true, completion: nil)
 }
@@ -111,7 +111,7 @@ func logInViewController(controller: PFLogInViewController, didLogInUser user: P
 func logInViewControllerDidCancelLogIn(controller: PFLogInViewController) -> Void {
   self.dismissViewControllerAnimated(true, completion: nil)
 }
-</code></pre>
+````
 
 Besides the delegate pattern, the `PFLogInViewController` also supports `NSNotification`s, which is useful if there are multiple observers of the sign in events.
 
@@ -119,7 +119,7 @@ Besides the delegate pattern, the `PFLogInViewController` also supports `NSNotif
 
 You might want to use your own logo or background image. You can achieve this by subclassing `PFLogInViewController` and overriding `viewDidLoad` method:
 
-<pre><code class="objectivec">
+````objectivec
 @interface MyLogInViewController : PFLogInViewController
 
 @end
@@ -135,8 +135,8 @@ You might want to use your own logo or background image. You can achieve this by
     self.logInView.logo = logoView; // logo can be any UIView
 }
 @end
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 class MyLogInViewController : PFLogInViewController {
 
   override func viewDidLoad() {
@@ -149,26 +149,26 @@ class MyLogInViewController : PFLogInViewController {
   }
 
 }
-</code></pre>
+````
 
 If you would like to modify the logo and the background of the associated sign up view, you will need to subclass `PFSignUpViewController` and create an instance of the subclass and assign it to the `signUpController` as soon as you instantiate `PFLogInViewController`:
 
-<pre><code class="objectivec">
+````objectivec
 MyLogInViewController *logInController = [[MyLogInViewController alloc] init];
 logInController.signUpController = [[MySignUpViewController alloc] init];
 [self presentViewController:logInController animated:YES completion:nil];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let logInController = MyLogInViewController()
 logInController.signUpController = MySignUpViewController()
 self.presentViewController(logInController, animated: true, completion: nil)
-</code></pre>
+````
 
 ### Further View Customization
 
 Occasionally you might want to customize `PFLogInViewController` further. For example, you might want to change the placeholder text to "Email" or change the size of the login button. In both cases, you need to subclass `PFLogInViewController` and override either `viewDidLoad` or `viewDidLayoutSubviews`. Override the former if the behavior is not related to layout, and override the latter otherwise:
 
-<pre><code class="objectivec">
+````objectivec
 @interface MyLogInViewController : PFLogInViewController
 
 @end
@@ -186,8 +186,8 @@ Occasionally you might want to customize `PFLogInViewController` further. For ex
 }
 
 @end
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 class MyLogInViewController : PFLogInViewController {
 
   override func viewDidLoad() {
@@ -203,7 +203,7 @@ class MyLogInViewController : PFLogInViewController {
   }
 
 }
-</code></pre>
+````
 
 Developers interested in this kind of customization should take a look at the interface of [`PFLogInView`](ios/api/Classes/PFLogInView.html), where all customizable properties are documented.
 
@@ -221,16 +221,16 @@ If you are using `PFLogInViewController` with the `PFLogInFieldsSignUpButton` op
 
 You use `PFSignUpViewController` by instantiating it and presenting it modally:
 
-<pre><code class="objectivec">
+````objectivec
 PFSignUpViewController *signUpController = [[PFSignUpViewController alloc] init];
 signUpController.delegate = self;
 [self presentViewController:signUpController animated:YES completion:nil];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let signUpController = PFSignUpViewController()
 signUpController.delegate = self
 self.presentViewController(signUpController, animated: true, completion: nil)
-</code></pre>
+````
 
 That is all you need to do to get a functional sign up screen.
 
@@ -247,20 +247,20 @@ That is all you need to do to get a functional sign up screen.
 
 If your sign up screen requires an additional field on top of the default ones, such as "phone number", you can turn on a field called named "additional":
 
-<pre><code class="objectivec">
+````objectivec
 signUpController.fields = (PFSignUpFieldsUsernameAndPassword
                           | PFSignUpFieldsSignUpButton
                           | PFSignUpFieldsEmail
                           | PFSignUpFieldsAdditional
                           | PFSignUpFieldsDismissButton);
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 signUpController.fields = (PFSignUpFields.UsernameAndPassword
                           | PFSignUpFields.SignUpButton
                           | PFSignUpFields.Email
                           | PFSignUpFields.Additional
                           | PFSignUpFields.DismissButton)
-</code></pre>
+````
 
 Essentially, you use the bitwise or operator (`|`) to chain up all the options you want to include in the sign up screen, and assign the value to `fields`. Similarly, you can turn off any field by omitting it in the assignment to fields.
 
@@ -268,7 +268,7 @@ Essentially, you use the bitwise or operator (`|`) to chain up all the options y
 
 When the user signs up or cancels, the `PFSignUpViewController` notifies the delegate of the event. Upon receiving this callback, the delegate should, at a minimum, dismiss `PFSignUpViewController`. Additionally, the delegate could update its own views or forward the message to the other components that need to know about the `PFUser`.
 
-<pre><code class="objectivec">
+````objectivec
 - (void)signUpViewController:(PFSignUpViewController *)signUpController didSignUpUser:(PFUser *)user {
     [self dismissViewControllerAnimated:YES completion:nil];
 }
@@ -276,8 +276,8 @@ When the user signs up or cancels, the `PFSignUpViewController` notifies the del
 - (void)signUpViewControllerDidCancelSignUp:(PFSignUpViewController *)signUpController {
     [self dismissViewControllerAnimated:YES completion:nil];
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 func signUpViewController(signUpController: PFSignUpViewController, didSignUpUser user: PFUser) -> Void {
   self.dismissViewControllerAnimated(true, completion: nil)
 }
@@ -285,7 +285,7 @@ func signUpViewController(signUpController: PFSignUpViewController, didSignUpUse
 func signUpViewControllerDidCancelSignUp(signUpController: PFSignUpViewController) -> Void {
   self.dismissViewControllerAnimated(true, completion: nil)
 }
-</code></pre>
+````
 
 Besides the delegate pattern, the `PFSignUpViewController` also supports `NSNotification`s, which is useful when there are multiple listeners of the sign up events.
 
@@ -293,7 +293,7 @@ Besides the delegate pattern, the `PFSignUpViewController` also supports `NSNoti
 
 You might want to use your own logo or background image. You can achieve this by subclassing `PFSignUpViewController` and overriding `viewDidLoad`:
 
-<pre><code class="objectivec">
+````objectivec
 @interface MySignUpViewController : PFSignUpViewController
 
 @end
@@ -310,8 +310,8 @@ You might want to use your own logo or background image. You can achieve this by
 }
 
 @end
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 class MySignUpViewController : PFSignUpViewController {
 
   override func viewDidLoad() {
@@ -323,20 +323,20 @@ class MySignUpViewController : PFSignUpViewController {
     self.signUpView.logo = logoView // 'logo' can be any UIView
   }
 }
-</code></pre>
+````
 
 ### Customizing Validation Logic
 
 Often you will want to run some client-side validation on the sign up information before submitting it to the Parse Cloud. You can add your validation logic in the `signUpViewController:shouldBeginSignUp:` method in the `PFSignUpViewControllerDelegate`. For example, if you decide any password less than 8 characters is too short, you can achieve the following with:
 
-<pre><code class="objectivec">
+````objectivec
 - (BOOL)signUpViewController:(PFSignUpViewController *)signUpController
            shouldBeginSignUp:(NSDictionary *)info {
     NSString *password = info[@"password"];
     return (password.length >= 8); // prevent sign up if password has to be at least 8 characters long
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 func signUpViewController(signUpController: PFSignUpViewController!,
                           shouldBeginSignUp info: [NSObject : AnyObject]!) -> Bool {
     if let password = info?["password"] as? String {
@@ -344,14 +344,14 @@ func signUpViewController(signUpController: PFSignUpViewController!,
     }
     return false
 }
-</code></pre>
+````
 `info` is a dictionary that contains all sign up fields, such as username, password, email, and additional.
 
 ### Further View Customization
 
 Occasionally you might want to customize `PFSignUpViewController` further. For example, you might want to change the "additional" placeholder text to "Phone" or change the size of the signup button. You can always subclass `PFSignUpViewController` and override `UIViewController`'s various methods. You should override the `viewDidLoad` if the behavior you want to change is unrelated to view layout, and override `viewDidLayoutSubviews` otherwise:
 
-<pre><code class="objectivec">
+````objectivec
 @interface MySignUpViewController : PFSignUpViewController
 
 @end
@@ -369,8 +369,8 @@ Occasionally you might want to customize `PFSignUpViewController` further. For e
 }
 
 @end
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 class MySignUpViewController : PFSignUpViewController {
 
   override func viewDidLoad() {
@@ -386,7 +386,7 @@ class MySignUpViewController : PFSignUpViewController {
   }
 
 }
-</code></pre>
+````
 
 Developer interested in this kind of customization should take a look at the interface of [`PFSignUpView`](ios/api/Classes/PFSignUpView.html), where all customizable properties are documented.
 
@@ -423,7 +423,7 @@ The class allows you to think about a one-to-one mapping between a `PFObject` an
 
 The easiest way to understand this class is with an example. This subclass of `PFQueryTableViewController` displays a series of Todo items and their numeric priorities:
 
-<pre><code class="objectivec">
+````objectivec
 @interface SimpleTableViewController : PFQueryTableViewController
 
 @end
@@ -474,8 +474,8 @@ The easiest way to understand this class is with an example. This subclass of `P
 }
 
 @end
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 class SimpleTableViewController : PFQueryTableViewController {
 
     override init(style: UITableViewStyle, className: String?) {
@@ -526,7 +526,7 @@ class SimpleTableViewController : PFQueryTableViewController {
         return cell
     }
 }
-</code></pre>
+````
 
 <img src="https://parse.com/images/docs/todo_view.png" style="max-width:200px"/>
 
@@ -540,7 +540,7 @@ A good starting point to learn more is to look at the [API for the class](/image
 
 `PFQueryTableViewController` makes it simple to display remote images stored in the Parse Cloud as `PFFile`s. All you need to do is to override `tableView:cellForRowAtIndexPath:object:` and return a `PFTableViewCell` with its `imageView`'s `file` property specified. If you would like to display a placeholder image to be shown before the remote image is loaded, assign the placeholder image to the `image` property of the `imageView`.
 
-<pre><code class="objectivec">
+````objectivec
 @implementation SimpleTableViewController
 
 - (UITableViewCell *)tableView:(UITableView *)tableView  cellForRowAtIndexPath:(NSIndexPath *)indexPath object:(PFObject *)object {
@@ -556,8 +556,8 @@ A good starting point to learn more is to look at the [API for the class](/image
     return cell;
 }
 @end
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath, object: PFObject?) -> PFTableViewCell? {
     let identifier = "cell"
 
@@ -574,7 +574,7 @@ override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath:
 
     return cell
 }
-</code></pre>
+````
 
 <img src="https://parse.com/images/docs/images_table.png" style="max-width:200px"/>
 
@@ -628,20 +628,20 @@ When the user is offline or a Parse error was generated from a query, an alert c
 
 Many apps need to display images stored in the Parse Cloud as `PFFile`s. However, to load remote images with the built-in `UIImageView` involves writing many lines of boilerplate code. `PFImageView` simplifies this task:
 
-<pre><code class="objectivec">
+````objectivec
 PFImageView *imageView = [[PFImageView alloc] init];
 imageView.image = [UIImage imageNamed:@"..."]; // placeholder image
 imageView.file = (PFFile *)someObject[@"picture"]; // remote image
 
 [imageView loadInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let imageView = PFImageView()
 imageView.image = UIImage(named: "...") // placeholder image
 imageView.file = someObject.picture // remote image
 
 imageView.loadInBackground()
-</code></pre>
+````
 
 If assigned to, the `image` property is used to display a placeholder before the remote image is downloaded. Note that the download does not start as soon as the `file` property is assigned to, but the loading only begins when `loadInBackground:` is called. The remote image is cached both in memory and on disc. If the image is found in cache, the call to `loadInBackground:` would return immediately.
 
@@ -649,7 +649,7 @@ If assigned to, the `image` property is used to display a placeholder before the
 
 Many apps need to display table view cells which contain images stored in the Parse Cloud as `PFFile`s. However, to load remote images with the built-in `UITableViewCell` involves writing many lines of boilerplate code. `PFTableViewCell` simplifies this task by exposing an `imageView` property of the type `PFImageView` that supports remote image loading:
 
-<pre><code class="objectivec">
+````objectivec
 @implementation SimpleTableViewController
 
 - (UITableViewCell *)tableView:(UITableView *)tableView  cellForRowAtIndexPath:(NSIndexPath *)indexPath object:(PFObject *)object {
@@ -666,8 +666,8 @@ Many apps need to display table view cells which contain images stored in the Pa
 }
 
 @end
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
     let identifier = "cell"
     var cell = tableView.dequeueReusableCellWithIdentifier(identifier) as? PFTableViewCell
@@ -685,7 +685,7 @@ func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexP
 
     return cell!
 }
-</code></pre>
+````
 
 Like `UITableViewCell`, `PFTableViewCell` supports the default layout styles. Unlike `UITableViewCell`, `PFTableViewCell`'s `imageView` property is of the type `PFImageView`, which supports downloading remote images in `PFFile`.
 
@@ -697,9 +697,9 @@ All strings in Parse's UI classes are customizable/localizable. The easiest way 
 
 Say, for example, you would like to customize the loading message in the HUD of `PFSignUpViewController` that says "Loading..." Assume you have followed the localization guide and set up `Localizable.strings` in the `en.lproj` directory. In `Localizable.strings`, you can then enter:
 
-<pre><code class="javascript">
+````javascript
 "Loading..." = "In progress";
-</code></pre>
+````
 
 That would customize the string to "In progress". The key on the left is the original string you want to customize, and the value on the right is the customized value.
 
@@ -707,8 +707,8 @@ Say, you would like to customize the error message in `PFSignUpViewController` t
 
 Included in  the Parse SDK is a file named `Localizable.string` which includes all the localizable keys in the Parse framework. Browsing this file, developers can find the key for the string they would like to customize. You notice that the string `"The email address \"%@\" is invalid. Please enter a valid email."` is a key in the file. In your own `Localizable.strings`, you can then enter:
 
-<pre><code class="javascript">
+````javascript
 "The email address \"%@\" is invalid. Please enter a valid email." = "Wrong email: \"%@\"";
-</code></pre>
+````
 
 The string is now customized.

--- a/_includes/ios/users.md
+++ b/_includes/ios/users.md
@@ -21,7 +21,7 @@ We'll go through each of these in detail as we run through the various use cases
 
 The first thing your app will do is probably ask the user to sign up. The following code illustrates a typical sign up:
 
-<pre><code class="objectivec">
+````objectivec
 - (void)myMethod {
     PFUser *user = [PFUser user];
     user.username = @"my name";
@@ -37,8 +37,8 @@ The first thing your app will do is probably ask the user to sign up. The follow
       }
     }];
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 func myMethod() {
   var user = PFUser()
   user.username = "myUsername"
@@ -57,7 +57,7 @@ func myMethod() {
     }
   }
 }
-</code></pre>
+````
 
 This call will asynchronously create a new user in your Parse App. Before it does this, it also checks to make sure that both the username and email are unique. Also, it securely hashes the password in the cloud using bcrypt. We never store passwords in plaintext, nor will we ever transmit passwords back to the client in plaintext.
 
@@ -73,7 +73,7 @@ You are free to use an email address as the username. Simply ask your users to e
 
 Of course, after you allow users to sign up, you need to let them log in to their account in the future. To do this, you can use the class method `logInWithUsernameInBackground:password:`.
 
-<pre><code class="objectivec">
+````objectivec
 [PFUser logInWithUsernameInBackground:@"myname" password:@"mypass"
   block:^(PFUser *user, NSError *error) {
     if (user) {
@@ -82,8 +82,8 @@ Of course, after you allow users to sign up, you need to let them log in to thei
       // The login failed. Check error to see why.
     }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFUser.logInWithUsernameInBackground("myname", password:"mypass") {
   (user: PFUser?, error: NSError?) -> Void in
   if user != nil {
@@ -92,7 +92,7 @@ PFUser.logInWithUsernameInBackground("myname", password:"mypass") {
     // The login failed. Check error to see why.
   }
 }
-</code></pre>
+````
 
 ## Verifying Emails
 
@@ -111,33 +111,33 @@ It would be bothersome if the user had to log in every time they open your app. 
 
 Whenever you use any signup or login methods, the user is cached on disk. You can treat this cache as a session, and automatically assume the user is logged in:
 
-<pre><code class="objectivec">
+````objectivec
 PFUser *currentUser = [PFUser currentUser];
 if (currentUser) {
     // do stuff with the user
 } else {
     // show the signup or login screen
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var currentUser = PFUser.currentUser()
 if currentUser != nil {
   // Do stuff with the user
 } else {
   // Show the signup or login screen
 }
-</code></pre>
+````
 
 You can clear the current user by logging them out:
 
-<pre><code class="objectivec">
+````objectivec
 [PFUser logOut];
 PFUser *currentUser = [PFUser currentUser]; // this will now be nil
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFUser.logOut()
 var currentUser = PFUser.currentUser() // this will now be nil
-</code></pre>
+````
 
 ## Anonymous Users
 
@@ -147,7 +147,7 @@ An anonymous user is a user that can be created without a username and password 
 
 You can create an anonymous user using `PFAnonymousUtils`:
 
-<pre><code class="objectivec">
+````objectivec
 [PFAnonymousUtils logInWithBlock:^(PFUser *user, NSError *error) {
     if (error) {
       NSLog(@"Anonymous login failed.");
@@ -155,8 +155,8 @@ You can create an anonymous user using `PFAnonymousUtils`:
       NSLog(@"Anonymous user logged in.");
     }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFAnonymousUtils.logInWithBlock {
   (user: PFUser?, error: NSError?) -> Void in
   if error != nil || user == nil {
@@ -165,43 +165,43 @@ PFAnonymousUtils.logInWithBlock {
     print("Anonymous user logged in.")
   }
 }
-</code></pre>
+````
 
 You can convert an anonymous user into a regular user by setting the username and password, then calling `signUp`, or by logging in or linking with a service like [Facebook](#fbusers) or [Twitter](#twitterusers). The converted user will retain all of its data.  To determine whether the current user is an anonymous user, you can check `PFAnonymousUtils isLinkedWithUser`:
 
-<pre><code class="objectivec">
+````objectivec
 if ([PFAnonymousUtils isLinkedWithUser:[PFUser currentUser]]) {
     [self enableSignUpButton];
 } else {
     [self enableLogOutButton];
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 if PFAnonymousUtils.isLinkedWithUser(PFUser.currentUser()) {
   self.enableSignUpButton()
 } else {
   self.enableLogOutButton()
 }
-</code></pre>
+````
 
 Anonymous users can also be automatically created for you without requiring a network request, so that you can begin working with your user immediately when your application starts.  When you enable automatic anonymous user creation at application startup, `[PFUser currentUser]` will never be `nil`. The user will automatically be created in the cloud the first time the user or any object with a relation to the user is saved.  Until that point, the user's object ID will be `nil`.  Enabling automatic user creation makes associating data with your users painless.  For example, in your `application:didFinishLaunchingWithOptions:` function, you might write:
 
-<pre><code class="objectivec">
+````objectivec
 [PFUser enableAutomaticUser];
 [[PFUser currentUser] incrementKey:@"RunCount"];
 [[PFUser currentUser] saveInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFUser.enableAutomaticUser()
 PFUser.currentUser().incrementKey("RunCount")
 PFUser.currentUser().saveInBackground()
-</code></pre>
+````
 
 ## Setting the Current User
 
 If you’ve created your own authentication routines, or otherwise logged in a user on the server side, you can now pass the session token to the client and use the `become` method. This method will ensure the session token is valid before setting the current user.
 
-<pre><code class="objectivec">
+````objectivec
 [PFUser becomeInBackground:@"session-token-here" block:^(PFUser *user, NSError *error) {
   if (error) {
     // The token could not be validated.
@@ -209,8 +209,8 @@ If you’ve created your own authentication routines, or otherwise logged in a u
     // The current user is now set to user.
   }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFUser.becomeInBackground("session-token-here", {
   (user: PFUser?, error: NSError?) -> Void in
   if error != nil {
@@ -219,7 +219,7 @@ PFUser.becomeInBackground("session-token-here", {
     // The current user is now set to user.
   }
 })
-</code></pre>
+````
 
 ## Security For User Objects
 
@@ -229,7 +229,7 @@ Specifically, you are not able to invoke any of the `save` or `delete` methods u
 
 The following illustrates this security policy:
 
-<pre><code class="objectivec">
+````objectivec
 PFUser *user = [PFUser logInWithUsername:@"my_username" password:@"my_password"];
 user.username = "my_new_username"; // attempt to change username
 [user save]; // This succeeds, since the user was authenticated on the device
@@ -242,8 +242,8 @@ userAgain.username = "another_username";
 
 // This will throw an exception, since the PFUser is not authenticated
 [userAgain save];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var user = PFUser.logInWithUsername("my_username", password:"my_password")
 user.username = "my_new_username" // attempt to change username
 user.save() // This succeeds, since the user was authenticated on the device
@@ -256,7 +256,7 @@ userAgain.username = "another_username"
 
 // This will crash, since the PFUser is not authenticated
 userAgain.save()
-</code></pre>
+````
 
 The `PFUser` obtained from `currentUser` will always be authenticated.
 
@@ -268,24 +268,24 @@ The same security model that applies to the `PFUser` can be applied to other obj
 
 The simplest way to use a `PFACL` is to specify that an object may only be read or written by a single user. To create such an object, there must first be a logged in `PFUser`. Then, the `ACLWithUser` method generates a `PFACL` that limits access to that user. An object's ACL is updated when the object is saved, like any other property. Thus, to create a private note that can only be accessed by the current user:
 
-<pre><code class="objectivec">
+````objectivec
 PFObject *privateNote = [PFObject objectWithClassName:@"Note"];
 privateNote[@"content"] = @"This note is private!";
 privateNote.ACL = [PFACL ACLWithUser:[PFUser currentUser]];
 [privateNote saveInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var privateNote = PFObject(className:"Note")
 privateNote["content"] = "This note is private!"
 privateNote.ACL = PFACL.ACLWithUser(PFUser.currentUser())
 privateNote.saveInBackground()
-</code></pre>
+````
 
 This note will then only be accessible to the current user, although it will be accessible to any device where that user is signed in. This functionality is useful for applications where you want to enable access to user data across multiple devices, like a personal todo list.
 
 Permissions can also be granted on a per-user basis. You can add permissions individually to a `PFACL` using `setReadAccess:forUser:` and `setWriteAccess:forUser:`. For example, let's say you have a message that will be sent to a group of several users, where each of them have the rights to read and delete that message:
 
-<pre><code class="objectivec">
+````objectivec
 PFObject *groupMessage = [PFObject objectWithClassName:@"Message"];
 PFACL *groupACL = [PFACL ACL];
 
@@ -297,8 +297,8 @@ for (PFUser *user in userList) {
 
 groupMessage.ACL = groupACL;
 [groupMessage saveInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var groupMessage = PFObject(className:"Message")
 var groupACL = PFACL.ACL()
 
@@ -310,66 +310,66 @@ for (user : PFUser in userList) {
 
 groupMessage.ACL = groupACL
 groupMessage.saveInBackground()
-</code></pre>
+````
 
 You can also grant permissions to all users at once using `setPublicReadAccess:` and `setPublicWriteAccess:`. This allows patterns like posting comments on a message board. For example, to create a post that can only be edited by its author, but can be read by anyone:
 
-<pre><code class="objectivec">
+````objectivec
 PFObject *publicPost = [PFObject objectWithClassName:@"Post"];
 PFACL *postACL = [PFACL ACLWithUser:[PFUser currentUser]];
 [postACL setPublicReadAccess:YES];
 publicPost.ACL = postACL;
 [publicPost saveInBackground];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var publicPost = PFObject(className:"Post")
 var postACL = PFACL.ACLWithUser(PFUser.currentUser())
 postACL.setPublicReadAccess(true)
 publicPost.ACL = postACL
 publicPost.saveInBackground()
-</code></pre>
+````
 
 To help ensure that your users' data is secure by default, you can set a default ACL to be applied to all newly-created `PFObjects`:
 
-<pre><code class="objectivec">
+````objectivec
 [PFACL setDefaultACL:defaultACL withAccessForCurrentUser:YES];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFACL.setDefaultACL(defaultACL, withAccessForCurrentUser:true)
-</code></pre>
+````
 
 In the code above, the second parameter to setDefaultACL tells Parse to ensure that the default ACL assigned at the time of object creation allows read and write access to the current user at that time.  Without this setting, you would need to reset the defaultACL every time a user logs in or out so that the current user would be granted access appropriately.  With this setting, you can ignore changes to the current user until you explicitly need to grant different kinds of access.
 
 Default ACLs make it easy to create apps that follow common access patterns. An application like Twitter, for example, where user content is generally visible to the world, might set a default ACL such as:
 
-<pre><code class="objectivec">
+````objectivec
 PFACL *defaultACL = [PFACL ACL];
 [defaultACL setPublicReadAccess:YES];
 [PFACL setDefaultACL:defaultACL withAccessForCurrentUser:YES];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var defaultACL = PFACL.ACL()
 defaultACL.setPublicReadAccess(true)
 PFACL.setDefaultACL(defaultACL, withAccessForCurrentUser:true)
-</code></pre>
+````
 
 For an app like Dropbox, where a user's data is only accessible by the user itself unless explicit permission is given, you would provide a default ACL where only the current user is given access:
 
-<pre><code class="objectivec">
+````objectivec
 [PFACL setDefaultACL:[PFACL ACL] withAccessForCurrentUser:YES];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFACL.setDefaultACL(PFACL.ACL(), withAccessForCurrentUser:true)
-</code></pre>
+````
 
 For an application that logs data to Parse but doesn't provide any user access to that data, you would deny access to the current user while providing a restrictive ACL:
 
-<pre><code class="objectivec">
+````objectivec
 [PFACL setDefaultACL:[PFACL ACL] withAccessForCurrentUser:NO];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFACL.setDefaultACL(PFACL.ACL(), withAccessForCurrentUser:false)
-</code></pre>
+````
 
 Operations that are forbidden, such as deleting an object that you do not have write access to, result in a `kPFErrorObjectNotFound` error code. For security purposes, this prevents clients from distinguishing which object ids exist but are secured, versus which object ids do not exist at all.
 
@@ -379,12 +379,12 @@ It's a fact that as soon as you introduce passwords into a system, users will fo
 
 To kick off the password reset flow, ask the user for their email address, and call:
 
-<pre><code class="objectivec">
+````objectivec
 [PFUser requestPasswordResetForEmailInBackground:@"email@example.com"];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFUser.requestPasswordResetForEmailInBackground("email@example.com")
-</code></pre>
+````
 
 This will attempt to match the given email with the user's email or username field, and will send them a password reset email. By doing this, you can opt to have users use their email as their username, or you can collect it separately and store it in the email field.
 
@@ -401,16 +401,16 @@ Note that the messaging in this flow will reference your app by the name that yo
 
 To query for users, you need to use the special user query:
 
-<pre><code class="objectivec">
+````objectivec
 PFQuery *query = [PFUser query];
 [query whereKey:@"gender" equalTo:@"female"]; // find all the women
 NSArray *girls = [query findObjects];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var query = PFUser.query()
 query.whereKey("gender", equalTo:"female")
 var girls = query.findObjects()
-</code></pre>
+````
 
 In addition, you can use `getUserObjectWithId:objectId` to get a `PFUser` by id.
 
@@ -418,7 +418,7 @@ In addition, you can use `getUserObjectWithId:objectId` to get a `PFUser` by id.
 
 Associations involving a `PFUser` work right out of the box. For example, let's say you're making a blogging app. To store a new post for a user and retrieve all their posts:
 
-<pre><code class="objectivec">
+````objectivec
 PFUser *user = [PFUser currentUser];
 
 // Make a new post
@@ -432,8 +432,8 @@ post[@"user"] = user;
 PFQuery *query = [PFQuery queryWithClassName:@"Post"];
 [query whereKey:@"user" equalTo:user];
 NSArray *usersPosts = [query findObjects];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 var user = PFUser.currentUser()
 
 // Make a new post
@@ -442,7 +442,7 @@ post["title"] = "My New Post"
 post["body"] = "This is some great content."
 post["user"] = user
 post.save()
-</code></pre>
+````
 
 ## Facebook Users
 
@@ -464,7 +464,7 @@ To start using Facebook with Parse, you need to:
 
 There's also two code changes you'll need to make. First, add the following to your `application:didFinishLaunchingWithOptions:` method, after you've initialized the Parse SDK.
 
-<pre><code class="objectivec">
+````objectivec
 // AppDelegate.m
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #import <ParseFacebookUtilsV4/PFFacebookUtils.h>
@@ -476,8 +476,8 @@ There's also two code changes you'll need to make. First, add the following to y
   [PFFacebookUtils initializeFacebookWithApplicationLaunchOptions:launchOptions];
 }
 
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 import FBSDKCoreKit
 import ParseFacebookUtilsV4
 
@@ -486,11 +486,11 @@ func application(application: UIApplication, didFinishLaunchingWithOptions launc
   Parse.setApplicationId("parseAppId", clientKey:"parseClientKey")
   PFFacebookUtils.initializeFacebookWithApplicationLaunchOptions(launchOptions)
 }
-</code></pre>
+````
 
 Next, add the following handlers in your app delegate.
 
-<pre><code class="objectivec">
+````objectivec
 - (BOOL)application:(UIApplication *)application
             openURL:(NSURL *)url
   sourceApplication:(NSString *)sourceApplication
@@ -504,9 +504,9 @@ Next, add the following handlers in your app delegate.
 - (void)applicationDidBecomeActive:(UIApplication *)application {
   [FBSDKAppEvents activateApp];
 }
-</code></pre>
+````
 
-<pre><code class="swift">
+````swift
 func application(application: UIApplication,
                  openURL url: NSURL,
                  sourceApplication: String?,
@@ -521,7 +521,7 @@ func application(application: UIApplication,
 func applicationDidBecomeActive(application: UIApplication) {
   FBSDKAppEvents.activateApp()
 }
-</code></pre>
+````
 
 There are two main ways to use Facebook with your Parse users: (1) to log in (or sign up) as a Facebook user and creating a `PFUser`, or (2) linking Facebook to an existing `PFUser`.
 
@@ -533,7 +533,7 @@ There are two main ways to use Facebook with your Parse users: (1) to log in (or
 
 `PFUser` provides a way to allow your users to log in or sign up through Facebook. This is done by using the `logInInBackgroundWithReadPermissions` method like so:
 
-<pre><code class="objectivec">
+````objectivec
 [PFFacebookUtils logInInBackgroundWithReadPermissions:permissions block:^(PFUser *user, NSError *error) {
   if (!user) {
     NSLog(@"Uh oh. The user cancelled the Facebook login.");
@@ -543,8 +543,8 @@ There are two main ways to use Facebook with your Parse users: (1) to log in (or
     NSLog(@"User logged in through Facebook!");
   }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFFacebookUtils.logInInBackgroundWithReadPermissions(permissions) {
   (user: PFUser?, error: NSError?) -> Void in
   if let user = user {
@@ -557,7 +557,7 @@ PFFacebookUtils.logInInBackgroundWithReadPermissions(permissions) {
     print("Uh oh. The user cancelled the Facebook login.")
   }
 }
-</code></pre>
+````
 
 When this code is run, the following happens:
 
@@ -571,7 +571,7 @@ The permissions argument is an array of strings that specifies what permissions 
 
 To acquire publishing permissions for a user so that your app can, for example, post status updates on their behalf, you must call `[PFFacebookUtils logInInBackgroundWithPublishPermissions:]`:
 
-<pre><code class="objectivec">
+````objectivec
 [PFFacebookUtils logInInBackgroundWithPublishPermissions:@[ @"publish_actions" ] block:^(PFUser *user, NSError *error) {
   if (!user) {
     NSLog(@"Uh oh. The user cancelled the Facebook login.");
@@ -579,21 +579,21 @@ To acquire publishing permissions for a user so that your app can, for example, 
     NSLog(@"User now has publish permissions!");
   }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFFacebookUtils.logInInBackgroundWithPublishPermissions(["publish_actions"], {
   (user: PFUser?, error: NSError?) -> Void in
   if user != nil {
     // Your app now has publishing permissions for the user
   }
 })
-</code></pre>
+````
 
 ### Linking
 
 If you want to associate an existing `PFUser` to a Facebook account, you can link it like so:
 
-<pre><code class="objectivec">
+````objectivec
 if (![PFFacebookUtils isLinkedWithUser:user]) {
   [PFFacebookUtils linkUserInBackground:user withReadPermissions:nil block:^(BOOL succeeded, NSError *error) {
     if (succeeded) {
@@ -601,8 +601,8 @@ if (![PFFacebookUtils isLinkedWithUser:user]) {
     }
   }];
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 if !PFFacebookUtils.isLinkedWithUser(user) {
   PFFacebookUtils.linkUserInBackground(user, withReadPermissions: nil, {
     (succeeded: Bool?, error: NSError?) -> Void in
@@ -611,33 +611,33 @@ if !PFFacebookUtils.isLinkedWithUser(user) {
     }
   })
 }
-</code></pre>
+````
 
 The steps that happen when linking are very similar to log in. The difference is that on successful login, the existing `PFUser` is updated with the Facebook information. Future logins via Facebook will now log in the user to their existing account.
 
 If you want to unlink Facebook from a user, simply do this:
 
-<pre><code class="objectivec">
+````objectivec
 [PFFacebookUtils unlinkUserInBackground:user block:^(BOOL succeeded, NSError *error) {
   if (succeeded) {
     NSLog(@"The user is no longer associated with their Facebook account.");
   }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFFacebookUtils.unlinkUserInBackground(user, {
   (succeeded: Bool?, error: NSError?) -> Void in
   if succeeded {
     print("The user is no longer associated with their Facebook account.")
   }
 })
-</code></pre>
+````
 
 ### Log In / Link via Token
 
 In the previous sections, you've seen how `PFFacebookUtils` can be used to log in with the Facebook SDK and create a `PFUser` or link with existing ones. If you have already integrated the Facebook SDK and have a `FBSDKAccessToken`, there is an option to directly log in or link the users like this:
 
-<pre><code class="objectivec">
+````objectivec
 FBSDKAccessToken *accessToken = ...; // Use existing access token.
 
 // Log In (create/update currentUser) with FBSDKAccessToken
@@ -662,8 +662,8 @@ FBSDKAccessToken *accessToken = ...; // Use existing access token.
     NSLog(@"Woohoo, the user is linked with Facebook!");
   }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let accessToken: FBSDKAccessToken = ...; // Use existing access token.
 
 // Log In (create/update currentUser) with FBSDKAccessToken
@@ -687,13 +687,13 @@ PFFacebookUtils.linkUserInBackground(user, withAccessToken: accessToken, {
     print("Woohoo, the user is linked with Facebook!")
   }
 })
-</code></pre>
+````
 
 ### Additional Permissions
 
 Since Facebook SDK v4.0 - it is required to request **read** and **publish** permissions separately. With Parse SDK integration you can do that by logging in with read permissions first, and later, when the user wants to post to Facebook - linking a user with new set of publish permissions. This also works the other way around: logging in with publish permissions and linking with additional read permissions.
 
-<pre><code class="objectivec">
+````objectivec
 // Log In with Read Permissions
 [PFFacebookUtils logInInBackgroundWithReadPermissions:permissions block:^(PFUser *user, NSError *error) {
   if (!user) {
@@ -713,8 +713,8 @@ Since Facebook SDK v4.0 - it is required to request **read** and **publish** per
     NSLog(@"User now has read and publish permissions!");
   }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 // Log In with Read Permissions
 PFFacebookUtils.logInInBackgroundWithReadPermissions(permissions, {
   (user: PFUser?, error: NSError?) -> Void in
@@ -736,7 +736,7 @@ PFFacebookUtils.linkUserInBackground(user, withPublishPermissions: ["publish_act
     print("User now has read and publish permissions!")
   }
 })
-</code></pre>
+````
 
 ### Facebook SDK and Parse
 
@@ -757,13 +757,13 @@ To start using Twitter with Parse, you need to:
 3.  When asked to specify a "Callback URL" for your Twitter app, please insert a valid URL. This value will not be used by your iOS or Android application, but is necessary in order to enable authentication through Twitter.
 4.  Add the `Accounts.framework` and `Social.framework` libraries to your Xcode project.
 5.  Add the following where you initialize the Parse SDK, such as in `application:didFinishLaunchingWithOptions:`.
-<pre><code class="objectivec">
+````objectivec
 [PFTwitterUtils initializeWithConsumerKey:@"YOUR CONSUMER KEY"
                            consumerSecret:@"YOUR CONSUMER SECRET"];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFTwitterUtils.initializeWithConsumerKey("YOUR CONSUMER KEY",  consumerSecret:"YOUR CONSUMER SECRET")
-</code></pre>
+````
 
 If you encounter any issues that are Twitter-related, a good resource is the [official Twitter documentation](https://dev.twitter.com/docs).
 
@@ -773,7 +773,7 @@ There are two main ways to use Twitter with your Parse users: (1) logging in as 
 
 `PFTwitterUtils` provides a way to allow your `PFUser`s to log in or sign up through Twitter. This is accomplished using the `logInWithBlock` or `logInWithTarget` messages:
 
-<pre><code class="objectivec">
+````objectivec
 [PFTwitterUtils logInWithBlock:^(PFUser *user, NSError *error) {
     if (!user) {
       NSLog(@"Uh oh. The user cancelled the Twitter login.");
@@ -784,8 +784,8 @@ There are two main ways to use Twitter with your Parse users: (1) logging in as 
       NSLog(@"User logged in with Twitter!");
     }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFTwitterUtils.logInWithBlock {
   (user: PFUser?, error: NSError?) -> Void in
   if let user = user {
@@ -798,7 +798,7 @@ PFTwitterUtils.logInWithBlock {
     print("Uh oh. The user cancelled the Twitter login.")
   }
 }
-</code></pre>
+````
 
 When this code is run, the following happens:
 
@@ -811,7 +811,7 @@ When this code is run, the following happens:
 
 If you want to associate an existing `PFUser` with a Twitter account, you can link it like so:
 
-<pre><code class="objectivec">
+````objectivec
 if (![PFTwitterUtils isLinkedWithUser:user]) {
     [PFTwitterUtils linkUser:user block:^(BOOL succeeded, NSError *error) {
         if ([PFTwitterUtils isLinkedWithUser:user]) {
@@ -819,8 +819,8 @@ if (![PFTwitterUtils isLinkedWithUser:user]) {
         }
     }];
 }
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 if !PFTwitterUtils.isLinkedWithUser(user) {
   PFTwitterUtils.linkUser(user, {
     (succeeded: Bool?, error: NSError?) -> Void in
@@ -829,33 +829,33 @@ if !PFTwitterUtils.isLinkedWithUser(user) {
     }
   })
 }
-</code></pre>
+````
 
 The steps that happen when linking are very similar to log in. The difference is that on successful login, the existing `PFUser` is updated with the Twitter information. Future logins via Twitter will now log the user into their existing account.
 
 If you want to unlink Twitter from a user, simply do this:
 
-<pre><code class="objectivec">
+````objectivec
 [PFTwitterUtils unlinkUserInBackground:user block:^(BOOL succeeded, NSError *error) {
     if (!error && succeeded) {
       NSLog(@"The user is no longer associated with their Twitter account.");
     }
 }];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 PFTwitterUtils.unlinkUserInBackground(user, {
   (succeeded: Bool?, error: NSError?) -> Void in
   if error == nil && succeeded {
     print("The user is no longer associated with their Twitter account.")
   }
 })
-</code></pre>
+````
 
 ### Twitter API Calls
 
 Our SDK provides a straightforward way to sign your API HTTP requests to the [Twitter REST API](https://dev.twitter.com/docs/api) when your app has a Twitter-linked `PFUser`.  To make a request through our API, you can use the `PF_Twitter` singleton provided by `PFTwitterUtils`:
 
-<pre><code class="objectivec">
+````objectivec
 NSURL *verify = [NSURL URLWithString:@"https://api.twitter.com/1.1/account/verify_credentials.json"];
 NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:verify];
 [[PFTwitterUtils twitter] signRequest:request];
@@ -865,8 +865,8 @@ NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:r
   // Data will contain the response data
 }];
 [task resume];
-</code></pre>
-<pre><code class="swift">
+````
+````swift
 let verify = NSURL(string: "https://api.twitter.com/1.1/account/verify_credentials.json")
 var request = NSMutableURLRequest(URL: verify!)
 PFTwitterUtils.twitter()!.signRequest(request)
@@ -875,4 +875,4 @@ let task = NSURLSession.sharedSession().dataTaskWithRequest(request) { data, res
   // Data will contain the response data
 }
 task.resume()
-</code></pre>
+````

--- a/_includes/js/analytics.md
+++ b/_includes/js/analytics.md
@@ -13,7 +13,7 @@ Without having to implement any client-side logic, you can view real-time graphs
 
 Say your app offers search functionality for apartment listings, and you want to track how often the feature is used, with some additional metadata.
 
-<pre><code class="javascript">
+````javascript
 var dimensions = {
   // Define ranges to bucket data points into meaningful segments
   priceRange: '1000-1500',
@@ -24,13 +24,13 @@ var dimensions = {
 };
 // Send the dimensions to Parse along with the 'search' event
 Parse.Analytics.track('search', dimensions);
-</code></pre>
+````
 
 `Parse.Analytics` can even be used as a lightweight error tracker &mdash; simply invoke the following and you'll have access to an overview of the rate and frequency of errors, broken down by error code, in your application:
 
-<pre><code class="javascript">
+````javascript
 var codeString = '' + error.code;
 Parse.Analytics.track('error', { code: codeString });
-</code></pre>
+````
 
 Note that Parse currently only stores the first eight dimension pairs per call to `Parse.Analytics.track()`.

--- a/_includes/js/config.md
+++ b/_includes/js/config.md
@@ -4,7 +4,7 @@
 
 After that you will be able to fetch the `Parse.Config` on the client, like in this example:
 
-<pre><code class="javascript">
+````javascript
 Parse.Config.get().then(function(config) {
   var winningNumber = config.get("winningNumber");
   var message = "Yay! The number is " + winningNumber + "!";
@@ -12,13 +12,13 @@ Parse.Config.get().then(function(config) {
 }, function(error) {
   // Something went wrong (e.g. request timed out)
 });
-</code></pre>
+````
 
 ## Retrieving Config
 
 `ParseConfig` is built to be as robust and reliable as possible, even in the face of poor internet connections. Caching is used by default to ensure that the latest successfully fetched config is always available. In the below example we use `get` to retrieve the latest version of config from the server, and if the fetch fails we can simply fall back to the version that we successfully fetched before via `current`.
 
-<pre><code class="javascript">
+````javascript
 Parse.Config.get().then(function(config) {
   console.log("Yay! Config was fetched from the server.");
 
@@ -34,7 +34,7 @@ Parse.Config.get().then(function(config) {
   }
   console.log("Welcome Message = " + welcomeMessage);
 });
-</code></pre>
+````
 
 ## Current Config
 
@@ -42,7 +42,7 @@ Every `Parse.Config` instance that you get is always immutable. When you retriev
 
 It might be troublesome to retrieve the config from the server every time you want to use it. You can avoid this by simply using the cached `current()` object and fetching the config only once in a while.
 
-<pre><code class="javascript">
+````javascript
 // Fetches the config at most once every 12 hours per app runtime
 var refreshConfig = function() {
   var lastFetchedDate;
@@ -56,7 +56,7 @@ var refreshConfig = function() {
     }
   };
 }();
-</code></pre>
+````
 
 ## Parameters
 

--- a/_includes/js/files.md
+++ b/_includes/js/files.md
@@ -6,33 +6,33 @@
 
 Getting started with `Parse.File` is easy. There are a couple of ways to create a file. The first is with a base64-encoded String.
 
-<pre><code class="javascript">
+````javascript
 var base64 = "V29ya2luZyBhdCBQYXJzZSBpcyBncmVhdCE=";
 var file = new Parse.File("myfile.txt", { base64: base64 });
-</code></pre>
+````
 
 Alternatively, you can create a file from an array of byte values:
 
-<pre><code class="javascript">
+````javascript
 var bytes = [ 0xBE, 0xEF, 0xCA, 0xFE ];
 var file = new Parse.File("myfile.txt", bytes);
-</code></pre>
+````
 
 Parse will auto-detect the type of file you are uploading based on the file extension, but you can specify the `Content-Type` with a third parameter:
 
-<pre><code class="javascript">
+````javascript
 var file = new Parse.File("myfile.zzz", fileData, "image/png");
-</code></pre>
+````
 
 But most commonly for HTML5 apps, you'll want to use an html form with a file upload control. On modern browsers, this is easy. Create a file input tag which allows the user to pick a file from their local drive to upload:
 
-</code></pre>html
+````html
     <input type="file" id="profilePhotoFileUpload">
-</code></pre>
+````
 
 Then, in a click handler or other function, get a reference to that file:
 
-<pre><code class="javascript">
+````javascript
 var fileUploadControl = $("#profilePhotoFileUpload")[0];
 if (fileUploadControl.files.length > 0) {
   var file = fileUploadControl.files[0];
@@ -40,7 +40,7 @@ if (fileUploadControl.files.length > 0) {
 
   var parseFile = new Parse.File(name, file);
 }
-</code></pre>
+````
 
 Notice in this example that we give the file a name of `photo.jpg`. There's two things to note here: 
 
@@ -49,39 +49,39 @@ Notice in this example that we give the file a name of `photo.jpg`. There's two 
 
 Next you'll want to save the file up to the cloud. As with `Parse.Object`, there are many variants of the `save` method you can use depending on what sort of callback and error handling suits you.
 
-<pre><code class="javascript">
+````javascript
 parseFile.save().then(function() {
   // The file has been saved to Parse.
 }, function(error) {
   // The file either could not be read, or could not be saved to Parse.
 });
-</code></pre>
+````
 
 Finally, after the save completes, you can associate a `Parse.File` with a `Parse.Object` just like any other piece of data:
 
-<pre><code class="javascript">
+````javascript
 var jobApplication = new Parse.Object("JobApplication");
 jobApplication.set("applicantName", "Joe Smith");
 jobApplication.set("applicantResumeFile", parseFile);
 jobApplication.save();
-</code></pre>
+````
 
 ## Retrieving File Contents
 
 How to best retrieve the file contents back depends on the context of your application. Because of cross-domain request issues, it's best if you can make the browser do the work for you. Typically, that means rendering the file's URL into the DOM. Here we render an uploaded profile photo on a page with jQuery:
 
-<pre><code class="javascript">
+````javascript
 var profilePhoto = profile.get("photoFile");
 $("profileImg")[0].src = profilePhoto.url();
-</code></pre>
+````
 
 If you want to process a File's data in Cloud Code, you can retrieve the file using our http networking libraries:
 
-<pre><code class="javascript">
+````javascript
 Parse.Cloud.httpRequest({ url: profilePhoto.url() }).then(function(response) {
   // The file contents are in response.buffer.
 });
-</code></pre>
+````
 
 You can delete files that are referenced by objects using the [REST API](/docs/rest#files-deleting-files). You will need to provide the master key in order to be allowed to delete a file.
 

--- a/_includes/js/geopoints.md
+++ b/_includes/js/geopoints.md
@@ -6,15 +6,15 @@ Parse allows you to associate real-world latitude and longitude coordinates with
 
 To associate a point with an object you first need to create a `Parse.GeoPoint`.  For example, to create a point with latitude of 40.0 degrees and -30.0 degrees longitude:
 
-<pre><code class="javascript">
+````javascript
 var point = new Parse.GeoPoint({latitude: 40.0, longitude: -30.0});
-</code></pre>
+````
 
 This point is then stored in the object as a regular field.
 
-<pre><code class="javascript">
+````javascript
 placeObject.set("location", point);
-</code></pre>
+````
 
 Note: Currently only one key in a class may be a `Parse.GeoPoint`.
 
@@ -22,7 +22,7 @@ Note: Currently only one key in a class may be a `Parse.GeoPoint`.
 
 Now that you have a bunch of objects with spatial coordinates, it would be nice to find out which objects are closest to a point.  This can be done by adding another restriction to `Parse.Query` using `near`.  Getting a list of ten places that are closest to a user may look something like:
 
-<pre><code class="javascript">
+````javascript
 // User's location
 var userGeoPoint = userObject.get("location");
 // Create a query for places
@@ -36,7 +36,7 @@ query.find({
   success: function(placesObjects) {
   }
 });
-</code></pre>
+````
 
  At this point `placesObjects` will be an array of objects ordered by distance (nearest to farthest) from `userGeoPoint`. Note that if an additional `ascending()`/`descending()` order-by constraint is applied, it will take precedence over the distance ordering.
 
@@ -44,7 +44,7 @@ To limit the results using distance, check out `withinMiles`, `withinKilometers`
 
 It's also possible to query for the set of objects that are contained within a particular area.  To find the objects in a rectangular bounding box, add the `withinGeoBox` restriction to your `Parse.Query`.
 
-<pre><code class="javascript">
+````javascript
 var southwestOfSF = new Parse.GeoPoint(37.708813, -122.526398);
 var northeastOfSF = new Parse.GeoPoint(37.822802, -122.373962);
 
@@ -55,7 +55,7 @@ query.find({
     ...
   }
 });
-</code></pre>
+````
 
 ## Caveats
 

--- a/_includes/js/getting-started.md
+++ b/_includes/js/getting-started.md
@@ -2,7 +2,7 @@
 
 If you haven't set up your project yet, please [head over to the QuickStart guide]({{ page.quickstart }}#js/native/blank) to get up and running. You can also check out our [API Reference](/Parse-SDK-JS/api/) for more detailed information about our SDK.
 
-The Parse platform provides a complete backend solution for your mobile application. Our goal is to totally eliminate the need for writing server code or maintaining servers.</p>
+The Parse platform provides a complete backend solution for your mobile application. Our goal is to totally eliminate the need for writing server code or maintaining servers.
 
 <div class='tip info'><div>
   If you're looking to build a React application with Parse, we provide a special library for that. All of the documentation is available at the <a href="https://github.com/ParsePlatform/ParseReact">GitHub repo</a>.

--- a/_includes/js/handling-errors.md
+++ b/_includes/js/handling-errors.md
@@ -4,7 +4,7 @@ Most Parse JavaScript functions report their success or failure using an object 
 
 `error` is called for any kind of error that occurs when interacting with the Parse Cloud over the network. These errors are either related to problems connecting to the cloud or problems performing the requested operation. Let's take a look at another example.  In the code below, we try to fetch an object with a non-existent `objectId`. The Parse Cloud will return an error - so here's how to handle it properly in your callback:
 
-<pre><code class="javascript">
+````javascript
 var query = new Parse.Query(Note);
 query.get("aBcDeFgH", {
   success: function(results) {
@@ -19,11 +19,11 @@ query.get("aBcDeFgH", {
     }
   }
 });
-</code></pre>
+````
 
 The query might also fail because the device couldn't connect to the Parse Cloud. Here's the same callback but with a bit of extra code to handle that scenario:
 
-<pre><code class="javascript">
+````javascript
 var query = new Parse.Query(Note);
 query.get("thisObjectIdDoesntExist", {
   success: function(results) {
@@ -40,7 +40,7 @@ query.get("thisObjectIdDoesntExist", {
     }
   }
 });
-</code></pre>
+````
 
 For methods like `save` and `signUp` that affect a particular `Parse.Object`, the first argument to the error function will be the object itself, and the second will be the `Parse.Error` object.  This is for compatibility with Backbone-type frameworks.
 

--- a/_includes/js/live-queries.md
+++ b/_includes/js/live-queries.md
@@ -6,20 +6,20 @@ As we discussed in our [LiveQuery protocol](https://github.com/ParsePlatform/par
 Note: Live Queries is supported only in [Parse Server](https://github.com/ParsePlatform/parse-server) with [JS SDK ~1.8](https://github.com/ParsePlatform/Parse-SDK-JS).
 
 ## Create a subscription
-<pre><code class="java">script
+````javascript
 let query = new Parse.Query('Game');
 let subscription = query.subscribe();
-</code></pre>
+````
 The subscription you get is actually an event emitter. For more information on event emitter, check [here](https://nodejs.org/api/events.html). You'll get the LiveQuery events through this `subscription`. The first time you call subscribe, we'll try to open the WebSocket connection to the LiveQuery server for you.
 
 ## Event Handling
 We define several types of events you'll get through a subscription object:
 ### Open event
-<pre><code class="java">script
+````javascript
 subscription.on('open', () => {
  console.log('subscription opened');
 });
-</code></pre>
+````
 When you call `query.subscribe()`, we send a subscribe request to the LiveQuery server. When we get the confirmation from the LiveQuery server, this event will be emitted.
 
 When the client loses WebSocket connection to the LiveQuery server, we'll try to auto reconnect the LiveQuery server. If we reconnect the LiveQuery server and successfully resubscribe the `ParseQuery`, you'll also get this event.
@@ -27,113 +27,113 @@ When the client loses WebSocket connection to the LiveQuery server, we'll try to
 <br/>
 
 ### Create event
-<pre><code class="java">script
+````javascript
 subscription.on('create', (object) => {
   console.log('object created');
 });
-</code></pre>
+````
 When a new `ParseObject` is created and it fulfills the `ParseQuery` you subscribe, you'll get this event. The `object` is the `ParseObject` which was created.
 
 <br/>
 
 ### Update event
-<pre><code class="java">script
+````javascript
 subscription.on('update', (object) => {
   console.log('object updated');
 });
-</code></pre>
+````
 When an existing `ParseObject` which fulfills the `ParseQuery` you subscribe is updated (The `ParseObject` fulfills the `ParseQuery` before and after changes), you'll get this event. The `object` is the `ParseObject` which was updated. Its content is the latest value of the `ParseObject`.
 
 <br/>
 
 ### Enter event
-<pre><code class="java">script
+````javascript
 subscription.on('enter', (object) => {
   console.log('object entered');
 });
-</code></pre>
+````
 When an existing `ParseObject`'s old value does not fulfill the `ParseQuery` but its new value fulfills the `ParseQuery`, you'll get this event. The `object` is the `ParseObject` which enters the `ParseQuery`. Its content is the latest value of the `ParseObject`.
 
 <br/>
 
 ### Leave event
-<pre><code class="java">script
+````javascript
 subscription.on('leave', (object) => {
   console.log('object left');
 });
-</code></pre>
+````
 When an existing `ParseObject`'s old value fulfills the `ParseQuery` but its new value doesn't fulfill the `ParseQuery`, you'll get this event. The `object` is the `ParseObject` which leaves the `ParseQuery`. Its content is the latest value of the `ParseObject`.
 
 <br/>
 
 ### Delete event
-<pre><code class="java">script
+````javascript
 subscription.on('delete', (object) => {
   console.log('object deleted');
 });
-</code></pre>
+````
 When an existing `ParseObject` which fulfills the `ParseQuery` is deleted, you'll get this event. The `object` is the `ParseObject` which is deleted.
 
 <br/>
 
 ### Close event
-<pre><code class="java">script
+````javascript
 subscription.on('close', () => {
   console.log('subscription closed');
 });
-</code></pre>
+````
 When the client loses the WebSocket connection to the LiveQuery server and we can't get anymore events, you'll get this event.
 
 <br/>
 
 ## Unsubscribe
-<pre><code class="java">script
+````javascript
 subscription.unsubscribe();
-</code></pre>
+````
 If you would like to stop receiving events from a `ParseQuery`, you can just unsubscribe the `subscription`. After that, you won't get any events from the `subscription` object.
 
 
 ## Close
-<pre><code class="java">script
+````javascript
 Parse.LiveQuery.close();
-</code></pre>
+````
 When you are done using LiveQuery, you can call `Parse.LiveQuery.close()`. This function will close the WebSocket connection to the LiveQuery server, cancel the auto reconnect, and unsubscribe all subscriptions based on it. If you call `query.subscribe()` after this, we will create a new WebSocket connection to the LiveQuery server.
 
 
 ## Setup server URL
-<pre><code class="java">script
+````javascript
 Parse.liveQueryServerURL = 'ws://XXXX'
-</code></pre>
+````
 Most of the time you do not need to manually set this. If you have setup your `Parse.serverURL`, we will try to extract the hostname and use `ws://hostname` as the default `liveQueryServerURL`. However, if you want to define your own `liveQueryServerURL` or use a different protocol such as `wss`, you should set it by yourself.
 
 ## WebSocket Status
 We expose three events to help you monitor the status of the WebSocket connection:
 ### Open event
-<pre><code class="java">script
+````javascript
 Parse.LiveQuery.on('open', () => {
   console.log('socket connection established');
 });
-</code></pre>
+````
 When we establish the WebSocket connection to the LiveQuery server, you'll get this event.
 
 <br/>
 
 ### Close event
-<pre><code class="java">script
+````javascript
 Parse.LiveQuery.on('close', () => {
   console.log('socket connection closed');
 });
-</code></pre>
+````
 When we lose the WebSocket connection to the LiveQuery server, you'll get this event.
 
 <br/>
 
 ### Error event
-<pre><code class="java">script
+````javascript
 Parse.LiveQuery.on('error', (error) => {
   console.log(error);
 });
-</code></pre>
+````
 When some network error or LiveQuery server error happens, you'll get this event.
 
 <br/>
@@ -145,7 +145,7 @@ In our standard API, we manage a global WebSocket connection for you, which is s
 ## LiveQueryClient
 A `LiveQueryClient` is a wrapper of a standard WebSocket client. We add several useful methods to help you connect/disconnect to LiveQueryServer and subscribe/unsubscribe a `ParseQuery` easily.
 ### Initialize
-<pre><code class="java">script
+````javascript
 let Parse = require('parse/node');
 let LiveQueryClient = Parse.LiveQueryClient;
 let client = new LiveQueryClient({
@@ -155,41 +155,41 @@ let client = new LiveQueryClient({
   masterKey: ''
 });
 
-</code></pre> 
+````
 * `applicationId` is mandatory, it's the `applicationId` of your Parse app
 * `liveQueryServerURL` is mandatory, it's the URL of your LiveQuery server
 * `javascriptKey` and `masterKey` are optional, they are used for verifying the `LiveQueryClient` when it tries to connect to the LiveQuery server. If you set them, they should match your Parse app. You can check LiveQuery protocol [here](https://github.com/ParsePlatform/parse-server/wiki/Parse-LiveQuery-Protocol-Specification) for more details.
 
 ### Open
-<pre><code class="java">script
+````javascript
 client.open();
-</code></pre>
+````
 After you call this, the `LiveQueryClient` will try to send a connect request to the LiveQuery server.
 
 <br/>
 
 ### Subscribe
-<pre><code class="java">script
+````javascript
 let query = new Parse.Query('Game');
-let subscription = client.subscribe(query, sessionToken); 
-</code></pre>
+let subscription = client.subscribe(query, sessionToken);
+````
 * `query` is mandatory, it is the `ParseQuery` you want to subscribe
 * `sessionToken` is optional, if you provide the `sessionToken`, when the LiveQuery server gets `ParseObject`'s updates from parse server, it'll try to check whether the `sessionToken` fulfills the `ParseObject`'s ACL. The LiveQuery server will only send updates to clients whose sessionToken is fit for the `ParseObject`'s ACL. You can check the LiveQuery protocol [here](https://github.com/ParsePlatform/parse-server/wiki/Parse-LiveQuery-Protocol-Specification) for more details.
 The `subscription` you get is the same `subscription` you get from our Standard API. You can check our Standard API about how to use the `subscription` to get events.
 
 ### Unsubscribe
-<pre><code class="java">script
-client.unsubscribe(subscription); 
-</code></pre>
+````javascript
+client.unsubscribe(subscription);
+````
 * `subscription` is mandatory, it's the subscription you want to unsubscribe from.
 After you call this, you won't get any events from the subscription object.
 
 <br/>
 
 ### Close
-<pre><code class="java">script
+````javascript
 client.close();
-</code></pre>
+````
 This function will close the WebSocket connection to this `LiveQueryClient`, cancel the auto reconnect, and unsubscribe all subscriptions based on it.
 
 <br/>
@@ -197,31 +197,31 @@ This function will close the WebSocket connection to this `LiveQueryClient`, can
 ## Event Handling
 We expose three events to help you monitor the status of the `LiveQueryClient`.
 ### Open event
-<pre><code class="java">script
+````javascript
 client.on('open', () => {
   console.log('connection opened');
 });
-</code></pre>
+````
 When we establish the WebSocket connection to the LiveQuery server, you'll get this event.
 
 <br/>
 
 ### Close event
-<pre><code class="java">script
+````javascript
 client.on('close', () => {
   console.log('connection closed');
 });
-</code></pre>
+````
 When we lose the WebSocket connection to the LiveQuery server, you'll get this event.
 
 <br/>
 
 ### Error event
-<pre><code class="java">script
+````javascript
 client.on('error', (error) => {
   console.log('connection error');
 });
-</code></pre>
+````
 When some network error or LiveQuery server error happens, you'll get this event.
 
 <br/>

--- a/_includes/js/objects.md
+++ b/_includes/js/objects.md
@@ -6,9 +6,9 @@ Storing data on Parse is built around `Parse.Object`. Each `Parse.Object` contai
 
 For example, let's say you're tracking high scores for a game. A single `Parse.Object` could contain:
 
-<pre><code class="javascript">
+````javascript
 score: 1337, playerName: "Sean Plott", cheatMode: false
-</code></pre>
+````
 
 Keys must be alphanumeric strings. Values can be strings, numbers, booleans, or even arrays and dictionaries - anything that can be JSON-encoded.
 
@@ -16,7 +16,7 @@ Each `Parse.Object` is an instance of a specific subclass with a class name that
 
 To create a new subclass, use the `Parse.Object.extend` method.  Any `Parse.Query` will return instances of the new class for any `Parse.Object` with the same classname.  If you're familiar with `Backbone.Model`, then you already know how to use `Parse.Object`.  It's designed to be created and modified in the same ways.
 
-<pre><code class="javascript">
+````javascript
 // Simple syntax to create a new subclass of Parse.Object.
 var GameScore = Parse.Object.extend("GameScore");
 
@@ -27,11 +27,11 @@ var gameScore = new GameScore();
 var Achievement = Parse.Object.extend({
   className: "Achievement"
 });
-</code></pre>
+````
 
 You can add additional methods and properties to your subclasses of `Parse.Object`.
 
-<pre><code class="javascript">
+````javascript
 
 // A complex subclass of Parse.Object
 var Monster = Parse.Object.extend("Monster", {
@@ -55,13 +55,13 @@ var Monster = Parse.Object.extend("Monster", {
 var monster = Monster.spawn(200);
 alert(monster.get('strength'));  // Displays 200.
 alert(monster.sound); // Displays Rawr.
-</code></pre>
+````
 
 To create a single instance of any Parse Object class, you can also use the `Parse.Object` constructor directly. `new Parse.Object(className)` will create a single Parse Object with that class name.
 
 If you’re already using ES6 in your codebase, good news! From version 1.6.0 onwards, the JavaScript SDK is compatible with ES6 classes. You can subclass `Parse.Object` with the `extends` keyword:
 
-<pre><code class="javascript">
+````javascript
 class Monster extends Parse.Object {
   constructor() {
     // Pass the ClassName to the Parse.Object constructor
@@ -80,20 +80,20 @@ class Monster extends Parse.Object {
     return monster;
   }
 }
-</code></pre>
+````
 
 However, when using `extends`, the SDK is not automatically aware of your subclass. If you want objects returned from queries to use your subclass of `Parse.Object`, you will need to register the subclass, similar to what we do on other platforms.
 
-<pre><code class="javascript">
+````javascript
 // After specifying the Monster subclass...
 Parse.Object.registerSubclass('Monster', Monster);
-</code></pre>
+````
 
 ## Saving Objects
 
 Let's say you want to save the `GameScore` described above to the Parse Cloud. The interface is similar to a `Backbone.Model`, including the `save` method:
 
-<pre><code class="javascript">
+````javascript
 var GameScore = Parse.Object.extend("GameScore");
 var gameScore = new GameScore();
 
@@ -112,14 +112,14 @@ gameScore.save(null, {
     alert('Failed to create new object, with error code: ' + error.message);
   }
 });
-</code></pre>
+````
 
 After this code runs, you will probably be wondering if anything really happened. To make sure the data was saved, you can look at the Data Browser in your app on Parse. You should see something like this:
 
-<pre><code class="json">
+````json
 objectId: "xWMyZ4YEGZ", score: 1337, playerName: "Sean Plott", cheatMode: false,
 createdAt:"2011-06-10T18:33:42Z", updatedAt:"2011-06-10T18:33:42Z"
-</code></pre>
+````
 
 There are two things to note here. You didn't have to configure or set up a new Class called `GameScore` before running this code. Your Parse app lazily creates this Class for you when it first encounters it.
 
@@ -127,7 +127,7 @@ There are also a few fields you don't need to specify that are provided as a con
 
 If you prefer, you can set attributes directly in your call to `save` instead.
 
-<pre><code class="javascript">
+````javascript
 var GameScore = Parse.Object.extend("GameScore");
 var gameScore = new GameScore();
 
@@ -144,13 +144,13 @@ gameScore.save({
     // error is a Parse.Error with an error code and message.
   }
 });
-</code></pre>
+````
 
 ## Retrieving Objects
 
 Saving data to the cloud is fun, but it's even more fun to get that data out again. If you have the `objectId`, you can retrieve the whole `Parse.Object` using a `Parse.Query`:
 
-<pre><code class="javascript">
+````javascript
 var GameScore = Parse.Object.extend("GameScore");
 var query = new Parse.Query(GameScore);
 query.get("xWMyZ4YEGZ", {
@@ -162,28 +162,28 @@ query.get("xWMyZ4YEGZ", {
     // error is a Parse.Error with an error code and message.
   }
 });
-</code></pre>
+````
 
 To get the values out of the `Parse.Object`, use the `get` method.
 
-<pre><code class="javascript">
+````javascript
 var score = gameScore.get("score");
 var playerName = gameScore.get("playerName");
 var cheatMode = gameScore.get("cheatMode");
-</code></pre>
+````
 
 The three special reserved values are provided as properties and cannot be retrieved using the 'get' method nor modified with the 'set' method:
 
-<pre><code class="javascript">
+````javascript
 var objectId = gameScore.id;
 var updatedAt = gameScore.updatedAt;
 var createdAt = gameScore.createdAt;
-</code></pre>
+````
 
 If you need to refresh an object you already have with the latest data that
     is in the Parse Cloud, you can call the `fetch` method like so:
 
-<pre><code class="javascript">
+````javascript
 myObject.fetch({
   success: function(myObject) {
     // The object was refreshed successfully.
@@ -193,13 +193,13 @@ myObject.fetch({
     // error is a Parse.Error with an error code and message.
   }
 });
-</code></pre>
+````
 
 ## Updating Objects
 
 Updating an object is simple. Just set some new data on it and call the save method. For example:
 
-<pre><code class="javascript">
+````javascript
 // Create the object.
 var GameScore = Parse.Object.extend("GameScore");
 var gameScore = new GameScore();
@@ -218,7 +218,7 @@ gameScore.save(null, {
     gameScore.save();
   }
 });
-</code></pre>
+````
 
 Parse automatically figures out which data has changed so only "dirty" fields will be sent to the Parse Cloud. You don't need to worry about squashing data that you didn't intend to update.
 
@@ -228,10 +228,10 @@ The above example contains a common use case. The "score" field is a counter tha
 
 To help with storing counter-type data, Parse provides methods that atomically increment (or decrement) any number field. So, the same update can be rewritten as:
 
-<pre><code class="javascript">
+````javascript
 gameScore.increment("score");
 gameScore.save();
-</code></pre>
+````
 
 You can also increment by any amount by passing in a second argument to `increment`. When no amount is specified, 1 is used by default.
 
@@ -245,11 +245,11 @@ To help with storing array data, there are three operations that can be used to 
 
 For example, we can add items to the set-like "skills" field like so:
 
-<pre><code class="javascript">
+````javascript
 gameScore.addUnique("skills", "flying");
 gameScore.addUnique("skills", "kungfu");
 gameScore.save();
-</code></pre>
+````
 
 Note that it is not currently possible to atomically add and remove items from an array in the same save. You will have to call `save` in between every different kind of array operation.
 
@@ -257,7 +257,7 @@ Note that it is not currently possible to atomically add and remove items from a
 
 To delete an object from the cloud:
 
-<pre><code class="javascript">
+````javascript
 myObject.destroy({
   success: function(myObject) {
     // The object was deleted from the Parse Cloud.
@@ -267,18 +267,18 @@ myObject.destroy({
     // error is a Parse.Error with an error code and message.
   }
 });
-</code></pre>
+````
 
 You can delete a single field from an object with the `unset` method:
 
-<pre><code class="javascript">
+````javascript
 // After this, the playerName field will be empty
 myObject.unset("playerName");
 
 // Saves the field deletion to the Parse Cloud.
 // If the object's field is an array, call save() after every unset() operation.
 myObject.save();
-</code></pre>
+````
 
 Please note that use of object.set(null) to remove a field from an object is not recommended and will result in unexpected functionality.
 
@@ -292,7 +292,7 @@ One-to-one and one-to-many relationships are modeled by saving a `Parse.Object` 
 
 To create a new `Post` with a single `Comment`, you could write:
 
-<pre><code class="javascript">
+````javascript
 // Declare the types.
 var Post = Parse.Object.extend("Post");
 var Comment = Parse.Object.extend("Comment");
@@ -311,74 +311,74 @@ myComment.set("parent", myPost);
 
 // This will save both myPost and myComment
 myComment.save();
-</code></pre>
+````
 
 Internally, the Parse framework will store the referred-to object in just one place, to maintain consistency. You can also link objects using just their `objectId`s like so:
 
-<pre><code class="javascript">
+````javascript
 var post = new Post();
 post.id = "1zEcyElZ80";
 
 myComment.set("parent", post);
-</code></pre>
+````
 
 By default, when fetching an object, related `Parse.Object`s are not fetched.  These objects' values cannot be retrieved until they have been fetched like so:
 
-<pre><code class="javascript">
+````javascript
 var post = fetchedComment.get("parent");
 post.fetch({
   success: function(post) {
     var title = post.get("title");
   }
 });
-</code></pre>
+````
 
 ### Many-to-Many Relationships
 
 Many-to-many relationships are modeled using `Parse.Relation`. This works similar to storing an array of `Parse.Object`s in a key, except that you don't need to fetch all of the objects in a relation at once.  In addition, this allows `Parse.Relation` to scale to many more objects than the array of `Parse.Object` approach.  For example, a `User` may have many `Posts` that she might like. In this case, you can store the set of `Posts` that a `User` likes using `relation`.  In order to add a `Post` to the "likes" list of the `User`, you can do:
 
-<pre><code class="javascript">
+````javascript
 var user = Parse.User.current();
 var relation = user.relation("likes");
 relation.add(post);
 user.save();
-</code></pre>
+````
 
 You can remove a post from a `Parse.Relation`:
 
-<pre><code class="javascript">
+````javascript
 relation.remove(post);
 user.save();
-</code></pre>
+````
 
 You can call `add` and `remove` multiple times before calling save:
 
-<pre><code class="javascript">
+````javascript
 relation.remove(post1);
 relation.remove(post2);
 user.save();
-</code></pre>
+````
 
 You can also pass in an array of `Parse.Object` to `add` and `remove`:
 
-<pre><code class="javascript">
+````javascript
 relation.add([post1, post2, post3]);
 user.save();
-</code></pre>
+````
 
 By default, the list of objects in this relation are not downloaded.  You can get a list of the posts that a user likes by using the `Parse.Query` returned by `query`.  The code looks like:
 
-<pre><code class="javascript">
+````javascript
 relation.query().find({
   success: function(list) {
     // list contains the posts that the current user likes.
   }
 });
-</code></pre>
+````
 
 If you want only a subset of the Posts, you can add extra constraints to the `Parse.Query` returned by query like this:
 
-<pre><code class="javascript">
+````javascript
 var query = relation.query();
 query.equalTo("title", "I'm Hungry");
 query.find({
@@ -386,7 +386,7 @@ query.find({
     // list contains post liked by the current user which have the title "I'm Hungry".
   }
 });
-</code></pre>
+````
 
 For more details on `Parse.Query`, please look at the query portion of this guide. A `Parse.Relation` behaves similar to an array of `Parse.Object` for querying purposes, so any query you can do on an array of objects, you can do on a `Parse.Relation`.
 
@@ -407,7 +407,7 @@ So far we've used values with type `String`, `Number`, and `Parse.Object`. Parse
 
 Some examples:
 
-<pre><code class="javascript">
+````javascript
 var number = 42;
 var bool = false;
 var string = "the number is " + number;
@@ -427,7 +427,7 @@ bigObject.set("myObject", object);
 bigObject.set("anyKey", null); // this value can only be saved to an existing key
 bigObject.set("myPointerKey", pointer); // shows up as Pointer <MyClassName> in the Data Browser
 bigObject.save();
-</code></pre>
+````
 
 We do not recommend storing large pieces of binary data like images or documents on `Parse.Object`. `Parse.Object`s should not exceed 128 kilobytes in size. We recommend you use `Parse.File`s to store images, documents, and other types of files. You can do so by instantiating a `Parse.File` object and setting it on a field. See [Files](#files) for more details.
 

--- a/_includes/js/promises.md
+++ b/_includes/js/promises.md
@@ -6,7 +6,7 @@ In addition to callbacks, every asynchronous method in the Parse JavaScript SDK 
 
 Promises represent the next great paradigm in JavaScript programming. But understanding why they are so great is no simple matter. At its core, a `Promise` represents the result of a task, which may or may not have completed. The only interface requirement of a `Promise` is having a function called `then`, which can be given callbacks to be called when the promise is fulfilled or has failed. This is outlined in the [CommonJS Promises/A proposal](http://wiki.commonjs.org/wiki/Promises/A). For example, consider saving a `Parse.Object`, which is an asynchronous operation. In the old callback paradigm, your code would look like this:
 
-<pre><code class="javascript">
+````javascript
 object.save({ key: value }, {
   success: function(object) {
     // the object was saved.
@@ -15,11 +15,11 @@ object.save({ key: value }, {
     // saving the object failed.
   }
 });
-</code></pre>
+````
 
 In the new Promise paradigm, that same code would look like this:
 
-<pre><code class="javascript">
+````javascript
 object.save({ key: value }).then(
   function(object) {
     // the object was saved.
@@ -27,13 +27,13 @@ object.save({ key: value }).then(
   function(error) {
     // saving the object failed.
   });
-</code></pre>
+````
 
 Not much different, right? So what’s the big deal? Well, the real power of promises comes from chaining multiple of them together. Calling `promise.then(func)` returns a new promise, which is not fulfilled until `func` has completed. But there’s one really special thing about the way `func` is used. If a **callback supplied to `then` returns a new promise, then the promise returned by `then` will not be fulfilled until the promise returned by the callback is fulfilled**. The details of the behavior are explained in the [Promises/A+](https://github.com/promises-aplus/promises-spec) proposal. This is a complex topic, but maybe an example would make it clearer.
 
 Imagine you’re writing code to log in, find an object, and then update it. In the old callback paradigm, you’d end up with what we call pyramid code:
 
-<pre><code class="javascript">
+````javascript
 Parse.User.logIn("user", "pass", {
   success: function(user) {
     query.find({
@@ -47,11 +47,11 @@ Parse.User.logIn("user", "pass", {
     });
   }
 });
-</code></pre>
+````
 
 That’s getting pretty ridiculous, and that’s without any error handling code even. But because of the way promise chaining works, the code can now be much flatter:
 
-<pre><code class="javascript">
+````javascript
 Parse.User.logIn("user", "pass").then(function(user) {
   return query.find();
 }).then(function(results) {
@@ -59,7 +59,7 @@ Parse.User.logIn("user", "pass").then(function(user) {
 }).then(function(result) {
   // the object was saved.
 });
-</code></pre>
+````
 
 Ah! Much better!
 
@@ -67,18 +67,18 @@ Ah! Much better!
 
 Every `Promise` has a method named `then` which takes a pair of callbacks. The first callback is called if the promise is _resolved_, while the second is called if the promise is _rejected_.
 
-<pre><code class="javascript">
+````javascript
 obj.save().then(function(obj) {
   // the object was saved successfully.
 }, function(error) {
   // the save failed.
 });
-</code></pre>
+````
 
 ## Chaining Promises Together
 Promises are a little bit magical, in that they let you chain them without nesting. If a callback for a promise returns a new promise, then the first one will not be resolved until the second one is. This lets you perform multiple actions without incurring the pyramid code you would get with callbacks.
 
-<pre><code class="javascript">
+````javascript
 var query = new Parse.Query("Student");
 query.descending("gpa");
 query.find().then(function(students) {
@@ -96,13 +96,13 @@ query.find().then(function(students) {
   // Everything is done!
 
 });
-</code></pre>
+````
 
 ## Error Handling
 
 The code samples above left out error handling for simplicity, but adding it back reiterates what a mess the old callback code could be:
 
-<pre><code class="javascript">
+````javascript
 Parse.User.logIn("user", "pass", {
   success: function(user) {
     query.find({
@@ -125,11 +125,11 @@ Parse.User.logIn("user", "pass", {
     // An error occurred.
   }
 });
-</code></pre>
+````
 
 Because promises know whether they’ve been fulfilled or failed, they can propagate errors, not calling any callback until an error handler is encountered. For example, the code above could be written simply as:
 
-<pre><code class="javascript">
+````javascript
 Parse.User.logIn("user", "pass").then(function(user) {
   return query.find();
 }).then(function(results) {
@@ -139,11 +139,11 @@ Parse.User.logIn("user", "pass").then(function(user) {
 }, function(error) {
   // there was some error.
 });
-</code></pre>
+````
 
 Generally, developers consider a failing promise to be the asynchronous equivalent to throwing an exception. In fact, if a callback passed to `then` throws an error, the promise returned will fail with that error. If any Promise in a chain returns an error, all of the success callbacks after it will be skipped until an error callback is encountered. The error callback can transform the error, or it can handle it by returning a new Promise that isn't rejected. You can think of rejected promises kind of like throwing an exception. An error callback is like a catch block that can handle the error or rethrow it.
 
-<pre><code class="javascript">
+````javascript
 var query = new Parse.Query("Student");
 query.descending("gpa");
 query.find().then(function(students) {
@@ -169,7 +169,7 @@ query.find().then(function(students) {
 }, function(error) {
   // This isn't called because the error was already handled.
 });
-</code></pre>
+````
 
 It's often convenient to have a long chain of success callbacks with only one error handler at the end.
 
@@ -177,27 +177,27 @@ It's often convenient to have a long chain of success callbacks with only one er
 
 When you're getting started, you can just use the promises returned from methods like `find` or `save`. However, for more advanced scenarios, you may want to make your own promises. After you create a `Promise`, you'll need to call `resolve` or `reject` to trigger its callbacks.
 
-<pre><code class="javascript">
+````javascript
 var successful = new Parse.Promise();
 successful.resolve("The good result.");
 
 var failed = new Parse.Promise();
 failed.reject("An error message.");
-</code></pre>
+````
 
 If you know the result of a promise at the time it is created, there are some convenience methods you can use.
 
-<pre><code class="javascript">
+````javascript
 var successful = Parse.Promise.as("The good result.");
 
 var failed = Parse.Promise.error("An error message.");
-</code></pre>
+````
 
 ## Promises in Series
 
 Promises are convenient when you want to do a series of tasks in a row, each one waiting for the previous to finish. For example, imagine you want to delete all of the comments on your blog.
 
-<pre><code class="javascript">
+````javascript
 var query = new Parse.Query("Comments");
 query.equalTo("post", 123);
 
@@ -216,12 +216,12 @@ query.find().then(function(results) {
 }).then(function() {
   // Every comment was deleted.
 });
-</code></pre>
+````
 
 ## Promises in Parallel
 You can also use promises to perform several tasks in parallel, using the `when` method. You can start multiple operations at once, and use `Parse.Promise.when` to create a new promise that will be resolved when all of its input promises is resolved. The new promise will be successful if none of the passed-in promises fail; otherwise, it will fail with the last error. Performing operations in parallel will be faster than doing them serially, but may consume more system resources and bandwidth.
 
-<pre><code class="javascript">
+````javascript
 var query = new Parse.Query("Comments");
 query.equalTo("post", 123);
 
@@ -238,12 +238,12 @@ query.find().then(function(results) {
 }).then(function() {
   // Every comment was deleted.
 });
-</code></pre>
+````
 
 ## Creating Async Methods
 With these tools, it's easy to make your own asynchronous functions that return promises. For example, you can make a promisified version of `setTimeout`.
 
-<pre><code class="javascript">
+````javascript
 var delay = function(millis) {
   var promise = new Parse.Promise();
   setTimeout(function() {
@@ -255,4 +255,4 @@ var delay = function(millis) {
 delay(100).then(function() {
   // This ran after 100ms!
 });
-</code></pre>
+````

--- a/_includes/js/push-notifications.md
+++ b/_includes/js/push-notifications.md
@@ -61,7 +61,7 @@ The JavaScript SDK does not currently support subscribing iOS and Android device
 
 With the JavaScript SDK, the following code can be used to alert all subscribers of the "Giants" and "Mets" channels about the results of the game. This will display a notification center alert to iOS users and a system tray notification to Android users.
 
-<pre><code class="javascript">
+````javascript
 Parse.Push.send({
   channels: [ "Giants", "Mets" ],
   data: {
@@ -75,7 +75,7 @@ Parse.Push.send({
     // Handle error
   }
 });
-</code></pre>
+````
 
 
 ### Using Advanced Targeting
@@ -92,7 +92,7 @@ The JavaScript SDK does not currently support modifying `Installation` objects. 
 
 Once you have your data stored on your `Installation` objects, you can use a query to target a subset of these devices. `Parse.Installation` queries work just like any other [Parse query](#queries).
 
-<pre><code class="javascript">
+````javascript
 var query = new Parse.Query(Parse.Installation);
 query.equalTo('injuryReports', true);
 
@@ -109,11 +109,11 @@ Parse.Push.send({
     // Handle error
   }
 });
-</code></pre>
+````
 
 We can even use channels with our query. To send a push to all subscribers of the "Giants" channel but filtered by those who want score update, we can do the following:
 
-<pre><code class="javascript">
+````javascript
 var query = new Parse.Query(Parse.Installation);
 query.equalTo('channels', 'Giants'); // Set our channel
 query.equalTo('scores', true);
@@ -131,11 +131,11 @@ Parse.Push.send({
     // Handle error
   }
 });
-</code></pre>
+````
 
 If we store relationships to other objects in our `Installation` class, we can also use those in our query. For example, we could send a push notification to all users near a given location like this.
 
- <pre><code class="javascript">
+ ````javascript
 // Find users near a given location
 var userQuery = new Parse.Query(Parse.User);
 userQuery.withinMiles("location", stadiumLocation, 1.0);
@@ -158,7 +158,7 @@ Parse.Push.send({
     // Handle error
   }
 });
-</code></pre>
+````
 
 ## Sending Options
 
@@ -178,7 +178,7 @@ If you want to send more than just a message, you can set other fields in the `d
 
 For example, to send a notification that increases the current badge number by 1 and plays a custom sound for iOS devices, and displays a particular title for Android users, you can do the following:
 
-<pre><code class="javascript">
+````javascript
 Parse.Push.send({
   channels: [ "Mets" ],
   data: {
@@ -195,11 +195,11 @@ Parse.Push.send({
     // Handle error
   }
 });
-</code></pre>
+````
 
 It is also possible to specify your own data in this dictionary. As explained in the Receiving Notifications section for [iOS](/docs/ios/guide#push-notifications-scheduling-pushes) and [Android](/docs/android/guide#push-notifications-scheduling-pushes), iOS will give you access to this data only when the user opens your app via the notification and Android will provide you this data in the `Intent` if one is specified.
 
-<pre><code class="javascript">
+````javascript
 var query = new Parse.Query(Parse.Installation);
 query.equalTo('channels', 'Indians');
 query.equalTo('injuryReports', true);
@@ -220,7 +220,7 @@ Parse.Push.send({
     // Handle error
   }
 });
-</code></pre>
+````
 
 ### Setting an Expiration Date
 
@@ -228,7 +228,7 @@ When a user's device is turned off or not connected to the internet, push notifi
 
 There are two parameters provided by Parse to allow setting an expiration date for your notification. The first is `expiration_time` which takes a `Date` specifying when Parse should stop trying to send the notification. To expire the notification exactly 1 week from now, you can use the following:
 
-<pre><code class="javascript">
+````javascript
 var oneWeekAway = new Date(...);
 
 Parse.Push.send({
@@ -245,11 +245,11 @@ Parse.Push.send({
     // Handle error
   }
 });
-</code></pre>
+````
 
 Alternatively, you can use the `expiration_interval` parameter to specify a duration of time before your notification expires. This value is relative to the `push_time` parameter used to [schedule notifications](#push-notifications-scheduling-pushes). This means that a push notification scheduled to be sent out in 1 day and an expiration interval of 6 days can be received up to a week from now.
 
-<pre><code class="javascript">
+````javascript
 var oneDayAway = new Date(...);
 var sixDaysAwayEpoch = (new Date(...)).getTime();
 
@@ -267,7 +267,7 @@ Parse.Push.send({
     // Handle error
   }
 });
-</code></pre>
+````
 
 ### Targeting by Platform
 
@@ -275,7 +275,7 @@ If you build a cross platform app, it is possible you may only want to target iO
 
 The following examples would send a different notification to Android and iOS users.
 
-<pre><code class="javascript">
+````javascript
 // Notification for Android users
 var queryAndroid = new Parse.Query(Parse.Installation);
 queryAndroid.equalTo('deviceType', 'android');
@@ -319,13 +319,13 @@ Parse.Push.send({
     alert: "Your suitcase is very hip; very metro."
   }
 });
-</code></pre>
+````
 
 ## Scheduling Pushes
 
 You can schedule a push in advance by specifying a `push_time`. For example, if a user schedules a game reminder for a game tomorrow at noon UTC, you can schedule the push notification by sending:
 
-<pre><code class="javascript">
+````javascript
 var tomorrowDate = new Date(...);
 
 var query = new Parse.Query(Parse.Installation);
@@ -345,7 +345,7 @@ Parse.Push.send({
     // Handle error
   }
 });
-</code></pre>
+````
 
 If you also specify an `expiration_interval`, it will be calculated from the scheduled push time, not from the time the push is submitted. This means a push scheduled to be sent in a week with an expiration interval of a day will expire 8 days after the request is sent.
 

--- a/_includes/js/queries.md
+++ b/_includes/js/queries.md
@@ -8,7 +8,7 @@ In many cases, `get` isn't powerful enough to specify which objects you want to 
 
 The general pattern is to create a `Parse.Query`, put conditions on it, and then retrieve an `Array` of matching `Parse.Object`s using `find`. For example, to retrieve the scores that have a particular `playerName`, use the `equalTo` method to constrain the value for a key.
 
-<pre><code class="javascript">
+````javascript
 var GameScore = Parse.Object.extend("GameScore");
 var query = new Parse.Query(GameScore);
 query.equalTo("playerName", "Dan Stemkoski");
@@ -25,32 +25,32 @@ query.find({
     alert("Error: " + error.code + " " + error.message);
   }
 });
-</code></pre>
+````
 
 ## Query Constraints
 
 There are several ways to put constraints on the objects found by a `Parse.Query`. You can filter out objects with a particular key-value pair with `notEqualTo`:
 
-<pre><code class="javascript">
+````javascript
 query.notEqualTo("playerName", "Michael Yabuti");
-</code></pre>
+````
 
 You can give multiple constraints, and objects will only be in the results if they match all of the constraints.  In other words, it's like an AND of constraints.
 
-<pre><code class="javascript">
+````javascript
 query.notEqualTo("playerName", "Michael Yabuti");
 query.greaterThan("playerAge", 18);
-</code></pre>
+````
 
 You can limit the number of results by setting `limit`. By default, results are limited to 100, but anything from 1 to 1000 is a valid limit:
 
-<pre><code class="javascript">
+````javascript
 query.limit(10); // limit to at most 10 results
-</code></pre>
+````
 
 If you want exactly one result, a more convenient alternative may be to use `first` instead of using `find`.
 
-<pre><code class="javascript">
+````javascript
 var GameScore = Parse.Object.extend("GameScore");
 var query = new Parse.Query(GameScore);
 query.equalTo("playerEmail", "dstemkoski@example.com");
@@ -62,27 +62,27 @@ query.first({
     alert("Error: " + error.code + " " + error.message);
   }
 });
-</code></pre>
+````
 
 You can skip the first results by setting `skip`. This can be useful for pagination:
 
-<pre><code class="javascript">
+````javascript
 query.skip(10); // skip the first 10 results
-</code></pre>
+````
 
 For sortable types like numbers and strings, you can control the order in which results are returned:
 
-<pre><code class="javascript">
+````javascript
 // Sorts the results in ascending order by the score field
 query.ascending("score");
 
 // Sorts the results in descending order by the score field
 query.descending("score");
-</code></pre>
+````
 
 For sortable types, you can also use comparisons in queries:
 
-<pre><code class="javascript">
+````javascript
 // Restricts to wins < 50
 query.lessThan("wins", 50);
 
@@ -94,37 +94,37 @@ query.greaterThan("wins", 50);
 
 // Restricts to wins >= 50
 query.greaterThanOrEqualTo("wins", 50);
-</code></pre>
+````
 
 If you want to retrieve objects matching any of the values in a list of values, you can use `containedIn`, providing an array of acceptable values. This is often useful to replace multiple queries with a single query. For example, if you want to retrieve scores made by any player in a particular list:
 
-<pre><code class="javascript">
+````javascript
 // Finds scores from any of Jonathan, Dario, or Shawn
 query.containedIn("playerName",
                   ["Jonathan Walsh", "Dario Wunsch", "Shawn Simon"]);
-</code></pre>
+````
 
 If you want to retrieve objects that do not match any of  several values you can use `notContainedIn`, providing an array of acceptable values.  For example if you want to retrieve scores from players besides those in a list:
 
-<pre><code class="javascript">
+````javascript
 // Finds scores from anyone who is neither Jonathan, Dario, nor Shawn
 query.notContainedIn("playerName",
                      ["Jonathan Walsh", "Dario Wunsch", "Shawn Simon"]);
-</code></pre>
+````
 
 If you want to retrieve objects that have a particular key set, you can use `exists`. Conversely, if you want to retrieve objects without a particular key set, you can use `doesNotExist`.
 
-<pre><code class="javascript">
+````javascript
 // Finds objects that have the score set
 query.exists("score");
 
 // Finds objects that don't have the score set
 query.doesNotExist("score");
-</code></pre>
+````
 
 You can use the `matchesKeyInQuery` method to get objects where a key matches the value of a key in a set of objects resulting from another query.  For example, if you have a class containing sports teams and you store a user's hometown in the user class, you can issue one query to find the list of users whose hometown teams have winning records.  The query would look like:
 
-<pre><code class="javascript">
+````javascript
 var Team = Parse.Object.extend("Team");
 var teamQuery = new Parse.Query(Team);
 teamQuery.greaterThan("winPct", 0.5);
@@ -135,11 +135,11 @@ userQuery.find({
     // results has the list of users with a hometown team with a winning record
   }
 });
-</code></pre>
+````
 
 Conversely, to get objects where a key does not match the value of a key in a set of objects resulting from another query, use `doesNotMatchKeyInQuery`. For example, to find users whose hometown teams have losing records:
 
-<pre><code class="javascript">
+````javascript
 var losingUserQuery = new Parse.Query(Parse.User);
 losingUserQuery.doesNotMatchKeyInQuery("hometown", "city", teamQuery);
 losingUserQuery.find({
@@ -147,45 +147,45 @@ losingUserQuery.find({
     // results has the list of users with a hometown team with a losing record
   }
 });
-</code></pre>
+````
 
 You can restrict the fields returned by calling `select` with a list of keys. To retrieve documents that contain only the `score` and `playerName` fields (and also special built-in fields such as `objectId`, `createdAt`, and `updatedAt`):
 
-<pre><code class="javascript">
+````javascript
 var GameScore = Parse.Object.extend("GameScore");
 var query = new Parse.Query(GameScore);
 query.select("score", "playerName");
 query.find().then(function(results) {
   // each of results will only have the selected fields available.
 });
-</code></pre>
+````
 
 The remaining fields can be fetched later by calling `fetch` on the returned objects:
 
-<pre><code class="javascript">
+````javascript
 query.first().then(function(result) {
   // only the selected fields of the object will now be available here.
   return result.fetch();
 }).then(function(result) {
   // all fields of the object will now be available here.
 });
-</code></pre>
+````
 
 ## Queries on Array Values
 
 For keys with an array type, you can find objects where the key's array value contains 2 by:
 
-<pre><code class="javascript">
+````javascript
 // Find objects where the array in arrayKey contains 2.
 query.equalTo("arrayKey", 2);
-</code></pre>
+````
 
 You can also find objects where the key's array value contains each of the elements 2, 3, and 4 with the following:
 
-<pre><code class="javascript">
+````javascript
 // Find objects where the array in arrayKey contains all of the elements 2, 3, and 4.
 query.containsAll("arrayKey", [2, 3, 4]);
-</code></pre>
+````
 
 ## Queries on String Values
 
@@ -195,11 +195,11 @@ query.containsAll("arrayKey", [2, 3, 4]);
 
 Use `startsWith` to restrict to string values that start with a particular string. Similar to a MySQL LIKE operator, this is indexed so it is efficient for large datasets:
 
-<pre><code class="javascript">
+````javascript
 // Finds barbecue sauces that start with "Big Daddy's".
 var query = new Parse.Query(BarbecueSauce);
 query.startsWith("name", "Big Daddy's");
-</code></pre>
+````
 
 The above example will match any `BarbecueSauce` objects where the value in the "name" String key starts with "Big Daddy's". For example, both "Big Daddy's" and "Big Daddy's BBQ" will match, but "big daddy's" or "BBQ Sauce: Big Daddy's" will not.
 
@@ -210,7 +210,7 @@ Queries that have regular expression constraints are very expensive, especially 
 
 There are several ways to issue queries for relational data. If you want to retrieve objects where a field matches a particular `Parse.Object`, you can use `equalTo` just like for other data types. For example, if each `Comment` has a `Post` object in its `post` field, you can fetch comments for a particular `Post`:
 
-<pre><code class="javascript">
+````javascript
 // Assume Parse.Object myPost was previously created.
 var query = new Parse.Query(Comment);
 query.equalTo("post", myPost);
@@ -219,11 +219,11 @@ query.find({
     // comments now contains the comments for myPost
   }
 });
-</code></pre>
+````
 
 If you want to retrieve objects where a field contains a `Parse.Object` that matches a different query, you can use `matchesQuery`. Note that the default limit of 100 and maximum limit of 1000 apply to the inner query as well, so with large data sets you may need to construct queries carefully to get the desired behavior. In order to find comments for posts containing images, you can do:
 
-<pre><code class="javascript">
+````javascript
 var Post = Parse.Object.extend("Post");
 var Comment = Parse.Object.extend("Comment");
 var innerQuery = new Parse.Query(Post);
@@ -235,11 +235,11 @@ query.find({
     // comments now contains the comments for posts with images.
   }
 });
-</code></pre>
+````
 
 If you want to retrieve objects where a field contains a `Parse.Object` that does not match a different query, you can use `doesNotMatchQuery`.  In order to find comments for posts without images, you can do:
 
-<pre><code class="javascript">
+````javascript
 var Post = Parse.Object.extend("Post");
 var Comment = Parse.Object.extend("Comment");
 var innerQuery = new Parse.Query(Post);
@@ -251,19 +251,19 @@ query.find({
     // comments now contains the comments for posts without images.
   }
 });
-</code></pre>
+````
 
 You can also do relational queries by `objectId`:
 
-<pre><code class="javascript">
+````javascript
 var post = new Post();
 post.id = "1zEcyElZ80";
 query.equalTo("post", post);
-</code></pre>
+````
 
 In some situations, you want to return multiple types of related objects in one query. You can do this with the `include` method. For example, let's say you are retrieving the last ten comments, and you want to retrieve their related posts at the same time:
 
-<pre><code class="javascript">
+````javascript
 var query = new Parse.Query(Comment);
 
 // Retrieve the most recent ones
@@ -285,13 +285,13 @@ query.find({
     }
   }
 });
-</code></pre>
+````
 
 You can also do multi level includes using dot notation.  If you wanted to include the post for a comment and the post's author as well you can do:
 
-<pre><code class="javascript">
+````javascript
 query.include(["post.author"]);
-</code></pre>
+````
 
 You can issue a query with multiple fields included by calling `include` multiple times. This functionality also works with Parse.Query helpers like `first` and `get`.
 
@@ -301,7 +301,7 @@ Caveat: Count queries are rate limited to a maximum of 160 requests per minute. 
 
 If you just need to count how many objects match a query, but you do not need to retrieve all the objects that match, you can use `count` instead of `find`. For example, to count how many games have been played by a particular player:
 
-<pre><code class="javascript">
+````javascript
 var GameScore = Parse.Object.extend("GameScore");
 var query = new Parse.Query(GameScore);
 query.equalTo("playerName", "Sean Plott");
@@ -314,13 +314,13 @@ query.count({
     // The request failed
   }
 });
-</code></pre>
+````
 
 ## Compound Queries
 
  If you want to find objects that match one of several queries, you can use `Parse.Query.or` method to construct a query that is an OR of the queries passed in.  For instance if you want to find players who either have a lot of wins or a few wins, you can do:
 
-<pre><code class="javascript">
+````javascript
 var lotsOfWins = new Parse.Query("Player");
 lotsOfWins.greaterThan("wins", 150);
 
@@ -336,7 +336,7 @@ mainQuery.find({
     // There was an error.
   }
 });
-</code></pre>
+````
 
 You can add additional constraints to the newly created `Parse.Query` that act as an 'and' operator.
 

--- a/_includes/js/roles.md
+++ b/_includes/js/roles.md
@@ -20,22 +20,22 @@ The `Parse.Role` uses the same security scheme (ACLs) as all other objects on Pa
 
 To create a new `Parse.Role`, you would write:
 
-<pre><code class="javascript">
+````javascript
 // By specifying no write privileges for the ACL, we can ensure the role cannot be altered.
 var roleACL = new Parse.ACL();
 roleACL.setPublicReadAccess(true);
 var role = new Parse.Role("Administrator", roleACL);
 role.save();
-</code></pre>
+````
 
 You can add users and roles that should inherit your new role's permissions through the "users" and "roles" relations on `Parse.Role`:
 
-<pre><code class="javascript">
+````javascript
 var role = new Parse.Role(roleName, roleACL);
 role.getUsers().add(usersToAddToRole);
 role.getRoles().add(rolesToAddToRole);
 role.save();
-</code></pre>
+````
 
 Take great care when assigning ACLs to your roles so that they can only be modified by those who should have permissions to modify them.
 
@@ -45,24 +45,24 @@ Now that you have created a set of roles for use in your application, you can us
 
 Giving a role read or write permission to an object is straightforward.  You can either use the `Parse.Role`:
 
-<pre><code class="javascript">
+````javascript
 var moderators = /* Query for some Parse.Role */;
 var wallPost = new Parse.Object("WallPost");
 var postACL = new Parse.ACL();
 postACL.setRoleWriteAccess(moderators, true);
 wallPost.setACL(postACL);
 wallPost.save();
-</code></pre>
+````
 
 You can avoid querying for a role by specifying its name for the ACL:
 
-<pre><code class="javascript">
+````javascript
 var wallPost = new Parse.Object("WallPost");
 var postACL = new Parse.ACL();
 postACL.setRoleWriteAccess("Moderators", true);
 wallPost.setACL(postACL);
 wallPost.save();
-</code></pre>
+````
 
 ## Role Hierarchy
 
@@ -70,9 +70,9 @@ As described above, one role can contain another, establishing a parent-child re
 
 These types of relationships are commonly found in applications with user-managed content, such as forums. Some small subset of users are "Administrators", with the highest level of access to tweaking the application's settings, creating new forums, setting global messages, and so on. Another set of users are "Moderators", who are responsible for ensuring that the content created by users remains appropriate. Any user with Administrator privileges should also be granted the permissions of any Moderator. To establish this relationship, you would make your "Administrators" role a child role of "Moderators", like this:
 
-<pre><code class="javascript">
+````javascript
 var administrators = /* Your "Administrators" role */;
 var moderators = /* Your "Moderators" role */;
 moderators.getRoles().add(administrators);
 moderators.save();
-</code></pre>
+````

--- a/_includes/js/users.md
+++ b/_includes/js/users.md
@@ -20,7 +20,7 @@ We'll go through each of these in detail as we run through the various use cases
 
 The first thing your app will do is probably ask the user to sign up. The following code illustrates a typical sign up:
 
-<pre><code class="javascript">
+````javascript
 var user = new Parse.User();
 user.set("username", "my name");
 user.set("password", "my pass");
@@ -38,7 +38,7 @@ user.signUp(null, {
     alert("Error: " + error.code + " " + error.message);
   }
 });
-</code></pre>
+````
 
 This call will asynchronously create a new user in your Parse App. Before it does this, it also checks to make sure that both the username and email are unique. Also, it securely hashes the password in the cloud using bcrypt. We never store passwords in plaintext, nor will we ever transmit passwords back to the client in plaintext.
 
@@ -52,7 +52,7 @@ You are free to use an email address as the username. Simply ask your users to e
 
 Of course, after you allow users to sign up, you need to let them log in to their account in the future. To do this, you can use the class method `logIn`.
 
-<pre><code class="javascript">
+````javascript
 Parse.User.logIn("myname", "mypass", {
   success: function(user) {
     // Do stuff after successful login.
@@ -61,7 +61,7 @@ Parse.User.logIn("myname", "mypass", {
     // The login failed. Check error to see why.
   }
 });
-</code></pre>
+````
 
 ## Verifying Emails
 
@@ -79,34 +79,34 @@ It would be bothersome if the user had to log in every time they open your app. 
 
 Whenever you use any signup or login methods, the user is cached in localStorage. You can treat this cache as a session, and automatically assume the user is logged in:
 
-<pre><code class="javascript">
+````javascript
 var currentUser = Parse.User.current();
 if (currentUser) {
     // do stuff with the user
 } else {
     // show the signup or login page
 }
-</code></pre>
+````
 
 You can clear the current user by logging them out:
 
-<pre><code class="javascript">
+````javascript
 Parse.User.logOut().then(() => {
   var currentUser = Parse.User.current();  // this will now be null
 });
-</code></pre>
+````
 
 ## Setting the Current User
 
 If you’ve created your own authentication routines, or otherwise logged in a user on the server side, you can now pass the session token to the client and use the `become` method. This method will ensure the session token is valid before setting the current user.
 
-<pre><code class="javascript">
+````javascript
 Parse.User.become("session-token-here").then(function (user) {
   // The current user is now set to user.
 }, function (error) {
   // The token could not be validated.
 });
-</code></pre>
+````
 
 ## Security For User Objects
 
@@ -116,7 +116,7 @@ Specifically, you are not able to invoke any of the `save` or `delete` methods u
 
 The following illustrates this security policy:
 
-<pre><code class="javascript">
+````javascript
 var user = Parse.User.logIn("my_username", "my_password", {
   success: function(user) {
     user.set("username", "my_new_username");  // attempt to change username
@@ -141,7 +141,7 @@ var user = Parse.User.logIn("my_username", "my_password", {
   }
 });
 
-</code></pre>
+````
 
 The `Parse.User` obtained from `Parse.User.current()` will always be authenticated.
 
@@ -153,19 +153,19 @@ The same security model that applies to the `Parse.User` can be applied to other
 
 The simplest way to use a `Parse.ACL` is to specify that an object may only be read or written by a single user. This is done by initializing a Parse.ACL with a `Parse.User`: `new Parse.ACL(user)` generates a `Parse.ACL` that limits access to that user. An object's ACL is updated when the object is saved, like any other property. Thus, to create a private note that can only be accessed by the current user:
 
-<pre><code class="javascript">
+````javascript
 var Note = Parse.Object.extend("Note");
 var privateNote = new Note();
 privateNote.set("content", "This note is private!");
 privateNote.setACL(new Parse.ACL(Parse.User.current()));
 privateNote.save();
-</code></pre>
+````
 
 This note will then only be accessible to the current user, although it will be accessible to any device where that user is signed in. This functionality is useful for applications where you want to enable access to user data across multiple devices, like a personal todo list.
 
 Permissions can also be granted on a per-user basis. You can add permissions individually to a `Parse.ACL` using `setReadAccess` and `setWriteAccess`. For example, let's say you have a message that will be sent to a group of several users, where each of them have the rights to read and delete that message:
 
-<pre><code class="javascript">
+````javascript
 var Message = Parse.Object.extend("Message");
 var groupMessage = new Message();
 var groupACL = new Parse.ACL();
@@ -178,17 +178,17 @@ for (var i = 0; i < userList.length; i++) {
 
 groupMessage.setACL(groupACL);
 groupMessage.save();
-</code></pre>
+````
 
 You can also grant permissions to all users at once using `setPublicReadAccess` and `setPublicWriteAccess`. This allows patterns like posting comments on a message board. For example, to create a post that can only be edited by its author, but can be read by anyone:
 
-<pre><code class="javascript">
+````javascript
 var publicPost = new Post();
 var postACL = new Parse.ACL(Parse.User.current());
 postACL.setPublicReadAccess(true);
 publicPost.setACL(postACL);
 publicPost.save();
-</code></pre>
+````
 
 Operations that are forbidden, such as deleting an object that you do not have write access to, result in a `Parse.Error.OBJECT_NOT_FOUND` error code. For security purposes, this prevents clients from distinguishing which object ids exist but are secured, versus which object ids do not exist at all.
 
@@ -198,7 +198,7 @@ It's a fact that as soon as you introduce passwords into a system, users will fo
 
 To kick off the password reset flow, ask the user for their email address, and call:
 
-<pre><code class="javascript">
+````javascript
 Parse.User.requestPasswordReset("email@example.com", {
   success: function() {
   // Password reset request was sent successfully
@@ -208,7 +208,7 @@ Parse.User.requestPasswordReset("email@example.com", {
     alert("Error: " + error.code + " " + error.message);
   }
 });
-</code></pre>
+````
 
 This will attempt to match the given email with the user's email or username field, and will send them a password reset email. By doing this, you can opt to have users use their email as their username, or you can collect it separately and store it in the email field.
 
@@ -225,7 +225,7 @@ Note that the messaging in this flow will reference your app by the name that yo
 
 To query for users, you can simple create a new `Parse.Query` for `Parse.User`s:
 
-<pre><code class="javascript">
+````javascript
 var query = new Parse.Query(Parse.User);
 query.equalTo("gender", "female");  // find all the women
 query.find({
@@ -233,13 +233,13 @@ query.find({
     // Do stuff
   }
 });
-</code></pre>
+````
 
 ## Associations
 
 Associations involving a `Parse.User` work right of the box. For example, let's say you're making a blogging app. To store a new post for a user and retrieve all their posts:
 
-<pre><code class="javascript">
+````javascript
 var user = Parse.User.current();
 
 // Make a new post
@@ -260,7 +260,7 @@ post.save(null, {
     });
   }
 });
-</code></pre>
+````
 
 ## Facebook Users
 
@@ -278,7 +278,7 @@ To start using Facebook with Parse, you need to:
 3.  Follow [these instructions](https://developers.facebook.com/docs/javascript/quickstart/) for loading the Facebook JavaScript SDK into your application.
 4.  Replace your call to `FB.init()` with a call to `Parse.FacebookUtils.init()`. For example, if you load the Facebook JavaScript SDK asynchronously, your `fbAsyncInit` function will look like this:
 
-<pre><code class="javascript">
+````javascript
 <script>
   // Initialize Parse
   Parse.initialize("$PARSE_APPLICATION_ID", "$PARSE_JAVASCRIPT_KEY");
@@ -303,7 +303,7 @@ To start using Facebook with Parse, you need to:
     fjs.parentNode.insertBefore(js, fjs);
   }(document, 'script', 'facebook-jssdk'));
 </script>
-</code></pre>
+````
 
 The function assigned to `fbAsyncInit` is run as soon as the Facebook JavaScript SDK has completed loading. Any code that you want to run after the Facebook JavaScript SDK is loaded should be placed within this function and after the call to `Parse.FacebookUtils.init()`.
 
@@ -317,7 +317,7 @@ There are two main ways to use Facebook with your Parse users: (1) logging in as
 
 `Parse.FacebookUtils` provides a way to allow your `Parse.User`s to log in or sign up through Facebook. This is accomplished using the `logIn()` method:
 
-<pre><code class="javascript">
+````javascript
 Parse.FacebookUtils.logIn(null, {
   success: function(user) {
     if (!user.existed()) {
@@ -330,7 +330,7 @@ Parse.FacebookUtils.logIn(null, {
     alert("User cancelled the Facebook login or did not fully authorize.");
   }
 });
-</code></pre>
+````
 
 When this code is run, the following happens:
 
@@ -341,7 +341,7 @@ When this code is run, the following happens:
 
 You may optionally provide a comma-delimited string that specifies what [permissions](https://developers.facebook.com/docs/authentication/permissions/) your app requires from the Facebook user.  For example:
 
-<pre><code class="javascript">
+````javascript
 Parse.FacebookUtils.logIn("user_likes,email", {
   success: function(user) {
     // Handle successful login
@@ -350,7 +350,7 @@ Parse.FacebookUtils.logIn("user_likes,email", {
     // Handle errors and cancellation
   }
 });
-</code></pre>
+````
 
 `Parse.User` integration doesn't require any permissions to work out of the box (ie. `null` or specifying no permissions is perfectly acceptable). [Read more about permissions on Facebook's developer guide.](https://developers.facebook.com/docs/reference/api/permissions/)
 
@@ -363,7 +363,7 @@ Parse.FacebookUtils.logIn("user_likes,email", {
 
 If you want to associate an existing `Parse.User` to a Facebook account, you can link it like so:
 
-<pre><code class="javascript">
+````javascript
 if (!Parse.FacebookUtils.isLinked(user)) {
   Parse.FacebookUtils.link(user, null, {
     success: function(user) {
@@ -374,19 +374,19 @@ if (!Parse.FacebookUtils.isLinked(user)) {
     }
   });
 }
-</code></pre>
+````
 
 The steps that happen when linking are very similar to log in. The difference is that on successful login, the existing `Parse.User` is updated with the Facebook information. Future logins via Facebook will now log the user into their existing account.
 
 If you want to unlink Facebook from a user, simply do this:
 
-<pre><code class="javascript">
+````javascript
 Parse.FacebookUtils.unlink(user, {
   success: function(user) {
     alert("The user is no longer associated with their Facebook account.");
   }
 });
-</code></pre>
+````
 
 ### Facebook SDK and Parse
 

--- a/_includes/php/analytics.md
+++ b/_includes/php/analytics.md
@@ -10,22 +10,22 @@ While this section will cover different ways to instrument your app to best take
 
 Say your app offers search functionality for apartment listings, and you want to track how often the feature is used, with some additional metadata.
 
-<pre><code class="php">
+````php
 // Define ranges to bucket data points into meaningful segments
 $dimensions = [
-  "priceRange" => '1000-1500', 
-  "source" => 'craigslist', 
+  "priceRange" => '1000-1500',
+  "source" => 'craigslist',
   "dayType": 'weekday'
 ];
 // Send the dimensions to Parse along with the 'search' event
 ParseAnalytics::track('search', $dimensions);
-</code></pre>
+````
 
 `ParseAnalytics` can even be used as a lightweight error tracker &mdash; simply invoke the following and you'll have access to an overview of the rate and frequency of errors, broken down by error code, in your application:
 
-<pre><code class="php">
+````php
 $codeString = '' + $error->getCode();
 ParseAnalytics::track('error', ["code" => codeString]);
-</code></pre>
+````
 
 Note that Parse currently only stores the first eight dimension pairsper call to `ParseAnalytics::track()`.

--- a/_includes/php/files.md
+++ b/_includes/php/files.md
@@ -6,17 +6,17 @@
 
 Getting started with `ParseFile` is easy. There are a couple of ways to create a file. The first is to provide the contents of the file.
 
-<pre><code class="php">
+````php
 $contents = "Hello World.";
 $file = ParseFile::createFromData($contents, "myfile.txt");
-</code></pre>
+````
 
 Alternatively, you can create a file from the contents of a local file:
 
-<pre><code class="php">
+````php
 $localFilePath = "/tmp/myFile.txt";
 $file = ParseFile::createFromFile($localFilePath, "myfile.txt");
-</code></pre>
+````
 
 Notice in this example that we give the file a name of `myfile.txt`. There's two things to note here: 
 
@@ -25,32 +25,32 @@ Notice in this example that we give the file a name of `myfile.txt`. There's two
 
 Next you'll want to save the file up to the cloud. As with `ParseObject`, the `save` method is the way to go.
 
-<pre><code class="php">
+````php
 $file->save();
 // The file has been saved to Parse and now has a URL.
 $url = $file->getURL();
-</code></pre>
+````
 
 Finally, after the save completes, you can associate a `ParseFile` with a `ParseObject` just like any other piece of data:
 
-<pre><code class="php">
+````php
 $jobApplication = new ParseObject("JobApplication");
 $jobApplication->set("applicantName", "Joe Smith");
 $jobApplication->set("applicantResumeFile", $file);
 $jobApplication->save();
-</code></pre>
+````
 
 ## Retrieving File Contents
 
 How to best retrieve the file contents back depends on the context of your application. It's best if you can make the visitors browser do the work for you. Typically, that means rendering the file's URL into your output. Here we output an uploaded profile photo in an image tag:
 
-<pre><code class="php">
+````php
 $profilePhoto = $profile->get("photoFile");
 echo '<img src="' . $profilePhoto->getURL() . '">';
-</code></pre>
+````
 
 If you want to fetch the contents of the file, you can retrieve it like this:
 
-<pre><code class="php">
+````php
 $contents = $file->getData();
-</code></pre>
+````

--- a/_includes/php/geopoints.md
+++ b/_includes/php/geopoints.md
@@ -6,15 +6,15 @@ Parse allows you to associate real-world latitude and longitude coordinates with
 
 To associate a point with an object you first need to create a `ParseGeoPoint`.  For example, to create a point with latitude of 40.0 degrees and -30.0 degrees longitude:
 
-<pre><code class="php">
+````php
 $point = new ParseGeoPoint(40.0, -30.0);
-</code></pre>
+````
 
 This point is then stored in the object as a regular field.
 
-<pre><code class="php">
+````php
 $placeObject->set("location", $point);
-</code></pre>
+````
 
 Note: Currently only one key in a class may be a `ParseGeoPoint`.
 
@@ -22,7 +22,7 @@ Note: Currently only one key in a class may be a `ParseGeoPoint`.
 
 Now that you have a bunch of objects with spatial coordinates, it would be nice to find out which objects are closest to a point.  This can be done by adding another restriction to `ParseQuery` using `near`.  Getting an array of ten places that are closest to a user may look something like:
 
-<pre><code class="php">
+````php
 // User's location
 $userGeoPoint = $userObject->get("location");
 // Create a query for places
@@ -33,7 +33,7 @@ $query->near("location", $userGeoPoint);
 $query->limit(10);
 // Final array of objects
 $placesObjects = $query->find();
-</code></pre>
+````
 
 At this point `$placesObjects` will be an array of objects ordered by distance (nearest to farthest) from `$userGeoPoint`. Note that if an additional `ascending()`/`descending()` order-by constraint is applied, it will take precedence over the distance ordering.
 
@@ -41,14 +41,14 @@ To limit the results using distance, check out `withinMiles`, `withinKilometers`
 
 It's also possible to query for the set of objects that are contained within a particular area.  To find the objects in a rectangular bounding box, add the `withinGeoBox` restriction to your `ParseQuery`.
 
-<pre><code class="php">
+````php
 $southwestOfSF = new ParseGeoPoint(37.708813, -122.526398);
 $northeastOfSF = new ParseGeoPoint(37.822802, -122.373962);
 
 $query = new ParseQuery("PizzaPlaceObject");
 $query->withinGeoBox("location", $southwestOfSF, $northeastOfSF);
 $pizzaPlacesInSF = $query->find();
-</code></pre>
+````
 
 ## Caveats
 

--- a/_includes/php/handling-errors.md
+++ b/_includes/php/handling-errors.md
@@ -2,7 +2,7 @@
 
 The Parse PHP SDK throws `ParseException`s when errors are returned from the Parse API.  For other errors, the base `Exception` class will be thrown.  It is recommended to wrap your Parse calls in try/catch blocks to handle any errors which occur.
 
-<pre><code class="php">
+````php
 $query = new ParseQuery("Note");
 try {
   // This will throw a ParseException, the object is not found.
@@ -12,6 +12,6 @@ try {
   echo $error->getCode();
   echo $error->getMessage();
 }
-</code></pre>
+````
 
 For a list of all possible error codes, scroll down to [Error Codes](#errors).

--- a/_includes/php/objects.md
+++ b/_includes/php/objects.md
@@ -6,9 +6,9 @@ Storing data on Parse is built around the `ParseObject`. Each `ParseObject` cont
 
 For example, let's say you're tracking high scores for a game. A single `ParseObject` could contain:
 
-<pre><code class="php">
+````php
 score: 1337, playerName: "Sean Plott", cheatMode: false
-</code></pre>
+````
 
 Keys must be alphanumeric strings. Values can be strings, numbers, booleans, or even sequential arrays and associative arrays - anything that can be JSON-encoded.  Note however that Arrays and Associative Arrays require separate methods to set them on a `ParseObject`.
 
@@ -16,7 +16,7 @@ Keys must be alphanumeric strings. Values can be strings, numbers, booleans, or 
 
 Let's say you want to save the `GameScore` described above to the Parse Cloud. The interface is similar to a our other SDKs, including the `save` method:
 
-<pre><code class="php">
+````php
 $gameScore = new ParseObject("GameScore");
 
 $gameScore->set("score", 1337);
@@ -31,14 +31,14 @@ try {
   // error is a ParseException object with an error code and message.
   echo 'Failed to create new object, with error message: ' . $ex->getMessage();
 }
-</code></pre>
+````
 
 After this code runs, you will probably be wondering if anything really happened. To make sure the data was saved, you can look at the Data Browser in your app on Parse. You should see something like this:
 
-<pre><code class="json">
+````json
 objectId: "xWMyZ4YEGZ", score: 1337, playerName: "Sean Plott", cheatMode: false,
 createdAt:"2011-06-10T18:33:42Z", updatedAt:"2011-06-10T18:33:42Z"
-</code></pre>
+````
 
 There are two things to note here. You didn't have to configure or set up a new Class called `GameScore` before running this code. Your Parse app lazily creates this Class for you when it first encounters it.
 
@@ -48,7 +48,7 @@ There are also a few fields you don't need to specify that are provided as a con
 
 Saving data to the cloud is fun, but it's even more fun to get that data out again. If you have the `objectId`, you can retrieve the whole `ParseObject` using a `ParseQuery`:
 
-<pre><code class="php">
+````php
 $query = new ParseQuery("GameScore");
 try {
   $gameScore = $query->get("xWMyZ4YEGZ");
@@ -57,36 +57,36 @@ try {
   // The object was not retrieved successfully.
   // error is a ParseException with an error code and message.
 }
-</code></pre>
+````
 
 To get the values out of the `ParseObject`, use the `get` method.
 
-<pre><code class="php">
+````php
 $score = $gameScore->get("score");
 $playerName = $gameScore->get("playerName");
 $cheatMode = $gameScore->get("cheatMode");
-</code></pre>
+````
 
 The three special values are provided as the result of methods:
 
-<pre><code class="php">
+````php
 $objectId = $gameScore->getObjectId();
 $updatedAt = $gameScore->getUpdatedAt();
 $createdAt = $gameScore->getCreatedAt();
-</code></pre>
+````
 
 If you need to refresh an object you already have with the latest data that
     is in the Parse Cloud, you can call the `fetch` method like so:
 
-<pre><code class="php">
+````php
 $gameScore->fetch();
-</code></pre>
+````
 
 ## Updating Objects
 
 Updating an object is simple. Just set some new data on it and call the save method. For example:
 
-<pre><code class="php">
+````php
 // Create the object.
 $gameScore = new ParseObject("GameScore");
 
@@ -101,7 +101,7 @@ $gameScore->save();
 $gameScore->set("cheatMode", true);
 $gameScore->set("score", 1338);
 $gameScore->save();
-</code></pre>
+````
 
 Parse automatically figures out which data has changed so only "dirty" fields will be sent to the Parse Cloud. You don't need to worry about squashing data that you didn't intend to update.
 
@@ -111,10 +111,10 @@ The above example contains a common use case. The "score" field is a counter tha
 
 To help with storing counter-type data, Parse provides methods that atomically increment (or decrement) any number field. So, the same update can be rewritten as:
 
-<pre><code class="php">
+````php
 $gameScore->increment("score");
 $gameScore->save();
-</code></pre>
+````
 
 You can also increment by any amount by passing in a second argument to `increment`. When no amount is specified, 1 is used by default.
 
@@ -128,11 +128,11 @@ To help with storing array data, there are three operations that can be used to 
 
 For example, we can add items to the set-like "skills" field like so:
 
-<pre><code class="php">
+````php
 $gameScore->addUnique("skills", ["flying"]);
 $gameScore->addUnique("skills", ["kungfu"]);
 $gameScore->save();
-</code></pre>
+````
 
 Note that it is not currently possible to atomically add and remove items from an array in the same save.
     You will have to call `save` in between every different kind of array operation.
@@ -142,19 +142,19 @@ Note that it is not currently possible to atomically add and remove items from a
 
 To delete an object from the cloud:
 
-<pre><code class="php">
+````php
 $gameScore->destroy();
-</code></pre>
+````
 
 You can delete a single field from an object with the `delete` method:
 
-<pre><code class="php">
+````php
 // After this, the playerName field will be empty
 $gameScore->delete("playerName");
 
 // Saves the field deletion to the Parse Cloud
 $gameScore->save();
-</code></pre>
+````
 
 ## Relational Data
 
@@ -166,7 +166,7 @@ One-to-one and one-to-many relationships are modeled by saving a `ParseObject` a
 
 To create a new `Post` with a single `Comment`, you could write:
 
-<pre><code class="php">
+````php
 // Create the post
 $myPost = new ParseObject("Post");
 $myPost->set("title", "I'm Hungry");
@@ -181,72 +181,72 @@ $myComment->set("parent", $myPost);
 
 // This will save both myPost and myComment
 $myComment->save();
-</code></pre>
+````
 
 Internally, the Parse framework will store the referred-to object in just one place, to maintain consistency. You can also link objects using just their `objectId`s like so:
 
-<pre><code class="php">
+````php
 $post = new ParseObject("Post", "1zEcyElZ80");
 
 $myComment->set("parent", $post);
-</code></pre>
+````
 
 By default, when fetching an object, related `ParseObject`s are not fetched.  These objects' values cannot be retrieved until they have been fetched like so:
 
-<pre><code class="php">
+````php
 $post = $fetchedComment->get("parent");
 $post->fetch();
 $title = $post->get("title");
-</code></pre>
+````
 
 ### Many-to-Many Relationships
 
 Many-to-many relationships are modeled using `ParseRelation`. This works similar to storing an array of `ParseObject`s in a key, except that you don't need to fetch all of the objects in a relation at once.  In addition, this allows `ParseRelation` to scale to many more objects than the array of `ParseObject` approach.  For example, a `User` may have many `Posts` that she might like. In this case, you can store the set of `Posts` that a `User` likes using `relation`.  In order to add a `Post` to the "likes" array of the `User`, you can do:
 
-<pre><code class="php">
+````php
 $user = ParseUser::getCurrentUser();
 $relation = $user->getRelation("likes");
 $relation->add($post);
 $user->save();
-</code></pre>
+````
 
  You can remove a post from a `ParseRelation`:
 
-<pre><code class="php">
+````php
 $relation->remove($post);
 $user->save();
-</code></pre>
+````
 
 You can call `add` and `remove` multiple times before calling save:
 
-<pre><code class="php">
+````php
 $relation->remove($post1);
 $relation->remove($post2);
 $user->save();
-</code></pre>
+````
 
 You can also pass in an array of `ParseObject` to `add` and `remove`:
 
-<pre><code class="php">
+````php
 $relation->add([$post1, $post2, $post3]);
 $user->save();
-</code></pre>
+````
 
 By default, the array of objects in this relation are not downloaded.  You can get an array of the posts that a user likes by using the `ParseQuery` returned by `getQuery`.  The code looks like:
 
-<pre><code class="php">
+````php
 $postsLiked = $relation->getQuery()->find();
 // $postsLiked contains the posts that the current user likes.
-</code></pre>
+````
 
 If you want only a subset of the Posts, you can add extra constraints to the `ParseQuery` returned by query like this:
 
-<pre><code class="php">
+````php
 $query = $relation->getQuery();
 $query->equalTo("title", "I'm Hungry");
 $postsLiked = $query->find();
 // $postsLiked contains post liked by the current user which have the title "I'm Hungry".
-</code></pre>
+````
 
 For more details on `ParseQuery`, please look at the query portion of this guide. A `ParseRelation` behaves similar to an array of `ParseObject` for querying purposes, so any query you can do on an array of objects, you can do on a `ParseRelation`.
 
@@ -268,7 +268,7 @@ So far we've used values with type `String`, `Integer`, and `ParseObject`. Parse
 
 Some examples:
 
-<pre><code class="php">
+````php
 $number = 42;
 $string = "the number is " . $number;
 $date = new DateTime();
@@ -283,7 +283,7 @@ $bigObject->setArray("myArray", $array);
 $bigObject->setAssociativeArray("myObject", $object);
 $bigObject->set("anyKey", null); // this value can only be saved to an existing key
 $bigObject->save();
-</code></pre>
+````
 
 We do not recommend storing large pieces of binary data like images or documents on `ParseObject`. `ParseObject`s should not exceed 128 kilobytes in size. We recommend you use `ParseFile`s to store images, documents, and other types of files. You can do so by instantiating a `ParseFile` object and setting it on a field. See [Files](#files) for more details.
 
@@ -295,24 +295,24 @@ Each `ParseObject` is an instance of a specific subclass with a class name that 
 
 To create a new subclass, create a new class which extends the `ParseObject` class, add the `$parseClassName` static property, and call the `registerSubclass` method before use.  Any `ParseQuery` will return instances of the new class for any `ParseObject` with the same class name.
 
-<pre><code class="php">
+````php
 class GameScore extends ParseObject
 {
   public static $parseClassName = "GameScore";
 }
-</code></pre>
+````
 
-<pre><code class="php">
+````php
 // Do this once, at the start of your app, before ParseClient::initialize(...);
 GameScore::registerSubclass();
 
 // Create a new instance of that class.
 $gameScore = new GameScore();
-</code></pre>
+````
 
 You can add additional methods and properties to your subclasses of `ParseObject`.
 
-<pre><code class="php">
+````php
 // A complex subclass of ParseObject
 class Monster extends ParseObject
 {
@@ -328,17 +328,17 @@ class Monster extends ParseObject
     return $monster;
   }
 }
-</code></pre>
+````
 
-<pre><code class="php">
+````php
 $monster = Monster::spawn(200);
 echo monster->strength();  // Displays 200.
 echo monster->hasSuperHumanStrength();  // Displays true.
-</code></pre>
+````
 
 If you want to override the __construct method, make sure the first three params are exactly as same as the parent ParseObject constructor:
 
-<pre><code class="php">
+````php
 class GameScore extends ParseObject
 {
   public static $parseClassName = "GameScore";
@@ -348,4 +348,4 @@ class GameScore extends ParseObject
     // ...
   }
 }
-</code></pre>
+````

--- a/_includes/php/push-notifications.md
+++ b/_includes/php/push-notifications.md
@@ -45,14 +45,14 @@ The PHP SDK does not currently support subscribing iOS and Android devices for p
 
 With the PHP SDK, the following code can be used to alert all subscribers of the "Giants" and "Mets" channels about the results of the game. This will display a notification center alert to iOS users and a system tray notification to Android users.
 
-<pre><code class="php">
+````php
 $data = array("alert" => "Hi!");
 
 ParsePush::send(array(
   "channels" => ["PHPFans"],
   "data" => $data
 ));
-</code></pre>
+````
 
 ### Using Advanced Targeting
 
@@ -68,18 +68,18 @@ The PHP SDK does not currently support modifying `Installation` objects. Take a 
 
 Once you have your data stored on your `Installation` objects, you can use a query to target a subset of these devices. `Parse.Installation` queries work just like any other [Parse query](/docs/php_guide#queries).
 
-<pre><code class="php">
+````php
 $query = ParseInstallation::query();
 $query->equalTo("design", "rad");
 ParsePush::send(array(
   "where" => $query,
   "data" => $data
 ));
-</code></pre>
+````
 
 We can even use channels with our query. To send a push to all subscribers of the "Giants" channel but filtered by those who want score update, we can do the following:
 
-<pre><code class="php">
+````php
 $query = ParseInstallation::query();
 $query->equalTo("channels", "Giants");
 $query->equalTo("scores", true);
@@ -90,11 +90,11 @@ ParsePush::send(array(
     "alert" => "Giants scored against the A's! It's now 2-2."
   )
 ));
-</code></pre>
+````
 
 If we store relationships to other objects in our `Installation` class, we can also use those in our query. For example, we could send a push notification to all users near a given location like this.
 
- <pre><code class="php">
+ ````php
 // Find users near a given location
 $userQuery = ParseUser::query();
 $userQuery->withinMiles("location", $stadiumLocation, 1.0);
@@ -110,7 +110,7 @@ ParsePush::send(array(
     "alert" => "Free hotdogs at the Parse concession stand!"
   )
 ));
-</code></pre>
+````
 
 ## Sending Options
 
@@ -130,7 +130,7 @@ If you want to send more than just a message, you can set other fields in the `d
 
 For example, to send a notification that increases the current badge number by 1 and plays a custom sound for iOS devices, and displays a particular title for Android users, you can do the following:
 
-<pre><code class="php">
+````php
 ParsePush::send(array(
   "channels" => [ "Mets" ],
   "data" => array(
@@ -140,11 +140,11 @@ ParsePush::send(array(
     "title" => "Mets Score!"
   )
 ));
-</code></pre>
+````
 
 It is also possible to specify your own data in this dictionary. As explained in the Receiving Notifications section for [iOS](#receiving/iOS) and [Android](#receiving/Android), iOS will give you access to this data only when the user opens your app via the notification and Android will provide you this data in the `Intent` if one is specified.
 
-<pre><code class="php">
+````php
 $query = ParseInstallation::query();
 $query->equalTo('channels', 'Indians');
 $query->equalTo('injuryReports', true);
@@ -158,7 +158,7 @@ ParsePush::send(array(
     "newsItem" => "Man bites dog"
   )
 ));
-</code></pre>
+````
 
 ### Setting an Expiration Date
 
@@ -174,7 +174,7 @@ If you build a cross platform app, it is possible you may only want to target iO
 
 The following examples would send a different notification to Android and iOS users.
 
-<pre><code class="php">
+````php
 // Notification for Android users
 $queryAndroid = ParseInstallation::query();
 $queryAndroid->equalTo('deviceType', 'android');
@@ -218,7 +218,7 @@ ParsePush::send(array(
     "alert" => "Your suitcase is very hip; very metro."
   )
 ));
-</code></pre>
+````
 
 ## Scheduling Pushes
 

--- a/_includes/php/queries.md
+++ b/_includes/php/queries.md
@@ -8,7 +8,7 @@ In many cases, `get` isn't powerful enough to specify which objects you want to 
 
 The general pattern is to create a `ParseQuery`, put conditions on it, and then retrieve an `Array` of matching `ParseObject`s using `find`. For example, to retrieve of the scores with a particular `playerName`, use the `equalTo` method to constrain the value for a key.
 
-<pre><code class="php">
+````php
 $query = new ParseQuery("GameScore");
 $query->equalTo("playerName", "Dan Stemkoski");
 $results = $query->find();
@@ -18,56 +18,56 @@ for ($i = 0; $i < count($results); $i++) {
   $object = $results[$i];
   echo $object->getObjectId() . ' - ' . $object->get('playerName');
 }
-</code></pre>
+````
 
 ## Query Constraints
 
 There are several ways to put constraints on the objects found by a `ParseQuery`. You can filter out objects with a particular key-value pair with `notEqualTo`:
 
-<pre><code class="php">
+````php
 $query->notEqualTo("playerName", "Michael Yabuti");
-</code></pre>
+````
 
 You can give multiple constraints, and objects will only be in the results if they match all of the constraints.  In other words, it's like an AND of constraints.
 
-<pre><code class="php">
+````php
 $query->notEqualTo("playerName", "Michael Yabuti");
 $query->greaterThan("playerAge", 18);
-</code></pre>
+````
 
 You can limit the number of results by setting `limit`. By default, results are limited to 100, but anything from 1 to 1000 is a valid limit:
 
-<pre><code class="php">
+````php
 $query->limit(10); // limit to at most 10 results
-</code></pre>
+````
 
 If you want exactly one result, a more convenient alternative may be to use `first` instead of using `find`.
 
-<pre><code class="php">
+````php
 $query = new ParseQuery("GameScore");
 $query->equalTo("playerEmail", "dstemkoski@example.com");
 $object = $query->first();
-</code></pre>
+````
 
 You can skip the first results by setting `skip`. This can be useful for pagination, though it is limited to a maximum of ten thousand:
 
-<pre><code class="php">
+````php
 $query->skip(10); // skip the first 10 results
-</code></pre>
+````
 
 For sortable types like numbers and strings, you can control the order in which results are returned:
 
-<pre><code class="php">
+````php
 // Sorts the results in ascending order by the score field
 $query->ascending("score");
 
 // Sorts the results in descending order by the score field
 $query->descending("score");
-</code></pre>
+````
 
 For sortable types, you can also use comparisons in queries:
 
-<pre><code class="php">
+````php
 // Restricts to wins < 50
 $query->lessThan("wins", 50);
 
@@ -79,87 +79,87 @@ $query->greaterThan("wins", 50);
 
 // Restricts to wins >= 50
 $query->greaterThanOrEqualTo("wins", 50);
-</code></pre>
+````
 
 If you want to retrieve objects matching several different values, you can use `containedIn`, providing an array of acceptable values. This is often useful to replace multiple queries with a single query. For example, if you want to retrieve scores made by any player in a particular array:
 
-<pre><code class="php">
+````php
 // Finds scores from any of Jonathan, Dario, or Shawn
 $query->containedIn("playerName",
                   ["Jonathan Walsh", "Dario Wunsch", "Shawn Simon"]);
-</code></pre>
+````
 
 If you want to retrieve objects that do not match any of  several values you can use `notContainedIn`, providing an array of acceptable values.  For example if you want to retrieve scores from players besides those in an array:
 
-<pre><code class="php">
+````php
 // Finds scores from anyone who is neither Jonathan, Dario, nor Shawn
 $query->notContainedIn("playerName",
                      ["Jonathan Walsh", "Dario Wunsch", "Shawn Simon"]);
-</code></pre>
+````
 
 If you want to retrieve objects that have a particular key set, you can use `exists`. Conversely, if you want to retrieve objects without a particular key set, you can use `doesNotExist`.
 
-<pre><code class="php">
+````php
 // Finds objects that have the score set
 $query->exists("score");
 
 // Finds objects that don't have the score set
 $query->doesNotExist("score");
-</code></pre>
+````
 
 You can use the `matchesKeyInQuery` method to get objects where a key matches the value of a key in a set of objects resulting from another query.  For example, if you have a class containing sports teams and you store a user's hometown in the user class, you can issue one query to find the array of users whose hometown teams have winning records.  The query would look like:
 
-<pre><code class="php">
+````php
 $teamQuery = new ParseQuery("Team");
 $teamQuery->greaterThan("winPct", 0.5);
 $userQuery = ParseUser::query();
 $userQuery->matchesKeyInQuery("hometown", "city", $teamQuery);
 $results = $userQuery->find();
 // results has the array of users with a hometown team with a winning record
-</code></pre>
+````
 
 Conversely, to get objects where a key does not match the value of a key in a set of objects resulting from another query, use `doesNotMatchKeyInQuery`. For example, to find users whose hometown teams have losing records:
 
-<pre><code class="php">
+````php
 $losingUserQuery = ParseUser::query();
 $losingUserQuery->doesNotMatchKeyInQuery("hometown", "city", teamQuery);
 $results = $losingUserQuery->find();
 // results has the array of users with a hometown team with a losing record
-</code></pre>
+````
 
 You can restrict the fields returned by calling `select` with an array of keys. To retrieve documents that contain only the `score` and `playerName` fields (and also special built-in fields such as `objectId`, `createdAt`, and `updatedAt`):
 
-<pre><code class="php">
+````php
 $query = new ParseQuery("GameScore");
 $query->select(["score", "playerName"]);
 $results = $query->find();
 // each of results will only have the selected fields available.
-</code></pre>
+````
 
 The remaining fields can be fetched later by calling `fetch` on the returned objects:
 
-<pre><code class="php">
+````php
 $result = $query->first();
 // only the selected fields of the object will now be available here.
 $result->fetch();
 // all fields of the object will now be available here.
-</code></pre>
+````
 
 ## Queries on Array Values
 
 For keys with an array type, you can find objects where the key's array value contains 2 by:
 
-<pre><code class="php">
+````php
 // Find objects where the array in arrayKey contains 2.
 $query->equalTo("arrayKey", 2);
-</code></pre>
+````
 
 You can also find objects where the key's array value contains each of the elements 2, 3, and 4 with the following:
 
-<pre><code class="php">
+````php
 // Find objects where the array in arrayKey contains all of the elements 2, 3, and 4.
 $query->containsAll("arrayKey", [2, 3, 4]);
-</code></pre>
+````
 
 ## Queries on String Values
 
@@ -169,11 +169,11 @@ $query->containsAll("arrayKey", [2, 3, 4]);
 
 Use `startsWith` to restrict to string values that start with a particular string. Similar to a MySQL LIKE operator, this is indexed so it is efficient for large datasets:
 
-<pre><code class="php">
+````php
 // Finds barbecue sauces that start with "Big Daddy's".
 $query = new ParseQuery("BarbecueSauce");
 $query->startsWith("name", "Big Daddy's");
-</code></pre>
+````
 
 The above example will match any `BarbecueSauce` objects where the value in the "name" String key starts with "Big Daddy's". For example, both "Big Daddy's" and "Big Daddy's BBQ" will match, but "big daddy's" or "BBQ Sauce: Big Daddy's" will not.
 
@@ -184,46 +184,46 @@ Queries that have regular expression constraints are very expensive, especially 
 
 There are several ways to issue queries for relational data. If you want to retrieve objects where a field matches a particular `ParseObject`, you can use `equalTo` just like for other data types. For example, if each `Comment` has a `Post` object in its `post` field, you can fetch comments for a particular `Post`:
 
-<pre><code class="php">
+````php
 // Assume ParseObject $myPost was previously created.
 $query = new ParseQuery("Comment");
 $query->equalTo("post", $myPost);
 $comments = $query->find();
 // comments now contains the comments for myPost
-</code></pre>
+````
 
 If you want to retrieve objects where a field contains a `ParseObject` that matches a different query, you can use `matchesQuery`. Note that the default limit of 100 and maximum limit of 1000 apply to the inner query as well, so with large data sets you may need to construct queries carefully to get the desired behavior. In order to find comments for posts containing images, you can do:
 
-<pre><code class="php">
+````php
 $innerQuery = new ParseQuery("Post");
 $innerQuery->exists("image");
 $query = new ParseQuery("Comment");
 $query->matchesQuery("post", $innerQuery);
 $comments = $query->find();
 // comments now contains the comments for posts with images.
-</code></pre>
+````
 
 If you want to retrieve objects where a field contains a `ParseObject` that does not match a different query, you can use `doesNotMatchQuery`.  In order to find comments for posts without images, you can do:
 
-<pre><code class="php">
+````php
 $innerQuery = new ParseQuery("Post");
 $innerQuery->exists("image");
 $query = new ParseQuery("Comment");
 $query->doesNotMatchQuery("post", $innerQuery);
 $query->find();
 // comments now contains the comments for posts without images.
-</code></pre>
+````
 
 You can also do relational queries by `objectId`:
 
-<pre><code class="php">
+````php
 $post = new ParseObject("Post", "1zEcyElZ80");
 $query->equalTo("post", $post);
-</code></pre>
+````
 
 In some situations, you want to return multiple types of related objects in one query. You can do this with the `include` method. For example, let's say you are retrieving the last ten comments, and you want to retrieve their related posts at the same time:
 
-<pre><code class="php">
+````php
 $query = new ParseQuery("Comment");
 
 // Retrieve the most recent ones
@@ -242,13 +242,13 @@ for ($i = 0; $i < count($comments); $i++) {
   // This does not require a network access.
   $post = $comments[$i]->get("post");
 }
-</code></pre>
+````
 
 You can also do multi level includes using dot notation.  If you wanted to include the post for a comment and the post's author as well you can do:
 
-<pre><code class="php">
+````php
 $query->includeKey("post.author");
-</code></pre>
+````
 
 You can issue a query with multiple fields included by calling `includeKey` multiple times. This functionality also works with ParseQuery helpers like `first` and `get`.
 
@@ -258,19 +258,19 @@ Caveat: Count queries are rate limited to a maximum of 160 requests per minute. 
 
 If you just need to count how many objects match a query, but you do not need to retrieve all the objects that match, you can use `count` instead of `find`. For example, to count how many games have been played by a particular player:
 
-<pre><code class="php">
+````php
 $query = new ParseQuery("GameScore");
 $query->equalTo("playerName", "Sean Plott");
 $count = $query->count();
 // The count request succeeded. Show the count
 echo "Sean has played " . $count . " games";
-</code></pre>
+````
 
 ## Compound Queries
 
  If you want to find objects that match one of several queries, you can use `ParseQuery.or` method to construct a query that is an OR of the queries passed in.  For instance if you want to find players who either have a lot of wins or a few wins, you can do:
 
-<pre><code class="php">
+````php
 $lotsOfWins = new ParseQuery("Player");
 $lotsOfWins->greaterThan("wins", 150);
 
@@ -280,7 +280,7 @@ $fewWins->lessThan("wins", 5);
 $mainQuery = ParseQuery::orQueries([$lotsOfWins, $fewWins]);
 $results = $mainQuery->find();
 // results contains an array of players that either have won a lot of games or won only a few games.
-</code></pre>
+````
 
 You can add additional constraints to the newly created `ParseQuery` that act as an 'and' operator.
 
@@ -290,24 +290,24 @@ Each `ParseObject` is an instance of a specific subclass with a class name that 
 
 To create a new subclass, create a new class which extends the `ParseObject` class, add the `$parseClassName` static property, and call the `registerSubclass` method before use.  Any `ParseQuery` will return instances of the new class for any `ParseObject` with the same class name.
 
-<pre><code class="php">
+````php
 class GameScore extends ParseObject
 {
   public static $parseClassName = "GameScore";
 }
-</code></pre>
+````
 
-<pre><code class="php">
+````php
 // Do this once, at the start of your app, before ParseClient::initialize(...);
 GameScore::registerSubclass();
 
 // Create a new instance of that class.
 $gameScore = new GameScore();
-</code></pre>
+````
 
 You can add additional methods and properties to your subclasses of `ParseObject`.
 
-<pre><code class="php">
+````php
 // A complex subclass of ParseObject
 class Monster extends ParseObject
 {
@@ -323,10 +323,10 @@ class Monster extends ParseObject
     return $monster;
   }
 }
-</code></pre>
+````
 
-<pre><code class="php">
+````php
 $monster = Monster::spawn(200);
 echo monster->strength();  // Displays 200.
 echo monster->hasSuperHumanStrength();  // Displays true.
-</code></pre>
+````

--- a/_includes/php/roles.md
+++ b/_includes/php/roles.md
@@ -20,17 +20,17 @@ The `ParseRole` uses the same security scheme (ACLs) as all other objects on Par
 
 To create a new `ParseRole`, you would write:
 
-<pre><code class="php">
+````php
 // By specifying no write privileges for the ACL, we can ensure the role cannot be altered.
 $roleACL = new ParseACL();
 $roleACL->setPublicReadAccess(true);
 $role = ParseRole::createRole("Administrator", $roleACL);
 $role->save();
-</code></pre>
+````
 
 You can add users and roles that should inherit your new role's permissions through the "users" and "roles" relations on `ParseRole`:
 
-<pre><code class="php">
+````php
 $role = ParseRole::createRole($roleName, $roleACL);
 for ($i = 0; $i < count($usersToAddToRole); $i++) {
   $role->getUsers()->add($usersToAddToRole[$i]);
@@ -39,7 +39,7 @@ for ($i = 0; $i < count($rolesToAddToRole); $i++) {
   $role->getRoles()->add($rolesToAddToRole[$i]);
 }
 $role->save();
-</code></pre>
+````
 
 Take great care when assigning ACLs to your roles so that they can only be modified by those who should have permissions to modify them.
 
@@ -49,24 +49,24 @@ Now that you have created a set of roles for use in your application, you can us
 
 Giving a role read or write permission to an object is straightforward.  You can either use the `ParseRole`:
 
-<pre><code class="php">
+````php
 $moderators = /* Query for some ParseRole */;
 $wallPost = new ParseObject("WallPost");
 $postACL = new ParseACL();
 $postACL->setRoleWriteAccess($moderators, true);
 $wallPost->setACL($postACL);
 $wallPost->save();
-</code></pre>
+````
 
 You can avoid querying for a role by specifying its name for the ACL:
 
-<pre><code class="php">
+````php
 $wallPost = new ParseObject("WallPost");
 $postACL = new ParseACL();
 $postACL->setRoleWriteAccessWithName("Moderators", true);
 $wallPost->setACL($postACL);
 $wallPost->save();
-</code></pre>
+````
 
 ## Role Hierarchy
 
@@ -74,9 +74,9 @@ As described above, one role can contain another, establishing a parent-child re
 
 These types of relationships are commonly found in applications with user-managed content, such as forums. Some small subset of users are "Administrators", with the highest level of access to tweaking the application's settings, creating new forums, setting global messages, and so on. Another set of users are "Moderators", who are responsible for ensuring that the content created by users remains appropriate. Any user with Administrator privileges should also be granted the permissions of any Moderator. To establish this relationship, you would make your "Administrators" role a child role of "Moderators", like this:
 
-<pre><code class="php">
+````php
 $administrators = /* Your "Administrators" role */;
 $moderators = /* Your "Moderators" role */;
 $moderators->getRoles()->add($administrators);
 $moderators->save();
-</code></pre>
+````

--- a/_includes/php/users.md
+++ b/_includes/php/users.md
@@ -21,7 +21,7 @@ We'll go through each of these in detail as we run through the various use cases
 
 The first thing your app will do is probably ask the user to sign up. The following code illustrates a typical sign up:
 
-<pre><code class="php">
+````php
 
 $user = new ParseUser();
 $user->set("username", "my name");
@@ -38,7 +38,7 @@ try {
   // Show the error message somewhere and let the user try again.
   echo "Error: " . $ex->getCode() . " " . $ex->getMessage();
 }
-</code></pre>
+````
 
 This call will asynchronously create a new user in your Parse App. Before it does this, it also checks to make sure that both the username and email are unique. Also, it securely hashes the password in the cloud using bcrypt. We never store passwords in plaintext, nor will we ever transmit passwords back to the client in plaintext.
 
@@ -52,14 +52,14 @@ You are free to use an email address as the username. Simply ask your users to e
 
 Of course, after you allow users to sign up, you need to let them log in to their account in the future. To do this, you can use the class method `logIn`.
 
-<pre><code class="php">
+````php
 try {
   $user = ParseUser::logIn("myname", "mypass");
   // Do stuff after successful login.
 } catch (ParseException $error) {
   // The login failed. Check error to see why.
 }
-</code></pre>
+````
 
 ## Verifying Emails
 
@@ -77,43 +77,43 @@ It would be bothersome if the user had to log in every time they open your app. 
 
 By default, whenever you use any signup or login methods, the user will be saved in PHP Session storage (The `$_SESSION` superglobal.)
 
-<pre><code class="php">
+````php
 $currentUser = ParseUser::getCurrentUser();
 if ($currentUser) {
     // do stuff with the user
 } else {
     // show the signup or login page
 }
-</code></pre>
+````
 
 You can clear the current user by logging them out:
 
-<pre><code class="php">
+````php
 ParseUser::logOut();
 
 $currentUser = ParseUser::getCurrentUser();  // this will now be null
-</code></pre>
+````
 
 ## Setting the Current User
 
 If you’ve created your own authentication routines, or otherwise logged in a user on the server side, you can now pass the session token to the client and use the `become` method. This method will ensure the session token is valid before setting the current user.
 
-<pre><code class="php">
+````php
 try {
   $user = ParseUser::become("session-token-here");
   // The current user is now set to user.
 } catch (ParseException $ex) {
   // The token could not be validated.
 }
-</code></pre>
+````
 
 ## Session Storage Interface
 
 If you do not want to use the default PHP `$_SESSION` for storage, you can add your own storage mechanism.  We provide the `ParseSessionStorageInterface` and a default implementation, `ParseSessionStorage`.  Simply create your own storage class that implements `ParseSessionStorageInterface` and inject it to the SDK when you initialize:
 
-<pre><code class="php">
+````php
     ParseClient::setStorage(new MyStorageClass());
-</code></pre>
+````
 
 ## Security For User Objects
 
@@ -123,7 +123,7 @@ Specifically, you are not able to invoke any of the `save` or `delete` methods u
 
 The following illustrates this security policy:
 
-<pre><code class="php">
+````php
 $user = ParseUser::logIn("my_username", "my_password");
 $user->set("username", "my_new_username");  // attempt to change username
 $user->save();
@@ -135,7 +135,7 @@ $userAgain = $query->get($user->getObjectId());
 $userAgain->set("username", "another_username");
 // This will throw a ParseException, since the ParseUser is not authenticated
 $userAgain->save();
-</code></pre>
+````
 
 The `ParseUser` obtained from `ParseUser::getCurrentUser()` will always be authenticated.
 
@@ -147,18 +147,18 @@ The same security model that applies to the `ParseUser` can be applied to other 
 
 The simplest way to use a `ParseACL` is to specify that an object may only be read or written by a single user. To create such an object, there must first be a logged in `ParseUser`. Then, `new ParseACL::createACLWithUser($user)` generates a `ParseACL` that limits access to that user. An object's ACL is updated when the object is saved, like any other property. Thus, to create a private note that can only be accessed by the current user:
 
-<pre><code class="php">
+````php
 $privateNote = new ParseObject("Note");
 $privateNote->set("content", "This note is private!");
 $privateNote->setACL(ParseACL::createACLWithUser(ParseUser::getCurrentUser()));
 $privateNote->save();
-</code></pre>
+````
 
 This note will then only be accessible to the current user, although it will be accessible to any device where that user is signed in. This functionality is useful for applications where you want to enable access to user data across multiple devices, like a personal todo list.
 
 Permissions can also be granted on a per-user basis. You can add permissions individually to a `ParseACL` using `setReadAccess` and `setWriteAccess`. For example, let's say you have a message that will be sent to a group of several users, where each of them have the rights to read and delete that message:
 
-<pre><code class="php">
+````php
 $groupMessage = new ParseObject("Message");
 $groupACL = new ParseACL();
 
@@ -170,17 +170,17 @@ for ($i = 0; $i < count($userList); $i++) {
 
 $groupMessage->setACL($groupACL);
 $groupMessage->save();
-</code></pre>
+````
 
 You can also grant permissions to all users at once using `setPublicReadAccess` and `setPublicWriteAccess`. This allows patterns like posting comments on a message board. For example, to create a post that can only be edited by its author, but can be read by anyone:
 
-<pre><code class="php">
+````php
 $publicPost = new ParseObject("Post");
 $postACL = ParseACL::createACLWithUser(ParseUser::getCurrentUser());
 $postACL->setPublicReadAccess(true);
 $publicPost->setACL($postACL);
 $publicPost->save();
-</code></pre>
+````
 
 Operations that are forbidden, such as deleting an object that you do not have write access to, result in a `ParseError.OBJECT_NOT_FOUND` error code. For security purposes, this prevents clients from distinguishing which object ids exist but are secured, versus which object ids do not exist at all.
 
@@ -190,14 +190,14 @@ It's a fact that as soon as you introduce passwords into a system, users will fo
 
 To kick off the password reset flow, ask the user for their email address, and call:
 
-<pre><code class="php">
+````php
 try {
   ParseUser::requestPasswordReset("email@example.com");
 	// Password reset request was sent successfully
 } catch (ParseException $ex) {
   // Password reset failed, check the exception message
 }
-</code></pre>
+````
 
 This will attempt to match the given email with the user's email or username field, and will send them a password reset email. By doing this, you can opt to have users use their email as their username, or you can collect it separately and store it in the email field.
 
@@ -214,17 +214,17 @@ Note that the messaging in this flow will reference your app by the name that yo
 
 To query for users, you can get a new `ParseQuery` for `ParseUser`s:
 
-<pre><code class="php">
+````php
 $query = ParseUser::query();
 $query->equalTo("gender", "female"); 
 $results = $query->find();
-</code></pre>
+````
 
 ## Associations
 
 Associations involving a `ParseUser` work right out of the box. For example, let's say you're making a blogging app. To store a new post for a user and retrieve all of their posts:
 
-<pre><code class="php">
+````php
 $user = ParseUser::getCurrentUser()
 
 // Make a new post
@@ -239,4 +239,4 @@ $query = new ParseQuery("Post");
 $query->equalTo("user", $user);
 $userPosts = $query->find();
 // $userPosts contains all of the posts by the current user.
-</code></pre>
+````

--- a/_includes/rest/analytics.md
+++ b/_includes/rest/analytics.md
@@ -8,14 +8,14 @@ Without having to implement any client-side logic, you can view real-time graphs
 
 The current server time will be used for all analytics requests. To explicitly set the time associated with a given event, an optional `at` parameter can be provided in ISO 8601 format.
 
-<pre><code class="json">
+````json
 -d '{
     "at": {
       "__type": "Date",
       "iso": "2015-03-01T15:59:11-07:00"
     }
   }
-</code></pre>
+````
 
 ## App-Open Analytics
 
@@ -23,7 +23,7 @@ Our analytics hook allows you to track your application being launched. By makin
 
 In the example below, the `at` parameter is optional. If omitted, the current server time will be used instead.
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -31,8 +31,8 @@ curl -X POST \
   -d '{
       }' \
   https://api.parse.com/1/events/AppOpened
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -44,7 +44,7 @@ connection.request('POST', '/1/events/AppOpened', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 Graphs and breakdowns of your statistics are accessible from your app's Dashboard.
 
@@ -55,7 +55,7 @@ Parse Analytics also allows you to track free-form events, with a handful of str
 
 Say your app offers search functionality for apartment listings, and you want to track how often the feature is used, with some additional metadata.
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -68,8 +68,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/events/Search
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -86,11 +86,11 @@ connection.request('POST', '/1/events/Search', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 Parse Analytics can even be used as a lightweight error tracker — simply invoke the following and you'll have access to an overview of the rate and frequency of errors, broken down by error code, in your application:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -101,8 +101,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/events/Error
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -117,6 +117,6 @@ connection.request('POST', '/1/events/Error', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 Note that Parse currently only stores the first eight dimension pairs per call to `/1/events/<eventName>`.

--- a/_includes/rest/apps.md
+++ b/_includes/rest/apps.md
@@ -22,14 +22,14 @@ and use the header `X-Parse-Account-Key` instead.
 To fetch the keys and settings for all of the apps that you are a collaborator
 on, run:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Email: <PARSE_ACCOUNT_EMAIL>" \
   -H "X-Parse-Password: <PARSE_ACCOUNT_PASSWORD>" \
   -H "Content-Type: application/json" \
   https://api.parse.com/1/apps
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -40,11 +40,11 @@ connection.request('GET', '/1/apps', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The response body is JSON containing the keys and settings for your apps.
 
-<pre><code class="json">
+````json
 {
   "results": [
     {
@@ -64,18 +64,18 @@ The response body is JSON containing the keys and settings for your apps.
     ...
   ]
 }
-</code></pre>
+````
 
 To fetch the keys and settings of a single app, run:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Email: <PARSE_ACCOUNT_EMAIL>" \
   -H "X-Parse-Password: <PARSE_ACCOUNT_PASSWORD>" \
   -H "Content-Type: application/json" \
   https://api.parse.com/1/apps/${APPLICATION_ID}
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -86,7 +86,7 @@ connection.request('GET', '/1/apps/${APPLICATION_ID}', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Creating apps
 
@@ -105,15 +105,15 @@ The default values for the allowable settings are:
 | `requireRevocableSessions`      | true          |
 | `revokeSessionOnPasswordChange` | true          |
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Email: <PARSE_ACCOUNT_EMAIL>" \
   -H "X-Parse-Password: <PARSE_ACCOUNT_PASSWORD>" \
   -H "Content-Type: application/json" \
   -d '{"appName":"my new app","clientClassCreationEnabled":false}' \
   https://api.parse.com/1/apps
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -126,21 +126,21 @@ connection.request('POST', '/1/apps', json.dumps(
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Updating apps
 
 You can change your app's name, as well as change your app's settings, by sending a PUT request to `/1/apps`:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Email: ${PARSE_ACCOUNT_EMAIL}" \
   -H "X-Parse-Password: <PARSE_ACCOUNT_PASSWORD>" \
   -H "Content-Type: application/json" \
   -d '{"appName":"updated app name","clientClassCreationEnabled":true}' \
   https://api.parse.com/1/apps/${APPLICATION_ID}
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -153,4 +153,4 @@ connection.request('PUT', '/1/apps/${APPLICATION_ID}', json.dumps(
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````

--- a/_includes/rest/cloud-code.md
+++ b/_includes/rest/cloud-code.md
@@ -4,15 +4,15 @@
 
 Cloud Functions can be called using the REST API. For example, to call the Cloud Function named `hello`:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{}' \
   https://api.parse.com/1/functions/hello
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -24,7 +24,7 @@ connection.request('POST', '/1/functions/hello', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ##  Background Jobs
 
@@ -34,15 +34,15 @@ Similarly, you can trigger a background job from the REST API. For example, to t
   Take a look at the <a href="/docs/cloudcode/guide#cloud-code-cloud-functions">Cloud Code Guide</a> to learn more about Cloud Functions and Background Jobs.
 </div></div>
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"plan":"paid"}' \
   https://api.parse.com/1/jobs/userMigration
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -55,4 +55,4 @@ connection.request('POST', '/1/jobs/userMigration', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````

--- a/_includes/rest/config.md
+++ b/_includes/rest/config.md
@@ -6,13 +6,13 @@
 
 After that you will be able to fetch the config on the client by sending a `GET` request to config URL. Here is a simple example that will fetch the `Parse.Config`:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   https://api.parse.com/1/config
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -22,29 +22,29 @@ connection.request('GET', '/1/config', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The response body is a JSON object containing all the configuration parameters in the `params` field.
 
-<pre><code class="json">
+````json
 {
   "params": {
     "welcomeMessage": "Welcome to The Internet!",
     "winningNumber": 42
   }
 }
-</code></pre>
+````
 
 You can also update the config by sending a `PUT` request to config URL. Here is a simple example that will update the `Parse.Config`:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -d "{\"params\":{\"winningNumber\":43}}"
   https://api.parse.com/1/config
-</code></pre>
-<pre><code class="javascript">
+````
+````javascript
 var request = require('request');
 return request({
   method: 'PUT',
@@ -58,12 +58,12 @@ return request({
     params: { winningNumber: 43 }
   }
 })
-</code></pre>
+````
 
 The response body is a JSON object containing a simple boolean value in the `result` field.
 
-<pre><code class="json">
+````json
 {
   "result": true
 }
-</code></pre>
+````

--- a/_includes/rest/files.md
+++ b/_includes/rest/files.md
@@ -4,15 +4,15 @@
 
 To upload a file to Parse, send a POST request to the files URL, postfixed with the name of the file. The request must contain the `Content-Type` header associated with the file. Keep in mind that files are limited to 10 megabytes. Here's a simple example that'll create a file named `hello.txt` containing a string:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: text/plain" \
   -d 'Hello, World!' \
   https://api.parse.com/1/files/hello.txt
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -23,35 +23,35 @@ connection.request('POST', '/1/files/hello.txt', 'Hello, World!', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 When the file upload is successful, the HTTP response is a `201 Created` and the `Location` header which contains the URL for the file:
 
-<pre><code class="javascript">
+````javascript
 Status: 201 Created
 Location: http://files.parsetfss.com/bc9f32df-2957-4bb1-93c9-ec47d9870a05/tfss-db295fb2-8a8b-49f3-aad3-dd911142f64f-hello.txt
-</code></pre>
+````
 
 The response body is a JSON object containing the `name` of the file, which is the original file name prefixed with a unique identifier in order to prevent name collisions. This means you can save files with the same name, and the files will not overwrite one another.
 
-<pre><code class="json">
+````json
 {
   "url": "http://files.parsetfss.com/bc9f32df-2957-4bb1-93c9-ec47d9870a05/tfss-db295fb2-8a8b-49f3-aad3-dd911142f64f-hello.txt",
   "name": "db295fb2-8a8b-49f3-aad3-dd911142f64f-hello.txt"
 }
-</code></pre>
+````
 
 To upload an image, the syntax is a little bit different. Here's an example that will upload the image `myPicture.jpg` from the current directory.
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: image/jpeg" \
   --data-binary '@myPicture.jpg' \
   https://api.parse.com/1/files/pic.jpg
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -62,13 +62,13 @@ connection.request('POST', '/1/files/pic.jpg', open('myPicture.jpg', 'rb').read(
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Associating with Objects
 
 After files are uploaded, you can associate them with Parse objects:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -81,8 +81,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/classes/PlayerProfile
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -99,7 +99,7 @@ connection.request('POST', '/1/classes/PlayerProfile', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 Note that the name of the file in the request is not the local file name, but the name in the response of the previous upload operation.
 
@@ -108,13 +108,13 @@ Note that the name of the file in the request is not the local file name, but th
 
 Users holding the master key are allowed to delete files using the REST API. To delete a file, send a DELETE request to the files URL, postfixed with the name of the file. Note that the name of the file must be the name in the response of the upload operation, rather than the original filename. Note that the `X-Parse-Master-Key` must be provided in headers.
 
-<pre><code class="bash">
+````bash
 curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   https://api.parse.com/1/files/...profile.png
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -124,6 +124,6 @@ connection.request('DELETE', '/1/files/...profile.png', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 Note that deleting a PFObject with a file associated with it will not delete the file. All files stored on Parse should be deleted by using the above explained API.

--- a/_includes/rest/geopoints.md
+++ b/_includes/rest/geopoints.md
@@ -6,7 +6,7 @@ Parse allows you to associate real-world latitude and longitude coordinates with
 
 To associate a point with an object you will need to embed a `GeoPoint` data type into your object.  This is done by using a JSON object with `__type` set to the string `GeoPoint` and numeric values being set for the `latitude` and `longitude` keys.  For example, to create an object containing a point under the "location" key with a latitude of 40.0 degrees and -30.0 degrees longitude:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -19,8 +19,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/classes/PlaceObject
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -37,13 +37,13 @@ connection.request('POST', '/1/classes/PlaceObject', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Geo Queries
 
 Now that you have a bunch of objects with spatial coordinates, it would be nice to find out which objects are closest to a point.  This can be done by using a `GeoPoint` data type with query on the field using `$nearSphere`.  Getting a list of ten places that are closest to a user may look something like:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -59,8 +59,8 @@ curl -X GET \
         }
       }' \
   https://api.parse.com/1/classes/PlaceObject
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"limit":10,"where":json.dumps({
@@ -79,11 +79,11 @@ connection.request('GET', '/1/classes/PlaceObject?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 This will return a list of results ordered by distance from 30.0 latitude and -20.0 longitude. The first result will be the nearest object. (Note that if an explicit `order` parameter is supplied, it will take precedence over the distance ordering.) For example, here are two results returned for the above query: 
 
-<pre><code class="json">
+````json
 {
   "results": [
     {
@@ -108,11 +108,11 @@ This will return a list of results ordered by distance from 30.0 latitude and -2
     }
   ]
 }
-</code></pre>
+````
 
 To limit the search to a maximum distance add a `$maxDistanceInMiles` (for miles), `$maxDistanceInKilometers` (for kms), or `$maxDistanceInRadians` (for radian angle), term to the key constraint.  For example, the following limits the radius to 10 miles:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -128,8 +128,8 @@ curl -X GET \
         }
       }' \
   https://api.parse.com/1/classes/PlaceObject
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -149,11 +149,11 @@ connection.request('GET', '/1/classes/PlaceObject?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 It's also possible to query for the set of objects that are contained within a particular area.  To find the objects in a rectangular bounding box, add a clause to the key constraint with the format `{"$within": {"$box": {[southwestGeoPoint, northeastGeoPoint]}}}`.
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -177,8 +177,8 @@ curl -X GET \
         }
       }' \
   https://api.parse.com/1/classes/PizzaPlaceObject
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -206,7 +206,7 @@ connection.request('GET', '/1/classes/PizzaPlaceObject?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Caveats
 

--- a/_includes/rest/hooks.md
+++ b/_includes/rest/hooks.md
@@ -27,38 +27,38 @@ These are the generic concepts encapsulating both use cases:
 `Cloud Trigger` is either a `cloud code trigger` or a `trigger webhook`.
 
 A function webhook has a name and a url. Hence, its JSON response looks like:
-<pre><code class="json">
+````json
 {"functionName": "foo", "url": "https://api.example.com/foo"}
-</code></pre>
+````
 
 JSON reponse for a cloud code function just contains the function name.
-<pre><code class="json">
+````json
 {"functionName": "foo"}
-</code></pre>
+````
 
 A trigger webhook belongs to a class, has a trigger name and a url. Hence, its JSON response looks like:
-<pre><code class="json">
+````json
 {"className": "score", "triggerName": "beforeSave", "url": "https://api.example.com/score/beforeSave"}
-</code></pre>
+````
 
 JSON response for a cloud code trigger contains the class name and the trigger name.
-<pre><code class="json">
+````json
 {"className": "score", "triggerName": "beforeSave"}
-</code></pre>
+````
 Note that trigger name can only be one of `beforeSave`, `afterSave`, `beforeDelete` and `afterDelete`.
 
 
 ## Fetch functions
 To fetch the list of all cloud functions you deployed or created, use:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   https://api.parse.com/1/hooks/functions
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -69,10 +69,10 @@ connection.request('GET', '/1/hooks/functions', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The output is a json object with one key: "results" whose value is a list of cloud functions.
-<pre><code class="json">
+````json
 {
   "results": [
     { "functionName": "sendMessage", "url": "https://api.example.com/sendMessage" },
@@ -81,18 +81,18 @@ The output is a json object with one key: "results" whose value is a list of clo
     { "functionName": "bar" }
   ]
 }
-</code></pre>
+````
 
 To fetch a single cloud function with a given name, use:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   https://api.parse.com/1/hooks/functions/sendMessage
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -103,29 +103,29 @@ connection.request('GET', '/1/hooks/functions/sendMessage', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The output is a json object with one key: "results" whose value is a list of cloud functions with the given name.
 
-<pre><code class="json">
+````json
 {
   "results": [
     { "functionName": "sendMessage", "url": "https://api.example.com/sendMessage" },
     { "functionName": "sendMessage" }
   ]
 }
-</code></pre>
+````
 
 ## Fetch triggers
 To fetch the list of all cloud triggers you deployed or created, use:
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   https://api.parse.com/1/hooks/triggers
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -136,10 +136,10 @@ connection.request('GET', '/1/hooks/triggers', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The output is a json object with one key: "results" whose value is a list of cloud triggers.
-<pre><code class="json">
+````json
 {
   "results": [
     { "className": "Scores", "triggerName": "beforeSave" },
@@ -156,17 +156,17 @@ The output is a json object with one key: "results" whose value is a list of clo
     { "className": "Tournament", "triggerName": "beforeDelete" }
   ]
 }
-</code></pre>
+````
 
 To fetch a single cloud trigger, use:
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   https://api.parse.com/1/hooks/triggers/Scores/beforeSave
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -177,13 +177,13 @@ connection.request('GET', '/1/hooks/triggers/Scores/beforeSave', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The path looks like `/hooks/triggers/className/triggerName` where `triggerName`
 can be one of `beforeSave`, `afterSave`, `beforeDelete`, `afterDelete`.
 
 The output may look like this:
-<pre><code class="json">
+````json
 {
   "results": [
     { "className": "Scores", "triggerName": "beforeSave" },
@@ -194,7 +194,7 @@ The output may look like this:
     }
   ]
 }
-</code></pre>
+````
 
 The output is a json object with one key: "results" whose value is a list of all
 cloud triggers with given name for a given class.
@@ -205,21 +205,21 @@ and perform a `parse deploy` the usual way.
 
 ## Create function webhook
 To create a new function webhook post to `/1/hooks/functions` with payload in the format
-<pre><code class="bash">
+````bash
 {"functionName" : x, "url" : y}
-</code></pre>
+````
 
 Post example,
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"functionName":"baz","url":"https://api.example.com/baz"}' \
   https://api.parse.com/1/hooks/functions
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -232,27 +232,27 @@ connection.request('POST', '/1/hooks/functions', json.dumps(
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The output may look like this:
-<pre><code class="json">
+````json
 {"functionName": "baz", "url": "https://api.example.com/baz"}'
-</code></pre>
+````
 
 It returns the function name and url of the created webhook.
 
 If you try to create a function webhook and a cloud code function with the same name already exists, upon successful creation the response json has an additional `warning` field informing about the name conflict. Note that, function webhooks takes precedence over cloud code functions.
 
 For example,
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"functionName":"bar","url":"https://api.example.com/bar"}' \
   https://api.parse.com/1/hooks/functions
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -265,36 +265,36 @@ connection.request('POST', '/1/hooks/functions', json.dumps(
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The output may look like this:
-<pre><code class="json">
+````json
 {
   "functionName": "bar",
   "url": "https://api.example.com/bar",
   "warning": "a cloudcode function with name: bar already exists"
 }
-</code></pre>
+````
 
 ## Create trigger webhook
 To create a new function webhook post to `/1/hooks/triggers` with payload in the format
-<pre><code class="bash">
+````bash
 {"className": x, "triggerName": y, "url": z}
-</code></pre>
-<pre><code class="python">
+````
+````python
 {"className": x, "triggerName": y, "url": z}
-</code></pre>
+````
 
 Post example,
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"className": "Game", "triggerName": "beforeSave", "url": "https://api.example.com/Game/beforeSave"}' \
 https://api.parse.com/1/hooks/triggers
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -307,31 +307,31 @@ connection.request('POST', '/1/hooks/triggers', json.dumps(
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The output may look like this:
-<pre><code class="json">
+````json
 {
   "className": "Game",
   "triggerName": "beforeSave",
   "url": "https://api.example.com/Game/beforeSave"
 }
-</code></pre>
+````
 
 It returns the class name, trigger name and url of the created trigger webhook.
 
 If you try to create a trigger webhook and a cloud code trigger with the same name already exists, upon successful creation the response json has an additional `warning` field informing about the name conflict. Note that, trigger webhooks takes precedence over cloud code triggers.
 
 For example,
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"className": "Tournament", "triggerName": "beforeDelete", "url": "https://api.example.com/Scores/beforeDelete"}' \
 https://api.parse.com/1/hooks/triggers
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -344,31 +344,31 @@ connection.request('POST', '/1/hooks/triggers', json.dumps(
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The output may look like this:
-<pre><code class="json">
+````json
 {
   "className": "Tournament",
   "triggerName": "beforeDelete",
   "url": "https://api.example.com/Tournament/beforeDelete",
   "warning": "beforeDelete trigger already defined for class Tournament in cloud code"
 }
-</code></pre>
+````
 
 ## Edit function webhook
 To edit the url of a function webhook that was already created use the put method.
 
 Put example,
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"url":"https://api.example.com/_baz"}' \
   https://api.parse.com/1/hooks/functions/baz
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -381,27 +381,27 @@ connection.request('PUT', '/1/hooks/functions/baz', json.dumps(
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The output may look like this:
-<pre><code class="json">
+````json
 {"functionName": "baz", "url": "https://api.example.com/baz"}'
-</code></pre>
+````
 
 It returns the function name and url of the modified webhook.
 
 If you try to update a function webhook and a cloud code function with the same name already exists, upon successful update the response json has an additional `warning` field informing about the name conflict. Note that, function webhooks takes precedence over cloud code functions.
 
 For example,
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"url":"https://api.example.com/_bar"}' \
   https://api.parse.com/1/hooks/functions/bar
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -414,29 +414,29 @@ connection.request('PUT', '/1/hooks/functions/bar', json.dumps(
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The output may look like this:
-<pre><code class="json">
+````json
 {
   "functionName": "bar",
   "url": "https://api.example.com/_bar",
   "warning": "a cloudcode function with name: bar already exists"
 }
-</code></pre>
+````
 
 ## Edit trigger webhook
 To edit the url of a trigger webhook that was already crated use the put method.
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"url": "https://api.example.com/Game/_beforeSave"}' \
 https://api.parse.com/1/hooks/triggers/Game/beforeSave
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -449,31 +449,31 @@ connection.request('PUT', '/1/hooks/triggers/Game/beforeSave', json.dumps(
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The output may look like this:
-<pre><code class="json">
+````json
 {
   "className": "Game",
   "triggerName": "beforeSave",
   "url": "https://api.example.com/Game/_beforeSave"
 }
-</code></pre>
+````
 
 It returns the class name, trigger name and url of the modified trigger webhook.
 
 If you try to update a trigger webhook and a cloud code trigger with the same name already exists, upon successful update the response json has an additional `warning` field informing about the name conflict. Note that, trigger webhooks takes precedence over cloud code triggers.
 
 For example,
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"url": "https://api.example.com/Scores/beforeDelete"}' \
 https://api.parse.com/1/hooks/triggers/Tournament/beforeDelete
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -486,30 +486,30 @@ connection.request('PUT', '/1/hooks/triggers/Tournament/beforeDelete', json.dump
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The output may look like this:
-<pre><code class="json">
+````json
 {
   "className": "Tournament",
   "triggerName": "beforeDelete",
   "url": "https://api.example.com/Tournament/beforeDelete",
   "warning": "beforeDelete trigger already defined for class Tournament in cloud code"
 }
-</code></pre>
+````
 
 ## Delete function webhook
 To delete a function webhook use the put method.
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"__op": "Delete"}' \
 https://api.parse.com/1/hooks/functions/foo
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -522,25 +522,25 @@ connection.request('PUT', '/1/hooks/functions/foo', json.dumps(
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The output may look like this:
-<pre><code class="json">
+````json
 {}
-</code></pre>
+````
 
 If a cloud code function with the same name already exists then it is returned as the result.
 Since the overriding webhook was just deleted, this cloud code function will be run the next time sendMessage is called.
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{ "__op": "Delete" }' \
 https://api.parse.com/1/hooks/functions/sendMessage
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -553,25 +553,25 @@ connection.request('PUT', '/1/hooks/functions/sendMessage', json.dumps(
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The output may look like this:
-<pre><code class="json">
+````json
 { "functionName": "sendMessage" }
-</code></pre>
+````
 
 ## Delete trigger webhook
 To delete a trigger webhook use the put method.
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{ "__op": "Delete" }' \
 https://api.parse.com/1/hooks/triggers/Game/beforeSave
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -584,25 +584,25 @@ connection.request('PUT', '/1/hooks/triggers/Game/beforeSave', json.dumps(
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The output may look like this:
-<pre><code class="json">
+````json
 {}
-</code></pre>
+````
 
 If a cloud code trigger with the same name already exists then the it is returned as the result.
 Since the overriding webhook was just deleted, this cloud code trigger will be run the next time a Tournament object is saved.
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{ "__op": "Delete" }' \
 https://api.parse.com/1/hooks/triggers/Tournament/beforeDelete
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -615,12 +615,12 @@ connection.request('PUT', '/1/hooks/triggers/Tournament/beforeDelete', json.dump
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The output may look like this:
-<pre><code class="json">
+````json
 {
   "className": "Tournament",
   "triggerName": "beforeDelete"
 }
-</code></pre>
+````

--- a/_includes/rest/objects.md
+++ b/_includes/rest/objects.md
@@ -6,13 +6,13 @@ Storing data through the Parse REST API is built around a JSON encoding of the o
 
 For example, let's say you're tracking high scores for a game. A single object could contain:
 
-<pre><code class="json">
+````json
 {
   "score": 1337,
   "playerName": "Sean Plott",
   "cheatMode": false
 }
-</code></pre>
+````
 
 Keys must be alphanumeric strings. Values can be anything that can be JSON-encoded.
 
@@ -20,7 +20,7 @@ Each object has a class name that you can use to distinguish different sorts of 
 
 When you retrieve objects from Parse, some fields are automatically added: `createdAt`, `updatedAt`, and `objectId`. These field names are reserved, so you cannot set them yourself. The object above could look like this when retrieved:
 
-<pre><code class="json">
+````json
 {
   "score": 1337,
   "playerName": "Sean Plott",
@@ -29,43 +29,43 @@ When you retrieve objects from Parse, some fields are automatically added: `crea
   "updatedAt": "2011-08-20T02:06:57.931Z",
   "objectId": "Ed1nuqPvcm"
 }
-</code></pre>
+````
 
 `createdAt` and `updatedAt` are UTC timestamps stored in ISO 8601 format with millisecond precision: `YYYY-MM-DDTHH:MM:SS.MMMZ`. `objectId` is a string unique to this class that identifies this object.
 
 In the REST API, the class-level operations operate on a resource based on just the class name. For example, if the class name is `GameScore`, the class URL is:
 
-<pre><code class="javascript">
+````javascript
 https://api.parse.com/1/classes/GameScore
-</code></pre>
+````
 
 Users have a special class-level url:
 
-<pre><code class="javascript">
+````javascript
 https://api.parse.com/1/users
-</code></pre>
+````
 
 The operations specific to a single object are available a nested URL. For example, operations specific to the `GameScore` above with `objectId` equal to `Ed1nuqPvcm` would use the object URL:
 
-<pre><code class="javascript">
+````javascript
 https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
-</code></pre>
+````
 
 
 ## Creating Objects
 
 To create a new object on Parse, send a POST request to the class URL containing the contents of the object. For example, to create the object described above:
 
-<pre><code class="bash">
+````bash
   curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"score":1337,"playerName":"Sean Plott","cheatMode":false}' \
   https://api.parse.com/1/classes/GameScore
-</code></pre>
+````
 
-<pre><code class="python">
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -80,35 +80,35 @@ connection.request('POST', '/1/classes/GameScore', json.dumps({
      })
 results = json.loads(connection.getresponse().read())
 print results
-</code></pre>
+````
 
 When the creation is successful, the HTTP response is a `201 Created` and the `Location` header contains the object URL for the new object:
 
-<pre><code class="javascript">
+````javascript
 Status: 201 Created
 Location: https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
-</code></pre>
+````
 
 The response body is a JSON object containing the `objectId` and the `createdAt` timestamp of the newly-created object:
 
-<pre><code class="json">
+````json
 {
   "createdAt": "2011-08-20T02:06:57.931Z",
   "objectId": "Ed1nuqPvcm"
 }
-</code></pre>
+````
 
 ## Retrieving Objects
 
 Once you've created an object, you can retrieve its contents by sending a GET request to the object URL returned in the location header. For example, to retrieve the object we created above:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -118,11 +118,11 @@ connection.request('GET', '/1/classes/GameScore/Ed1nuqPvcm', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The response body is a JSON object containing all the user-provided fields, plus the `createdAt`, `updatedAt`, and `objectId` fields:
 
-<pre><code class="json">
+````json
 {
   "score": 1337,
   "playerName": "Sean Plott",
@@ -135,19 +135,19 @@ The response body is a JSON object containing all the user-provided fields, plus
   "updatedAt": "2011-08-20T02:06:57.931Z",
   "objectId": "Ed1nuqPvcm"
 }
-</code></pre>
+````
 
 When retrieving objects that have pointers to children, you can fetch child objects by using the `include` option. For instance, to fetch the object pointed to by the "game" key:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'include=game' \
   https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"include":"game"})
@@ -158,21 +158,21 @@ connection.request('GET', '/1/classes/GameScore/Ed1nuqPvcm?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Updating Objects
 
 To change the data on an object that already exists, send a PUT request to the object URL. Any keys you don't specify will remain unchanged, so you can update just a subset of the object's data. For example, if we wanted to change the score field of our object:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"score":73453}' \
   https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -185,29 +185,29 @@ connection.request('PUT', '/1/classes/GameScore/Ed1nuqPvcm', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The response body is a JSON object containing just an `updatedAt` field with the timestamp of the update.
 
-<pre><code class="json">
+````json
 {
   "updatedAt": "2011-08-21T18:02:52.248Z"
 }
-</code></pre>
+````
 
 ### Counters
 
 To help with storing counter-type data, Parse provides the ability to atomically increment (or decrement) any number field. So, we can increment the score field like so:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"score":{"__op":"Increment","amount":1}}' \
   https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -223,19 +223,19 @@ connection.request('PUT', '/1/classes/GameScore/Ed1nuqPvcm', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 To decrement the counter, use the `Increment` operator with a negative number:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"score":{"__op":"Increment","amount":-1}}' \
   https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -251,7 +251,7 @@ connection.request('PUT', '/1/classes/GameScore/Ed1nuqPvcm', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ### Arrays
 
@@ -263,15 +263,15 @@ To help with storing array data, there are three operations that can be used to 
 
 Each method takes an array of objects to add or remove in the "objects" key. For example, we can add items to the set-like "skills" field like so:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"skills":{"__op":"AddUnique","objects":["flying","kungfu"]}}' \
   https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -290,21 +290,21 @@ connection.request('PUT', '/1/classes/GameScore/Ed1nuqPvcm', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ### Relations
 
  In order to update `Relation` types, Parse provides special operators to atomically add and remove objects to a relation.  So, we can add an object to a relation like so:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"opponents":{"__op":"AddRelation","objects":[{"__type":"Pointer","className":"Player","objectId":"Vx4nudeWn"}]}}' \
   https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -326,19 +326,19 @@ connection.request('PUT', '/1/classes/GameScore/Ed1nuqPvcm', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 To remove an object from a relation, you can do:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"opponents":{"__op":"RemoveRelation","objects":[{"__type":"Pointer","className":"Player","objectId":"Vx4nudeWn"}]}}' \
   https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -360,19 +360,19 @@ connection.request('PUT', '/1/classes/GameScore/Ed1nuqPvcm', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Deleting Objects
 
 To delete an object from the Parse Cloud, send a DELETE request to its object URL. For example:
 
-<pre><code class="bash">
+````bash
 curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -382,19 +382,19 @@ connection.request('DELETE', '/1/classes/GameScore/Ed1nuqPvcm', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 You can delete a single field from an object by using the `Delete` operation:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"opponents":{"__op":"Delete"}}' \
   https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -409,7 +409,7 @@ connection.request('PUT', '/1/classes/GameScore/Ed1nuqPvcm', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Batch Operations
 
@@ -417,7 +417,7 @@ To reduce the amount of time spent on network round trips, you can create, updat
 
 Each command in a batch has `method`, `path`, and `body` parameters that specify the HTTP command that would normally be used for that command. The commands are run in the order they are given. For example, to create a couple of `GameScore` objects:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -443,8 +443,8 @@ curl -X POST \
         ]
       }' \
   https://api.parse.com/1/batch
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -474,33 +474,33 @@ connection.request('POST', '/1/batch', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The response from batch will be a list with the same number of elements as the input list. Each item in the list with be a dictionary with either the `success` or `error` field set. The value of `success` will be the normal response to the equivalent REST command:
 
-<pre><code class="json">
+````json
 {
   "success": {
     "createdAt": "2012-06-15T16:59:11.276Z",
     "objectId": "YAfSAWwXbL"
   }
 }
-</code></pre>
+````
 
 The value of `error` will be an object with a numeric `code` and `error` string:
 
-<pre><code class="json">
+````json
 {
   "error": {
     "code": 101,
     "error": "object not found for delete"
   }
 }
-</code></pre>
+````
 
 Other commands that work in a batch are `update` and `delete`.
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -521,8 +521,8 @@ curl -X POST \
         ]
       }' \
   https://api.parse.com/1/batch
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -547,7 +547,7 @@ connection.request('POST', '/1/batch', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 Note that N requests sent in a batch will still count toward your request limit as N requests.
 
@@ -568,24 +568,24 @@ So far we have only used values that can be encoded with standard JSON. The Pars
 
 The `Date` type contains a field `iso` which contains a UTC timestamp stored in ISO 8601 format with millisecond precision: `YYYY-MM-DDTHH:MM:SS.MMMZ`.
 
-<pre><code class="json">
+````json
 {
   "__type": "Date",
   "iso": "2011-08-21T18:02:52.249Z"
 }
-</code></pre>
+````
 
 Dates are useful in combination with the built-in `createdAt` and `updatedAt` fields. For example, to retrieve objects created since a particular time, just encode a Date in a comparison query:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"createdAt":{"$gte":{"__type":"Date","iso":"2011-08-21T18:02:52.249Z"}}}' \
   https://api.parse.com/1/classes/GameScore
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -603,38 +603,38 @@ connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The `Pointer` type is used when mobile code sets another Parse `Object` as the value of another object. It contains the `className` and `objectId` of the referred-to value.
 
-<pre><code class="json">
+````json
 {
   "__type": "Pointer",
   "className": "GameScore",
   "objectId": "Ed1nuqPvc"
 }
-</code></pre>
+````
 
 Note that the built-in `User`, `Role`, and `Installation` classes are prefixed by an underscore. For example, pointers to user objects have a `className` of `_User`. Prefixing with an underscore is forbidden for developer-defined classes as it signifies the class is a special built-in.
 
 The `Relation` type is used for many-to-many relations. It has a `className` that is the class name of the target objects.
 
-<pre><code class="json">
+````json
 {
   "__type": "Relation",
   "className": "GameScore"
 }
-</code></pre>
+````
 
 When querying, `Relation` objects behave like arrays of Pointers. Any operation that is valid for arrays of pointers (other than `include`) works for `Relation` objects.
 
 We do not recommend storing large pieces of binary data like images or documents on a Parse object. Parse objects should not exceed 128 kilobytes in size. To store more, we recommend you use `File`. You may associate a [previously uploaded file](#files) using the `File` type.
 
-<pre><code class="json">
+````json
 {
   "__type": "File",
   "name": "...profile.png"
 }
-</code></pre>
+````
 
 When more data types are added, they will also be represented as hashes with a `__type` field set, so you may not use this field yourself on JSON objects. For more information about how Parse handles data, check out our documentation on [Data](#data).

--- a/_includes/rest/push-notifications.md
+++ b/_includes/rest/push-notifications.md
@@ -28,7 +28,7 @@ Most of the time, installation data is modified by push-related methods in the c
 
 Creating an installation object is similar to creating a generic object, but the special installation fields listed above must pass validation. For example, if you have a device token provided by the Apple Push Notification service and would like to subscribe it to the broadcast channel `""`, you can use the following command:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -41,8 +41,8 @@ curl -X POST \
         ]
       }' \
   https://api.parse.com/1/installations
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -59,23 +59,23 @@ connection.request('POST', '/1/installations', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 When the creation is successful, the HTTP response is a `201 Created` and the `Location` header contains the URL for the new installation:
 
-<pre><code class="javascript">
+````javascript
 Status: 201 Created
 Location: https://api.parse.com/1/installations/mrmBZvsErB
-</code></pre>
+````
 
 The response body is a JSON object containing the `objectId` and the `createdAt` timestamp of the newly-created installation:
 
-<pre><code class="json">
+````json
 {
   "createdAt": "2012-04-28T17:41:09.106Z",
   "objectId": "mrmBZvsErB"
 }
-</code></pre>
+````
 
 When creating Android installation objects containing GCM (Google Cloud Messaging) credentials, you must have at least the following fields in your installation object:
 
@@ -86,7 +86,7 @@ When creating Android installation objects containing GCM (Google Cloud Messagin
 
 You could create and object with these fields using a command like this:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -101,8 +101,8 @@ curl -X POST \
         ]
       }' \
   https://api.parse.com/1/installations
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -121,7 +121,7 @@ connection.request('POST', '/1/installations', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 If you upload Android installations with GCM credentials, then you must also set the GCM API Key associated with this GCM sender ID in your application's push settings.
 
@@ -129,13 +129,13 @@ If you upload Android installations with GCM credentials, then you must also set
 
 You can retrieve the contents of an installation object by sending a GET request to the URL returned in the location header when it was created. For example, to retrieve the installation created above:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   https://api.parse.com/1/installations/mrmBZvsErB
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -145,11 +145,11 @@ connection.request('GET', '/1/installations/mrmBZvsErB', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The response body is a JSON object containing all the user-provided fields, plus the `createdAt`, `updatedAt`, and `objectId` fields:
 
-<pre><code class="json">
+````json
 {
   "deviceType": "ios",
   "deviceToken": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -160,13 +160,13 @@ The response body is a JSON object containing all the user-provided fields, plus
   "updatedAt": "2012-04-28T17:41:09.106Z",
   "objectId": "mrmBZvsErB"
 }
-</code></pre>
+````
 
 ### Updating Installations
 
 Installation objects can be updated by sending a PUT request to the installation URL. For example, to subscribe the installation above to the "foo" push channel:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -180,8 +180,8 @@ curl -X PUT \
         ]
       }' \
   https://api.parse.com/1/installations/mrmBZvsErB
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -199,7 +199,7 @@ connection.request('PUT', '/1/installations/mrmBZvsErB', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 Note that there is a restriction on updating the `deviceToken` field of Installation objects. You can only update the `deviceToken` field of an Installation object if contains a non-nil `installationId` field.
 
@@ -209,13 +209,13 @@ You can retrieve multiple installations at once by sending a GET request to the 
 
 Without any URL parameters, a GET request simply lists installations:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   https://api.parse.com/1/installations
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -225,11 +225,11 @@ connection.request('GET', '/1/installations', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The return value is a JSON object that contains a results field with a JSON array that lists the users.
 
-<pre><code class="json">
+````json
 {
   "results": [
     {
@@ -254,7 +254,7 @@ The return value is a JSON object that contains a results field with a JSON arra
     }
   ]
 }
-</code></pre>
+````
 
 All of the options for queries that work for regular objects also work for installation objects, so check the section on [Querying Objects](#queries-basic-queries) for more details. By doing an array query over `channels`, for example, you can find the set of devices subscribed to a given push channel.
 
@@ -263,13 +263,13 @@ All of the options for queries that work for regular objects also work for insta
 
 To delete an installation from the Parse Cloud, send a DELETE request to its URL. This functionality is not available in the client SDKs, so you must authenticate this method using the `X-Parse-Master-Key` header in your request instead of the `X-Parse-REST-API-Key` header. Your master key allows you to bypass ACLs and should only be used from within a trusted environment. For example:
 
-<pre><code class="bash">
+````bash
 curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   https://api.parse.com/1/installations/mrmBZvsErB
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -279,7 +279,7 @@ connection.request('DELETE', '/1/installations/mrmBZvsErB', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Sending Pushes
 
@@ -297,7 +297,7 @@ A channel is identified by a string that starts with a letter and consists of al
 
 Subscribing to a channel via the REST API can be done by updating the `Installation` object. We send a PUT request to the `Installation` URL and update the `channels` field. For example, in a baseball score app, we could do:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -308,8 +308,8 @@ curl -X PUT \
         ]
       }' \
   https://api.parse.com/1/installations/mrmBZvsErB
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -324,7 +324,7 @@ connection.request('PUT', '/1/installations/mrmBZvsErB', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 Once subscribed to the "Giants" channel, your `Installation` object should have an updated `channels` field.
 
@@ -336,7 +336,7 @@ To unsubscribe from a channel you would need to update the `channels` array and 
 
 With the REST API, the following code can be used to alert all subscribers of the "Giants" and "Mets" channels about the results of the game. This will display a notification center alert to iOS users and a system tray notification to Android users.
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -351,8 +351,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/push
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -371,7 +371,7 @@ connection.request('POST', '/1/push', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ### Using Advanced Targeting
 
@@ -383,7 +383,7 @@ Since `Installation` objects are just like any other object stored in Parse, you
 
 Storing arbitrary data on an `Installation` object is done in the same way we store data on [any other object](#objects) on Parse. In our Baseball app, we could allow users to get pushes about game results, scores and injury reports.
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -394,8 +394,8 @@ curl -X PUT \
         "injuryReports": true
       }' \
   https://api.parse.com/1/installations/mrmBZvsErB
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -410,11 +410,11 @@ connection.request('PUT', '/1/installations/mrmBZvsErB', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 You can even create relationships between your `Installation` objects and other classes saved on Parse. To associate an Installation with a particular user, for example, you can use a pointer to the `_User` class on the `Installation`.
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -427,8 +427,8 @@ curl -X PUT \
         }
       }' \
   https://api.parse.com/1/installations/mrmBZvsErB
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -445,13 +445,13 @@ connection.request('PUT', '/1/installations/mrmBZvsErB', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 #### Sending Pushes to Queries
 
 Once you have your data stored on your `Installation` objects, you can use a query to target a subset of these devices. `Installation` queries work just like any other [Parse query](#queries).
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -465,8 +465,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/push
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -484,11 +484,11 @@ connection.request('POST', '/1/push', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 We can even use channels with our query. To send a push to all subscribers of the "Giants" channel but filtered by those who want score update, we can do the following:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -503,8 +503,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/push
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -523,11 +523,11 @@ connection.request('POST', '/1/push', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 If we store relationships to other objects in our `Installation` class, we can also use those in our query. For example, we could send a push notification to all users near a given location like this.
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -552,8 +552,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/push
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -582,7 +582,7 @@ connection.request('POST', '/1/push', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 An in depth look at the `Installation` end point can be found in the [REST guide](#push-notifications-installations).
 
@@ -604,7 +604,7 @@ If you want to send more than just a message, you can set other fields in the `d
 
 For example, to send a notification that increases the current badge number by 1 and plays a custom sound for iOS devices, and displays a particular title for Android users, you can do the following:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -621,8 +621,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/push
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -643,13 +643,13 @@ connection.request('POST', '/1/push', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 It is also possible to specify your own data in this dictionary. As explained in the Receiving Notifications section for [iOS](/docs/ios/guide#push-notifications-receiving-pushes) and [Android](/docs/android/guide#push-notifications-receiving-pushes), iOS will give you access to this data only when the user opens your app via the notification and Android will provide you this data in the `Intent` if one is specified.
 
-<pre><code class="bash">
-</code></pre>
-<pre><code class="python">
+````bash
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -670,7 +670,7 @@ connection.request('POST', '/1/push', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ### Setting an Expiration Date
 
@@ -678,7 +678,7 @@ When a user's device is turned off or not connected to the internet, push notifi
 
 There are two parameters provided by Parse to allow setting an expiration date for your notification. The first is `expiration_time` which takes a date (in ISO 8601 format or Unix epoch time) specifying when Parse should stop trying to send the notification. To expire the notification exactly 1 week from now, you can use the following command.
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -690,8 +690,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/push
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -707,11 +707,11 @@ connection.request('POST', '/1/push', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 Alternatively, you can use the `expiration_interval` parameter to specify a duration of time before your notification expired. This value is relative to the `push_time` parameter used to [schedule notifications](#push-notifications-scheduling-pushes). This means that a push notification scheduled to be sent out in 1 day and an expiration interval of 6 days can be received up to a week from March 16th, 2015.
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -724,8 +724,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/push
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -742,14 +742,14 @@ connection.request('POST', '/1/push', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 ### Targeting by Platform
 
 If you build a cross platform app, it is possible you may only want to target iOS or Android devices. There are two methods provided to filter which of these devices are targeted. Note that both platforms are targeted by default.
 
 The following examples would send a different notification to Android, iOS, and Windows users.
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -763,8 +763,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/push
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -782,9 +782,9 @@ connection.request('POST', '/1/push', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -798,8 +798,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/push
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -817,9 +817,9 @@ connection.request('POST', '/1/push', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -833,8 +833,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/push
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -852,9 +852,9 @@ connection.request('POST', '/1/push', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -868,8 +868,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/push
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -887,13 +887,13 @@ connection.request('POST', '/1/push', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Scheduling Pushes
 
 You can schedule a push in advance by specifying a `push_time`. For example, if a user schedules a game reminder for a game on March 19th, 2015 at noon UTC, you can schedule the push notification by sending:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -908,8 +908,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/push
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -928,7 +928,7 @@ connection.request('POST', '/1/push', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 If you also specify an `expiration_interval`, it will be calculated from the scheduled push time, not from the time the push is submitted. This means a push scheduled to be sent in a week with an expiration interval of a day will expire 8 days after the request is sent.
 

--- a/_includes/rest/queries.md
+++ b/_includes/rest/queries.md
@@ -4,13 +4,13 @@
 
 You can retrieve multiple objects at once by sending a GET request to the class URL. Without any URL parameters, this simply lists objects in the class:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   https://api.parse.com/1/classes/GameScore
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -20,11 +20,11 @@ connection.request('GET', '/1/classes/GameScore', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The return value is a JSON object that contains a `results` field with a JSON array that lists the objects.
 
-<pre><code class="json">
+````json
 {
   "results": [
     {
@@ -45,22 +45,22 @@ The return value is a JSON object that contains a `results` field with a JSON ar
     }
   ]
 }
-</code></pre>
+````
 
 
 ## Query Constraints
 
 There are several ways to put constraints on the objects found, using the `where` URL parameter. The value of the `where` parameter should be encoded JSON. Thus, if you look at the actual URL requested, it would be JSON-encoded, then URL-encoded. The simplest use of the `where` parameter is constraining the value for keys. For example, if we wanted to retrieve Sean Plott's scores that were not in cheat mode, we could do:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"playerName":"Sean Plott","cheatMode":false}' \
   https://api.parse.com/1/classes/GameScore
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -74,7 +74,7 @@ connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The values of the `where` parameter also support comparisons besides exact matching. Instead of an exact value, provide a hash with keys corresponding to the comparisons to do. The `where` parameter supports these options:
 
@@ -95,15 +95,15 @@ The values of the `where` parameter also support comparisons besides exact match
 
 For example, to retrieve scores between 1000 and 3000, including the endpoints, we could issue:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"score":{"$gte":1000,"$lte":3000}}' \
   https://api.parse.com/1/classes/GameScore
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -119,19 +119,19 @@ connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 To retrieve scores equal to an odd number below 10, we could issue:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"score":{"$in":[1,3,5,7,9]}}' \
   https://api.parse.com/1/classes/GameScore
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -152,11 +152,11 @@ connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 To retrieve scores not by a given list of players we could issue:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -171,8 +171,8 @@ curl -X GET \
    }
   }' \
   https://api.parse.com/1/classes/GameScore
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -191,19 +191,19 @@ connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 To retrieve documents with the score set, we could issue:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"score":{"$exists":true}}' \
   https://api.parse.com/1/classes/GameScore
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -218,19 +218,19 @@ connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 To retrieve documents without the score set, we could issue:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"score":{"$exists":false}}' \
   https://api.parse.com/1/classes/GameScore
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -245,19 +245,19 @@ connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 If you have a class containing sports teams and you store a user's hometown in the user class, you can issue one query to find the list of users whose hometown teams have winning records.  The query would look like:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"hometown":{"$select":{"query":{"className":"Team","where":{"winPct":{"$gt":0.5}}},"key":"city"}}}' \
   https://api.parse.com/1/classes/_User
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -282,7 +282,7 @@ connection.request('GET', '/1/classes/_User?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 In addition to `where`, there are several parameters you can use to configure what types of results are returned by the query.
 
@@ -296,15 +296,15 @@ In addition to `where`, there are several parameters you can use to configure wh
 
 You can use the `order` parameter to specify a field to sort by. Prefixing with a negative sign reverses the order. Thus, to retrieve scores in ascending order:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'order=score' \
   https://api.parse.com/1/classes/GameScore
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"order":"score"})
@@ -315,19 +315,19 @@ connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 And to retrieve scores in descending order:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'order=-score' \
   https://api.parse.com/1/classes/GameScore
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"order":"-score"})
@@ -338,19 +338,19 @@ connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 You can sort by multiple fields by passing `order` a comma-separated list. To retrieve documents that are ordered by scores in ascending order and the names in descending order:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'order=score,-name' \
   https://api.parse.com/1/classes/GameScore
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"order":"score,-name"})
@@ -361,11 +361,11 @@ connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 You can use the `limit` and `skip` parameters for pagination. `limit` defaults to 100, but anything from 1 to 1000 is a valid limit. Thus, to retrieve 200 objects after skipping the first 400:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -373,8 +373,8 @@ curl -X GET \
   --data-urlencode 'limit=200' \
   --data-urlencode 'skip=400' \
   https://api.parse.com/1/classes/GameScore
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"limit":200,"skip":400})
@@ -385,19 +385,19 @@ connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 You can restrict the fields returned by passing `keys` a comma-separated list. To retrieve documents that contain only the `score` and `playerName` fields (and also special built-in fields such as `objectId`, `createdAt`, and `updatedAt`):
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'keys=score,playerName' \
   https://api.parse.com/1/classes/GameScore
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"keys":"score,playerName"})
@@ -408,11 +408,11 @@ connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 All of these parameters can be used in combination with each other. For example:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -431,8 +431,8 @@ curl -X GET \
   --data-urlencode 'skip=400' \
   --data-urlencode 'keys=score,playerName' \
   https://api.parse.com/1/classes/GameScore
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({
@@ -456,22 +456,22 @@ connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 
 ##  Queries on Array Values
 
 For keys with an array type, you can find objects where the key's array value contains 2 by:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"arrayKey":2}' \
   https://api.parse.com/1/classes/RandomObject
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -484,19 +484,19 @@ connection.request('GET', '/1/classes/RandomObject?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 You can also use the `$all` operator to find objects with an array field which contains each of the values 2, 3, and 4 by:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"arrayKey":{"$all":[2,3,4]}}' \
   https://api.parse.com/1/classes/RandomObject
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -515,7 +515,7 @@ connection.request('GET', '/1/classes/RandomObject?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Queries on String Values
 
@@ -525,7 +525,7 @@ print result
 
 Use the `$regex` operator to restrict to string values that match a regular expression. Most regular expression queries in Parse are heavily throttled due to performance considerations. Use case sensitive, anchored queries where possible. Similar to a MySQL LIKE operator, anchored queries are indexed so they are efficient for large datasets. For example:
 
-<pre><code class="bash">
+````bash
 # Finds barbecue sauces that start with "Big Daddy"
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
@@ -533,8 +533,8 @@ curl -X GET \
   -G \
   --data-urlencode 'where={"name":{"$regex":"^Big Daddy"}}' \
   https://api.parse.com/1/classes/BarbecueSauce
-</code></pre>
-<pre><code class="python">
+````
+````python
 # Finds barbecue sauces that start with "Big Daddy"
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
@@ -550,7 +550,7 @@ connection.request('GET', '/1/classes/BarbecueSauce?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The above example will match any `BarbecueSauce` objects where the value in the "name" String key starts with "Big Daddy". For example, both "Big Daddy" and "Big Daddy's" will match, but "big daddy" or "BBQ Sauce: Big Daddy's" will not.
 
@@ -561,15 +561,15 @@ Queries that have regular expression constraints are very expensive, especially 
 
 There are several ways to issue queries for relational data. If you want to retrieve objects where a field matches a particular object, you can use a `where` clause with a `Pointer` encoded with `__type` just like you would use other data types. For example, if each `Comment` has a `Post` object in its `post` field, you can fetch comments for a particular `Post`:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"post":{"__type":"Pointer","className":"Post","objectId":"8TOXdXf3tz"}}' \
   https://api.parse.com/1/classes/Comment
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -586,19 +586,19 @@ connection.request('GET', '/1/classes/Comment?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 If you want to retrieve objects where a field contains an object that matches another query, you can use the `$inQuery` operator. Note that the default limit of 100 and maximum limit of 1000 apply to the inner query as well, so with large data sets you may need to construct queries carefully to get the desired behavior. For example, imagine you have Post class and a Comment class, where each Comment has a pointer to its parent Post. You can find comments on posts with images by doing:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"post":{"$inQuery":{"where":{"image":{"$exists":true}},"className":"Post"}}}' \
   https://api.parse.com/1/classes/Comment
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -620,19 +620,19 @@ connection.request('GET', '/1/classes/Comment?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 If you want to retrieve objects where a field contains an object that does not match another query, you can use the `$notInQuery` operator.  Imagine you have Post class and a Comment class, where each Comment has a pointer to its parent Post.  You can find comments on posts without images by doing:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"post":{"$notInQuery":{"where":{"image":{"$exists":true}},"className":"Post"}}}' \
   https://api.parse.com/1/classes/Comment
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -654,19 +654,19 @@ connection.request('GET', '/1/classes/Comment?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 If you want to retrieve objects that are members of `Relation` field of a parent object, you can use the `$relatedTo` operator.  Imagine you have a Post class and User class, where each Post can be liked by many users.  If the Users that liked a Post were stored in a `Relation` on the post under the key "likes", you can find the users that liked a particular post by:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"$relatedTo":{"object":{"__type":"Pointer","className":"Post","objectId":"8TOXdXf3tz"},"key":"likes"}}' \
   https://api.parse.com/1/users
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -686,11 +686,11 @@ connection.request('GET', '/1/users?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 In some situations, you want to return multiple types of related objects in one query. You can do this by passing the field to include in the `include` parameter. For example, let's say you are retrieving the last ten comments, and you want to retrieve their related posts at the same time:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -699,8 +699,8 @@ curl -X GET \
   --data-urlencode 'limit=10' \
   --data-urlencode 'include=post' \
   https://api.parse.com/1/classes/Comment
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"order":"-createdAt","limit":10,"include":"post"})
@@ -711,21 +711,21 @@ connection.request('GET', '/1/classes/Comment?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 Instead of being represented as a `Pointer`, the `post` field is now expanded into the whole object. `__type` is set to `Object` and `className` is provided as well. For example, a `Pointer` to a `Post` could be represented as:
 
-<pre><code class="json">
+````json
 {
   "__type": "Pointer",
   "className": "Post",
   "objectId": "8TOXdXf3tz"
 }
-</code></pre>
+````
 
 When the query is issued with an `include` parameter for the key holding this pointer, the pointer will be expanded to:
 
-<pre><code class="json">
+````json
 {
   "__type": "Object",
   "className": "Post",
@@ -734,11 +734,11 @@ When the query is issued with an `include` parameter for the key holding this po
   "updatedAt": "2011-12-06T20:59:34.428Z",
   "otherFields": "willAlsoBeIncluded"
 }
-</code></pre>
+````
 
 You can also do multi level includes using dot notation.  If you wanted to include the post for a comment and the post's author as well you can do:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -747,8 +747,8 @@ curl -X GET \
   --data-urlencode 'limit=10' \
   --data-urlencode 'include=post.author' \
   https://api.parse.com/1/classes/Comment
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"order":"-createdAt","limit":10,"include":"post.author"})
@@ -759,7 +759,7 @@ connection.request('GET', '/1/classes/Comment?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 You can issue a query with multiple fields included by passing a comma-separated list of keys as the `include` parameter.
 
@@ -770,7 +770,7 @@ Caveat: Count queries are rate limited to a maximum of 160 requests per minute. 
 
 If you are limiting your query, or if there are a very large number of results, and you want to know how many total results there are without returning them all, you can use the `count` parameter. For example, if you only care about the number of games played by a particular player:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -779,8 +779,8 @@ curl -X GET \
   --data-urlencode 'count=1' \
   --data-urlencode 'limit=0' \
   https://api.parse.com/1/classes/GameScore
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -793,16 +793,16 @@ connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 Since this requests a count as well as limiting to zero results, there will be a count but no results in the response.
 
-<pre><code class="json">
+````json
 {
   "results": [],
   "count": 1337
 }
-</code></pre>
+````
 
 With a nonzero limit, that request would return results as well as the count.
 
@@ -810,15 +810,15 @@ With a nonzero limit, that request would return results as well as the count.
 
  If you want to find objects that match one of several queries, you can use `$or` operator, with a JSONArray as its value.  For instance, if you want to find players with either have a lot of wins or a few wins, you can do:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"$or":[{"wins":{"$gt":150}},{"wins":{"$lt":5}}]}' \
   https://api.parse.com/1/classes/Player
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"where":json.dumps({
@@ -842,7 +842,7 @@ connection.request('GET', '/1/classes/Player?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 Any other constraints on the query are also applied to the object returned, so you can add other constraints to queries with `$or`.
 

--- a/_includes/rest/quick-reference.md
+++ b/_includes/rest/quick-reference.md
@@ -143,9 +143,9 @@ In the examples that follow, the keys for your app are included in the command. 
 
 You may also authenticate your REST API requests using basic HTTP authentication. For example, to retrieve an object you could set the URL using your Parse credentials in the following format:
 
-<pre><code class="json">
+````json
 https://myAppID:javascript-key=myJavaScriptKey@api.parse.com/1/classes/GameScore/Ed1nuqPvcm
-</code></pre>
+````
 
 For JavaScript usage, the Parse Cloud supports [cross-origin resource sharing](http://en.wikipedia.org/wiki/Cross-Origin_Resource_Sharing), so that you can use these headers in conjunction with XMLHttpRequest.
 
@@ -156,12 +156,12 @@ The response format for all requests is a JSON object.
 
 Whether a request succeeded is indicated by the HTTP status code. A 2xx status code indicates success, whereas a 4xx status code indicates failure. When a request fails, the response body is still JSON, but always contains the fields `code` and `error` which you can inspect to use for debugging. For example, trying to save an object with invalid keys will return the message:
 
-<pre><code class="json">
+````json
 {
   "code": 105,
   "error": "invalid field name: bl!ng"
 }
-</code></pre>
+````
 
 ## Calling from Client Apps
 

--- a/_includes/rest/roles.md
+++ b/_includes/rest/roles.md
@@ -18,7 +18,7 @@ Creating a new role differs from creating a generic object in that the `name` fi
 
 To create a new role, send a POST request to the roles root:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -32,8 +32,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/roles
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -51,11 +51,11 @@ connection.request('POST', '/1/roles', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 You can create a role with child roles or users by adding existing objects to the `roles` and `users` [relations](#objects-updating):
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -89,8 +89,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/roles
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -128,35 +128,35 @@ connection.request('POST', '/1/roles', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 When the creation is successful, the HTTP response is a `201 Created` and the Location header contains the object URL for the new object:
 
-<pre><code class="javascript">
+````javascript
 Status: 201 Created
 Location: https://api.parse.com/1/roles/mrmBZvsErB
-</code></pre>
+````
 
 The response body is a JSON object containing the `objectId` and `createdAt` timestamp of the newly-created object:
 
-<pre><code class="json">
+````json
 {
   "createdAt": "2012-04-28T17:41:09.106Z",
   "objectId": "mrmBZvsErB"
 }
-</code></pre>
+````
 
 ## Retrieving Roles
 
 You can also retrieve the contents of a role object by sending a GET request to the URL returned in the location header when it was created.  For example, to retrieve the role created above:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   https://api.parse.com/1/roles/mrmBZvsErB
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -166,11 +166,11 @@ connection.request('GET', '/1/roles/mrmBZvsErB', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The response body is a JSON object containing all of the fields on the role:
 
-<pre><code class="json">
+````json
 {
   "createdAt": "2012-04-28T17:41:09.106Z",
   "objectId": "mrmBZvsErB",
@@ -185,7 +185,7 @@ The response body is a JSON object containing all of the fields on the role:
   },
   "name": "Moderators"
 }
-</code></pre>
+````
 
 Note that the `users` and `roles` relations will not be visible in this JSON.  Instead, you must [query](#queries-relational) for the roles and users that belong to a given role using the `$relatedTo` operator.
 
@@ -196,7 +196,7 @@ Updating a role generally works like [updating any other object](#objects-updati
 
 For example, we can add two users to the "Moderators" role created above like so:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
@@ -219,8 +219,8 @@ curl -X PUT \
         }
       }' \
   https://api.parse.com/1/roles/mrmBZvsErB
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -247,11 +247,11 @@ connection.request('PUT', '/1/roles/mrmBZvsErB', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 Similarly, we can remove a child role from the "Moderators" role created above like so:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
@@ -269,8 +269,8 @@ curl -X PUT \
         }
       }' \
   https://api.parse.com/1/roles/mrmBZvsErB
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -292,7 +292,7 @@ connection.request('PUT', '/1/roles/mrmBZvsErB', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 Note that we've included the master key in the query above because the "Moderators" role has an ACL that restricts modification by the public.
 
@@ -301,13 +301,13 @@ Note that we've included the master key in the query above because the "Moderato
 
 To delete a role from the Parse Cloud, send a DELETE request to its URL.  For example:
 
-<pre><code class="bash">
+````bash
 curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   https://api.parse.com/1/roles/mrmBZvsErB
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -317,18 +317,18 @@ connection.request('DELETE', '/1/roles/mrmBZvsErB', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 Again, we pass the master key in order to bypass the ACL on the role itself.  Alternatively, we could pass an X-Parse-Session-Token for a user that has write access to the Role object (e.g. an Administrator).  For example:
 
-<pre><code class="bash">
+````bash
 curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: pnktnjyb996sj4p156gjtp4im" \
   https://api.parse.com/1/roles/mrmBZvsErB
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -339,7 +339,7 @@ connection.request('DELETE', '/1/roles/mrmBZvsErB', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Security
 
@@ -348,7 +348,7 @@ In addition to per-user permissions [as described above](#users-security), you c
 
 For example, to restrict an object to be readable by anyone in the "Members" role and writable by its creator and anyone in the "Moderators" role, you would specify an ACL like this:
 
-<pre><code class="json">
+````json
 {
   "8TOXdXf3tz": {
     "write": true
@@ -360,7 +360,7 @@ For example, to restrict an object to be readable by anyone in the "Members" rol
     "write": true
   }
 }
-</code></pre>
+````
 
 You are not required to specify read permissions for the user or the "Moderators" role if the user and role are already children of the "Members" role, since they will inherit read permissions granted to "Members".
 
@@ -371,7 +371,7 @@ As described above, one role can contain another, establishing a parent-child re
 
 These types of relationships are commonly found in applications with user-managed content, such as forums. Some small subset of users are "Administrators", with the highest level of access to tweaking the application's settings, creating new forums, setting global messages, and so on. Another set of users are "Moderators", who are responsible for ensuring that the content created by users remains appropriate. Any user with Administrator privileges should also be granted the permissions of any Moderator. To establish this relationship, you would make your "Administrators" role a child role of "Moderators" by adding the "Administrators" role to the `roles` relation on your "Moderators" object like this:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
@@ -389,8 +389,8 @@ curl -X PUT \
         }
       }' \
   https://api.parse.com/1/roles/<ModeratorsRoleObjectId>
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -412,4 +412,4 @@ connection.request('PUT', '/1/roles/<ModeratorsRoleObjectId>', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````

--- a/_includes/rest/schemas.md
+++ b/_includes/rest/schemas.md
@@ -15,14 +15,14 @@ To fetch the Schema for all the classes of your app, run:
 Note: `createdAt` and `updatedAt` are of type `Date` but they are represented
 as strings in object representation. This is a special case for the Parse API.
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   https://api.parse.com/1/schemas
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -33,11 +33,11 @@ connection.request('GET', '/1/schemas', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The response body is JSON containing all the schema information of the app.
 
-<pre><code class="json">
+````json
 {
   "results": [
     {
@@ -66,18 +66,18 @@ The response body is JSON containing all the schema information of the app.
     ...
   ]
 }
-</code></pre>
+````
 
 To fetch schema of a single class, run:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   https://api.parse.com/1/schemas/Game
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -88,14 +88,14 @@ connection.request('GET', '/1/schemas/Game', "", {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Adding a schema 
 
 When you add a new schema to your app, it creates an empty class with the provided
 fields and some default fields applicable to the class. To add the schema, run:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
@@ -110,8 +110,8 @@ curl -X POST \
       }
     }' \
   https://api.parse.com/1/schemas/City
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -124,13 +124,13 @@ connection.request('POST', '/1/schemas/Game', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Modifying the schema
 
 You can add or delete columns to a schema. To do so, run:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
@@ -145,8 +145,8 @@ curl -X PUT \
       }
     }' \
   https://api.parse.com/1/schemas/City
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -159,11 +159,11 @@ connection.request('PUT', '/1/schemas/City', json.dumps(
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 To delete a particular field, you need to use `{"__op" : "Delete" }`
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
@@ -178,8 +178,8 @@ curl -X PUT \
       }
     }' \
   https://api.parse.com/1/schemas/City
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -192,21 +192,21 @@ connection.request('PUT', '/1/schemas/Game', json.dumps(
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Removing a schema 
 
 You can only remove a schema from your app if it is empty (has 0 objects). 
 To do that, run:
 
-<pre><code class="bash">
+````bash
 curl -X DELETE\
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   https://api.parse.com/1/schemas/City
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -217,4 +217,4 @@ connection.request('PUT', '/1/schemas/City', "", {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````

--- a/_includes/rest/sessions.md
+++ b/_includes/rest/sessions.md
@@ -34,7 +34,7 @@ For mobile apps and websites, you should not create `Session` objects manually. 
 
 In "Parse for IoT" apps (e.g. Arduino or Embedded C), you may want to programmatically create a restricted session that can be transferred to an IoT device. In order to do this, you must first log in normally to obtain an unrestricted session token. Then, you can create a restricted session by providing this unrestricted session token:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -42,8 +42,8 @@ curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"customField":"value"}' \
   https://api.parse.com/1/sessions
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -57,13 +57,13 @@ connection.request('POST', '/1/sessions', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 In the above code, `r:pnktnjyb996sj4p156gjtp4im` is the unrestricted session token from the original user login.
 
 The response looks like:
 
-<pre><code class="javascript">
+````javascript
 {
   "createdAt": "2015-03-25T18:21:52.883Z",
   "createdWith": {
@@ -73,21 +73,21 @@ The response looks like:
   "restricted": true,
   "sessionToken": "r:aVrtljyb7E8xKo9256gfvp4n2"
 }
-</code></pre>
+````
 
 At this point, you can pass the session token `r:aVrtljyb7E8xKo9256gfvp4n2` to an IoT device so that it can access the current user's data.
 
 ## Retrieving Sessions
 
 If you have the session's objectId, you fetch the `Session` object as long as it belongs to the same user as your current session:
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
   https://api.parse.com/1/sessions/Axy98kq1B09
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -98,18 +98,18 @@ connection.request('GET', '/1/sessions/Axy98kq1B09', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 If you only have the session's token (from previous login or session create), you can validate and fetch the corresponding session by:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
   https://api.parse.com/1/sessions/me
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -120,13 +120,13 @@ connection.request('GET', '/1/sessions/me', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Updating Sessions
 
 Updating a session is analogous to updating a Parse object.
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -134,8 +134,8 @@ curl -X PUT \
   -H "Content-Type: application/json" \
   -d '{"customField":"value"}' \
   https://api.parse.com/1/sessions/Axy98kq1B09
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -146,20 +146,20 @@ connection.request('POST', '/1/logout', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Querying Sessions
 
 Querying for `Session` objects will only return objects belonging to the same user as your current session (due to the Session ACL). You can also add a where clause to your query, just like normal Parse objects.
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
   https://api.parse.com/1/sessions
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -170,7 +170,7 @@ connection.request('GET', '/1/sessions', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 
 
@@ -178,14 +178,14 @@ print result
 
 Deleting the Session object will revoke its session token and cause the user to be logged out on the device that's currently using this session token. When you have the session token, then you can delete its `Session` object by calling the logout endpoint:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
   https://api.parse.com/1/logout
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -196,18 +196,18 @@ connection.request('POST', '/1/logout', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 If you want to delete another `Session` object for your user, and you have its `objectId`, you can delete it (but not log yourself out) by:
 
-<pre><code class="bash">
+````bash
 curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
   https://api.parse.com/1/sessions/Axy98kq1B09
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -218,7 +218,7 @@ connection.request('DELETE', '/1/sessions/Axy98kq1B09', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 `X-Parse-Session-Token` authenticates the request as the user that also owns session `Axy98kq1B09`, which may have a different session token. You can only delete other sessions that belong to the same user.
 
@@ -233,7 +233,7 @@ The following API is most useful for "Parse for IoT" apps (e.g. Arduino or Embed
 3. IoT device connects to Internet via Wi-Fi, saves its `Installation` object.
 4. IoT device calls the following endpoint to associate the its `installationId` with its session. This endpoint only works with session tokens from restricted sessions. Please note that REST API calls from an IoT device should use the Client Key, not the REST API Key.
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Client-Key: ${CLIENT_KEY}" \
@@ -242,8 +242,8 @@ curl -X PUT \
   -H "Content-Type: application/json" \
   -d '{}' \
   https://api.parse.com/1/sessions/me
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -256,7 +256,7 @@ connection.request('PUT', '/1/sessions/me', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Security
 
@@ -270,7 +270,7 @@ Restricted sessions are prohibited from creating, modifying, or deleting any dat
 
 If you want to prevent restricted Sessions from modifying classes other than `User`, `Session`, or `Role`, you can write a Cloud Code `beforeSave` handler for that class:
 
-<pre><code class="javascript">
+````javascript
 Parse.Cloud.beforeSave("MyClass", function(request, response) {
   Parse.Session.current().then(function(session) {
     if (session.get('restricted')) {
@@ -279,7 +279,7 @@ Parse.Cloud.beforeSave("MyClass", function(request, response) {
     response.success();
   });
 });
-</code></pre>
+````
 You can configure Class-Level Permissions (CLPs) for the Session class just like other classes on Parse. CLPs restrict reading/writing of sessions via the `/1/sessions` API, but do not restrict Parse Cloud's automatic session creation/deletion when users log in, sign up, and log out. We recommend that you disable all CLPs not needed by your app. Here are some common use cases for Session CLPs:
 
 * **Find**, **Delete** — Useful for building a UI screen that allows users to see their active session on all devices, and log out of sessions on other devices. If your app does not have this feature, you should disable these permissions.

--- a/_includes/rest/users.md
+++ b/_includes/rest/users.md
@@ -12,7 +12,7 @@ You can ask Parse to verify user email addresses in your application settings pa
 
 To sign up a new user, send a POST request to the users root. You may add any additional fields. For example, to create a user with a specific phone number:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -20,8 +20,8 @@ curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"username":"cooldude6","password":"p_n7!-e8","phone":"415-392-0202"}' \
   https://api.parse.com/1/users
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -37,32 +37,32 @@ connection.request('POST', '/1/users', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 `The X-Parse-Revocable-Session` header tells Parse to return a [revocable session](#sessions) even if your app has "Require Revocable Sessions" turned off (at Parse.com app settings page). This is useful for [transitioning from legacy session tokens](https://www.parse.com/tutorials/session-migration-tutorial) to revocable sessions when your existing mobile app also accesses the same Parse data. If "Require Revocable Sessions" is turned on (default for new apps), the `X-Parse-Revocable-Session` header is unnecessary. When you ask for a revocable session during signup, the Parse Cloud will automatically create a `Session` object. On this request, you can also tell Parse to automatically attach an installation to that session by specifying the optional `X-Parse-Installation-Id` header with the `installationId` of that installation.
 
 When the creation is successful, the HTTP response is a `201 Created` and the `Location` header contains the URL for the new user:
 
-<pre><code class="javascript">
+````javascript
 Status: 201 Created
 Location: https://api.parse.com/1/users/g7y9tkhB7O
-</code></pre>
+````
 
 The response body is a JSON object containing the `objectId`, the `createdAt` timestamp of the newly-created object, and the `sessionToken` which can be used to authenticate subsequent requests as this user:
 
-<pre><code class="json">
+````json
 {
   "createdAt": "2011-11-07T20:58:34.448Z",
   "objectId": "g7y9tkhB7O",
   "sessionToken": "r:pnktnjyb996sj4p156gjtp4im"
 }
-</code></pre>
+````
 
 ## Logging In
 
 After you allow users to sign up, you need to let them log in to their account with a username and password in the future. To do this, send a GET request to the `/1/login` endpoint with `username` and `password` as URL-encoded parameters:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -71,8 +71,8 @@ curl -X GET \
   --data-urlencode 'username=cooldude6' \
   --data-urlencode 'password=p_n7!-e8' \
   https://api.parse.com/1/login
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib,urllib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 params = urllib.urlencode({"username":"cooldude6","password":"p_n7!-e8"})
@@ -84,13 +84,13 @@ connection.request('GET', '/1/login?%s' % params, '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 `The X-Parse-Revocable-Session` header tells Parse to return a [revocable session](#sessions) even if your app has "Require Revocable Sessions" turned off (at Parse.com app settings page). This is useful for [transitioning from legacy session tokens](https://www.parse.com/tutorials/session-migration-tutorial) to revocable sessions when your existing mobile app also accesses the same Parse data. If "Require Revocable Sessions" is turned on (default for new apps), the `X-Parse-Revocable-Session` header is unnecessary. When you ask for a revocable session during login, the Parse Cloud will automatically create a `Session` object. On this request, you can also tell Parse to automatically attach an installation to that session by specifying the optional `X-Parse-Installation-Id` header with the `installationId` of that installation.
 
 The response body is a JSON object containing all the user-provided fields except `password`. It also contains the `createdAt`, `updatedAt`, `objectId`, and `sessionToken` fields:
 
-<pre><code class="json">
+````json
 {
   "username": "cooldude6",
   "phone": "415-392-0202",
@@ -99,7 +99,7 @@ The response body is a JSON object containing all the user-provided fields excep
   "objectId": "g7y9tkhB7O",
   "sessionToken": "r:pnktnjyb996sj4p156gjtp4im"
 }
-</code></pre>
+````
 
 ## Verifying Emails
 
@@ -116,15 +116,15 @@ There are three `emailVerified` states to consider:
 
 You can initiate password resets for users who have emails associated with their account. To do this, send a POST request to `/1/requestPasswordReset` endpoint with `email` in the body of the request:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"email":"coolguy@iloveapps.com"}' \
   https://api.parse.com/1/requestPasswordReset
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -137,7 +137,7 @@ connection.request('POST', '/1/requestPasswordReset', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 If successful, the response body is an empty JSON object.
 
@@ -146,13 +146,13 @@ If successful, the response body is an empty JSON object.
 
 You can also retrieve the contents of a user object by sending a GET request to the URL returned in the location header when it was created. For example, to retrieve the user created above:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   https://api.parse.com/1/users/g7y9tkhB7O
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -162,11 +162,11 @@ connection.request('GET', '/1/users/g7y9tkhB7O', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The response body is a JSON object containing all the user-provided fields except `password`. It also contains the `createdAt`, `updatedAt`, and `objectId` fields:
 
-<pre><code class="json">
+````json
 {
   "username": "cooldude6",
   "phone": "415-392-0202",
@@ -174,20 +174,20 @@ The response body is a JSON object containing all the user-provided fields excep
   "updatedAt": "2011-11-07T20:58:34.448Z",
   "objectId": "g7y9tkhB7O"
 }
-</code></pre>
+````
 
 ## Validating Session Tokens / Retrieving Current User
 
 With a valid session token, you can send a GET request to the `/1/users/me` endpoint to retrieve the user associated with that session token:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
   https://api.parse.com/1/users/me
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -198,16 +198,16 @@ connection.request('GET', '/1/users/me', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The response matches the JSON object above for retrieving users.  If the session token is not valid, an error object is returned:
 
-<pre><code class="json">
+````json
 {
   "code": 209,
   "error": "invalid session token"
 }
-</code></pre>
+````
 
 ## Updating Users
 
@@ -217,7 +217,7 @@ To change the data on a user that already exists, send a PUT request to the user
 
 For example, if we wanted to change the phone number for `cooldude6`:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -225,8 +225,8 @@ curl -X PUT \
   -H "Content-Type: application/json" \
   -d '{"phone":"415-369-6201"}' \
   https://api.parse.com/1/users/g7y9tkhB7O
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -240,27 +240,27 @@ connection.request('PUT', '/1/users/g7y9tkhB7O', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The response body is a JSON object containing just an `updatedAt` field with the timestamp of the update.
 
-<pre><code class="json">
+````json
 {
   "updatedAt": "2011-11-07T21:25:10.623Z"
 }
-</code></pre>
+````
 
 ## Querying
 
 You can retrieve multiple users at once by sending a GET request to the root users URL. Without any URL parameters, this simply lists users:
 
-<pre><code class="bash">
+````bash
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   https://api.parse.com/1/users
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -270,11 +270,11 @@ connection.request('GET', '/1/users', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 The return value is a JSON object that contains a `results` field with a JSON array that lists the objects.
 
-<pre><code class="json">
+````json
 {
   "results": [
     {
@@ -293,7 +293,7 @@ The return value is a JSON object that contains a `results` field with a JSON ar
     }
   ]
 }
-</code></pre>
+````
 
 All of the options for queries that work for regular objects also work for user objects, so check the section on [Querying Objects](#queries-basic) for more details.
 
@@ -302,14 +302,14 @@ All of the options for queries that work for regular objects also work for user 
 
 To delete a user from the Parse Cloud, send a DELETE request to its URL. You must provide the `X-Parse-Session-Token` header to authenticate. For example:
 
-<pre><code class="bash">
+````bash
 curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
   https://api.parse.com/1/users/g7y9tkhB7O
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -320,7 +320,7 @@ connection.request('DELETE', '/1/users/g7y9tkhB7O', '', {
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Linking Users
 
@@ -330,7 +330,7 @@ Parse allows you to link your users with services like Twitter and Facebook, ena
 
 ### Facebook `authData`
 
-<pre><code class="json">
+````json
 {
   "facebook": {
     "id": "user's Facebook id number as a string",
@@ -338,12 +338,12 @@ Parse allows you to link your users with services like Twitter and Facebook, ena
     "expiration_date": "token expiration date of the format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
   }
 }
-</code></pre>
+````
 Learn more about [Facebook login](https://developers.facebook.com/docs/authentication/).
 
 ### Twitter `authData`
 
-<pre><code class="json">
+````json
 {
   "twitter": {
     "id": "user's Twitter id number as a string",
@@ -354,25 +354,25 @@ Learn more about [Facebook login](https://developers.facebook.com/docs/authentic
     "auth_token_secret": "the secret associated with the auth_token"
   }
 }
-</code></pre>
+````
 
 Learn more about [Twitter login](https://dev.twitter.com/docs/auth/implementing-sign-twitter).
 
 ### Anonymous user `authData`
 
-<pre><code class="json">
+````json
 {
   "anonymous": {
     "id": "random UUID with lowercase hexadecimal digits"
   }
 }
-</code></pre>
+````
 
 ### Signing Up and Logging In
 
 Signing a user up with a linked service and logging them in with that service uses the same POST request, in which the `authData` for the user is specified.  For example, to sign up or log in with a user's Twitter account:
 
-<pre><code class="bash">
+````bash
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -391,8 +391,8 @@ curl -X POST \
         }
       }' \
   https://api.parse.com/1/users
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -415,20 +415,20 @@ connection.request('POST', '/1/users', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 `The X-Parse-Revocable-Session` header tells Parse to return a [revocable session](#sessions) even if your app has "Require Revocable Sessions" turned off (at Parse.com app settings page). This is useful for [transitioning from legacy session tokens](https://www.parse.com/tutorials/session-migration-tutorial) to revocable sessions when your existing mobile app also accesses the same Parse data. If "Require Revocable Sessions" is turned on (default for new apps), the `X-Parse-Revocable-Session` header is unnecessary. When you ask for a revocable session during login or signup, the Parse Cloud will automatically create a `Session` object. On this request, you can also tell Parse to automatically attach an installation to that session by specifying the optional `X-Parse-Installation-Id` header with the `installationId` of that installation.
 
 Parse then verifies that the provided `authData` is valid and checks to see if a user is already associated with this data.  If so, it returns a status code of `200 OK` and the details (including a `sessionToken` for the user):
 
-<pre><code class="javascript">
+````javascript
 Status: 200 OK
 Location: https://api.parse.com/1/users/uMz0YZeAqc
-</code></pre>
+````
 
 With a response body like:
 
-<pre><code class="json">
+````json
 {
   "username": "Parse",
   "createdAt": "2012-02-28T23:49:36.353Z",
@@ -446,31 +446,31 @@ With a response body like:
     }
   }
 }
-</code></pre>
+````
 
 If the user has never been linked with this account, you will instead receive a status code of `201 Created`, indicating that a new user was created:
 
-<pre><code class="javascript">
+````javascript
 Status: 201 Created
 Location: https://api.parse.com/1/users/uMz0YZeAqc
-</code></pre>
+````
 
 The body of the response will contain the `objectId`, `createdAt`, `sessionToken`, and an automatically-generated unique `username`.  For example:
 
-<pre><code class="json">
+````json
 {
   "username": "iwz8sna7sug28v4eyu7t89fij",
   "createdAt": "2012-02-28T23:49:36.353Z",
   "objectId": "uMz0YZeAqc",
   "sessionToken": "r:samplei3l83eerhnln0ecxgy5"
 }
-</code></pre>
+````
 
 ### Linking
 
 Linking an existing user with a service like Facebook or Twitter uses a PUT request to associate `authData` with the user.  For example, linking a user with a Facebook account would use a request like this:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -486,8 +486,8 @@ curl -X PUT \
         }
       }' \
   https://api.parse.com/1/users/uMz0YZeAqc
-</code></pre>
-<pre><code class="python">
+````
+````python
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -507,7 +507,7 @@ connection.request('PUT', '/1/users/uMz0YZeAqc', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 After linking your user to a service, you can authenticate them using matching `authData`.
 
@@ -515,7 +515,7 @@ After linking your user to a service, you can authenticate them using matching `
 
 Unlinking an existing user with a service also uses a PUT request to clear `authData` from the user by setting the `authData` for the service to `null`.  For example, unlinking a user with a Facebook account would use a request like this:
 
-<pre><code class="bash">
+````bash
 curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
@@ -527,8 +527,8 @@ curl -X PUT \
         }
       }' \
   https://api.parse.com/1/users/uMz0YZeAqc
-</code></pre>
-<pre><code class="bash">
+````
+````bash
 import json,httplib
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
@@ -544,7 +544,7 @@ connection.request('PUT', '/1/users/uMz0YZeAqc', json.dumps({
      })
 result = json.loads(connection.getresponse().read())
 print result
-</code></pre>
+````
 
 ## Security
 
@@ -554,7 +554,7 @@ The ACL is formatted as a JSON object where the keys are either object ids or th
 
 For example, if you want the user with id `"3KmCvT7Zsb"` to have read and write access to an object, plus the object should be publicly readable, that corresponds to an ACL of:
 
-<pre><code class="json">
+````json
 {
   "3KmCvT7Zsb": {
     "read": true,
@@ -564,6 +564,6 @@ For example, if you want the user with id `"3KmCvT7Zsb"` to have read and write 
     "read": true
   }
 }
-</code></pre>
+````
 
 If you want to access your data ignoring all ACLs, you can use the master key provided on the Dashboard. Instead of the `X-Parse-REST-API-Key` header, set the `X-Parse-Master-Key` header. For backward compatibility, you can also do master-level authentication using HTTP Basic Auth, passing the application id as the username and the master key as the password. For security, the master key should not be distributed to end users, but if you are running code in a trusted environment, feel free to use the master key for authentication.

--- a/_includes/unity/analytics.md
+++ b/_includes/unity/analytics.md
@@ -10,9 +10,9 @@ Without having to implement any client-side logic, you can view real-time graphs
 
 Our initial analytics hook allows you to track your application being launched. By adding the following line to your Launching event handler, you'll be able to collect data on when and how often your application is opened.
 
-<pre><code class="cs">
+````cs
 ParseAnalytics.TrackAppOpenedAsync();
-</code></pre>
+````
 
 Graphs and breakdowns of your statistics are accessible from your app's Dashboard.
 
@@ -22,7 +22,7 @@ Graphs and breakdowns of your statistics are accessible from your app's Dashboar
 
 Say your app offers search functionality for apartment listings, and you want to track how often the feature is used, with some additional metadata.
 
-<pre><code class="cs">
+````cs
 var dimensions = new Dictionary<string, string> {
   // Define ranges to bucket data points into meaningful segments
   { "priceRange", "1000-1500" },
@@ -33,15 +33,15 @@ var dimensions = new Dictionary<string, string> {
 };
 // Send the dimensions to Parse along with the 'search' event
 ParseAnalytics.TrackEventAsync("search", dimensions);
-</code></pre>
+````
 
 `ParseAnalytics` can even be used as a lightweight error tracker &mdash; simply invoke the following and you'll have access to an overview of the rate and frequency of errors, broken down by error code, in your application:
 
-<pre><code class="cs">
+````cs
 var errDimensions = new Dictionary<string, string> {
   { "code", Convert.ToString(error.Code) }
 };
 ParseAnalytics.TrackEventAsync("error", errDimensions );
-</code></pre>
+````
 
 Note that Parse currently only stores the first eight dimension pairs per call to `ParseAnalytics.TrackEventAsync()`.

--- a/_includes/unity/config.md
+++ b/_includes/unity/config.md
@@ -8,7 +8,7 @@
 
 After that you will be able to fetch the `ParseConfig` on the client, like in this example:
 
-<pre><code class="cs">
+````cs
 ParseConfig.GetAsync().ContinueWith(t => 
 {
   if (t.isFaulted) {
@@ -17,13 +17,13 @@ ParseConfig.GetAsync().ContinueWith(t =>
     ParseConfig config = t.Result;
   }
 })
-</code></pre>
+````
 
 ## Retrieving Config
 
 `ParseConfig` is built to be as robust and reliable as possible, even in the face of poor internet connections. Caching is used by default to ensure that the latest successfully fetched config is always available. In the below example we use `GetAsync` to retrieve the latest version of config from the server, and if the fetch fails we can simply fall back to the version that we successfully fetched before via `CurrentConfig`.
 
-<pre><code class="cs">
+````cs
 ParseConfig.GetAsync().ContinueWith(t => 
 {
   ParseConfig config = null;
@@ -43,7 +43,7 @@ ParseConfig.GetAsync().ContinueWith(t =>
 
   Console.WriteLine(String.Format("Welcome Messsage From Config = {0}", welcomeMessage));
 })
-</code></pre>
+````
 
 ## Current Config
 
@@ -51,7 +51,7 @@ Every `ParseConfig` instance that you get is always immutable. When you retrieve
 
 It might be troublesome to retrieve the config from the server every time you want to use it. You can avoid this by simply using the cached `CurrentConfig` object and fetching the config only once in a while.
 
-<pre><code class="cs">
+````cs
 public class Helper
 {
   private static TimeSpan configRefreshInterval = TimeSpan.FromHours(12);
@@ -67,7 +67,7 @@ public class Helper
     }
   }
 }
-</code></pre>
+````
 
 ## Parameters
 

--- a/_includes/unity/files.md
+++ b/_includes/unity/files.md
@@ -6,10 +6,10 @@
 
 Getting started with `ParseFile` is easy. First, you'll need to have the data in `byte[]` or `Stream` form and then create a `ParseFile` with it. In this example, we'll just use a string:
 
-<pre><code class="cs">
+````cs
 byte[] data = System.Text.Encoding.UTF8.GetBytes("Working at Parse is great!");
 ParseFile file = new ParseFile("resume.txt", data);
-</code></pre>
+````
 
 Notice in this example that we give the file a name of `resume.txt`. There's two things to note here:
 
@@ -18,40 +18,40 @@ Notice in this example that we give the file a name of `resume.txt`. There's two
 
 Next you'll want to save the file up to the cloud. As with `ParseObject`, you can call `SaveAsync` to save the file to Parse.
 
-<pre><code class="cs">
+````cs
 Task saveTask = file.SaveAsync();
-</code></pre>
+````
 
 Finally, after the save completes, you can assign a `ParseFile` into a `ParseObject` just like any other piece of data:
 
-<pre><code class="cs">
+````cs
 var jobApplication = new ParseObject("JobApplication");
 jobApplication["applicantName"] = "Joe Smith";
 jobApplication["applicantResumeFile"] = file;
 Task saveTask = jobApplication.SaveAsync();
-</code></pre>
+````
 
 Retrieving it back involves downloading the resource at the `ParseFile`'s `Url`. Here we retrieve the resume file off another JobApplication object:
 
-<pre><code class="cs">
+````cs
 var applicantResumeFile = anotherApplication.Get<ParseFile>("applicantResumeFile");
 var resumeTextRequest = new WWW(applicantResumeFile.Url.AbsoluteUri);
 yield return resumeTextRequest;
 string resumeText = resumeTextRequest.text;
-</code></pre>
+````
 
 ## Progress
 
 It's easy to get the progress of `ParseFile` uploads by passing a `Progress` object to `SaveAsync`. For example:
 
-<pre><code class="cs">
+````cs
 byte[] data = System.Text.Encoding.UTF8.GetBytes("Working at Parse is great!");
 ParseFile file = new ParseFile("resume.txt", data);
 
 Task saveTask = file.SaveAsync(new Progress<ParseUploadProgressEventArgs>(e => {
     // Check e.Progress to get the progress of the file upload
 }));
-</code></pre>
+````
 
 You can delete files that are referenced by objects using the [REST API](/docs/rest#files-deleting). You will need to provide the master key in order to be allowed to delete a file.
 

--- a/_includes/unity/geopoints.md
+++ b/_includes/unity/geopoints.md
@@ -6,15 +6,15 @@ Parse allows you to associate real-world latitude and longitude coordinates with
 
 To associate a point with an object you first need to create a `ParseGeoPoint`.  For example, to create a point with latitude of 40.0 degrees and -30.0 degrees longitude:
 
-<pre><code class="cs">
+````cs
 var point = new ParseGeoPoint(40.0, -30.0);
-</code></pre>
+````
 
 This point is then stored in the object as a regular field.
 
-<pre><code class="cs">
+````cs
 placeObject["location"] = point;
-</code></pre>
+````
 
 Note: Currently only one key in a class may be a `ParseGeoPoint`.
 
@@ -22,7 +22,7 @@ Note: Currently only one key in a class may be a `ParseGeoPoint`.
 
 Now that you have a bunch of objects with spatial coordinates, it would be nice to find out which objects are closest to a point.  This can be done by adding another restriction to a `ParseQuery` using `WhereNear`.  Getting a list of ten places that are closest to a user may look something like:
 
-<pre><code class="cs">
+````cs
 // User's location
 var userGeoPoint = ParseUser.CurrentUser.Get<ParseGeoPoint>("location");
 // Create a query for places
@@ -36,7 +36,7 @@ query.FindAsync().ContinueWith(t =>
 {
     IEnumerable<ParseObject> nearbyPlaces = t.Result;
 });
-</code></pre>
+````
 
 At this point `placesObjects` will be an `IEnumerable<ParseObject>` of `PlaceObject`s ordered by distance (nearest to farthest) from `userGeoPoint`. 
 
@@ -44,7 +44,7 @@ To limit the results using distance check out `WhereWithinDistance`,.
 
 It's also possible to query for the set of objects that are contained within a particular area.  To find the objects in a rectangular bounding box, add the `WhereWithinGeoBox` restriction to your `ParseQuery`.
 
-<pre><code class="cs">
+````cs
 var swOfSF = new ParseGeoPoint(37.708813, -122.526398);
 var neOfSF = new ParseGeoPoint(37.822802, -122.373962);
 var query = ParseObject.GetQuery("PizzaPlaceObject")
@@ -53,21 +53,21 @@ query.FindAsync().ContinueWith(t =>
 {
     IEnumerable<ParseObject> pizzaPlacesInSF = t.Result;
 });
-</code></pre>
+````
 
 ## Geo Distances
 
 Parse makes it easy to find the distance between two GeoPoints and query based upon that distance. For example, to get a distance in kilometers between two points, you can use the `DistanceTo` method:
 
-<pre><code class="cs">
+````cs
 ParseGeoPoint p1 = /* Some location */;
 ParseGeoPoint p2 = /* Some other location */;
 double distanceInKm = p1.DistanceTo(p2).Kilometers;
-</code></pre>
+````
 
 You can also query for `ParseObject`s within a radius using a `ParseGeoDistance`. For example, to find all places within 5 miles of a user, you would use the `WhereWithinDistance` method:
 
-<pre><code class="cs">
+````cs
 ParseGeoPoint userGeoPoint = ParseUser.CurrentUser.Get<ParseGeoPoint>("location");
 ParseQuery<ParseObject> query = ParseObject.GetQuery("PlaceObject")
     .WhereWithinDistance("location", userGeoPoint, ParseGeoDistance.FromMiles(5));
@@ -76,7 +76,7 @@ query.FindAsync().ContinueWith(t =>
     IEnumerable<ParseObject> nearbyLocations = t.Result;
     // nearbyLocations contains PlaceObjects within 5 miles of the user's location
 });
-</code></pre>
+````
 
 At this point, `nearbyLocations` will be an array of objects ordered by distance (nearest to farthest) from `userGeoPoint`. Note that if an additional `OrderBy()` constraint is applied, it will take precedence over the distance ordering.
 

--- a/_includes/unity/getting-started.md
+++ b/_includes/unity/getting-started.md
@@ -10,7 +10,7 @@ Parse's Unity SDK makes heavy use of a subset of the [Task-based Asynchronous Pa
 ## Adding `link.xml`
 
 Create a file and name it `link.xml` under your Assets folder and put the following code to make sure Parse Unity SDK works with Unity code optimization pipeline:
-</code></pre>xml
+````xml
 <linker>
   <assembly fullname="UnityEngine">
     <type fullname="UnityEngine.iOS.NotificationServices" preserve="all"/>
@@ -24,4 +24,4 @@ Create a file and name it `link.xml` under your Assets folder and put the follow
     <namespace fullname="Parse.Internal" preserve="all"/>
   </assembly>
 </linker>
-</code></pre>
+````

--- a/_includes/unity/handling-errors.md
+++ b/_includes/unity/handling-errors.md
@@ -4,16 +4,16 @@ Parse has a few simple patterns for surfacing errors and handling them in your c
 
 There are two types of errors you may encounter. The first is those dealing with logic errors in the way you're using the SDK. These types of errors result in general `Exception` being raised. For an example take a look at the following code:
 
-<pre><code class="cs">
+````cs
 var user = new ParseUser();
 user.SignUpAsync();
-</code></pre>
+````
 
 This will throw an `InvalidOperationException` because `SignUpAsync` was called without first setting the required properties (`Username` and `Password`).
 
 The second type of error is one that occurs when interacting with the Parse Cloud over the network. These errors are either related to problems connecting to the cloud or problems performing the requested operation. For example, an error may result from an existing user trying to sign up. Here's how you could handle this error as well as the previous SDK logic errors:
 
-<pre><code class="cs">
+````cs
 try
 {
     user.SignUpAsync().ContinueWith(t => {
@@ -35,7 +35,7 @@ catch (InvalidOperationException e)
     // e.Message will contain the specific error
     // ex: "Cannot sign up user with an empty name."
 }
-</code></pre>
+````
 
 At the moment there are a couple of things to watch out for:
 
@@ -44,13 +44,13 @@ At the moment there are a couple of things to watch out for:
 
 Let's take a look at another error handling example:
 
-<pre><code class="cs">
+````cs
 ParseObject.GetQuery("Note").GetAsync("thisObjectIdDoesntExist");
-</code></pre>
+````
 
 In the above code, we try to fetch an object with a non-existent `ObjectId`. The Parse Cloud will return an error -- so here's how to handle it properly:
 
-<pre><code class="cs">
+````cs
 ParseObject.GetQuery("Note").GetAsync(someObjectId).ContinueWith(t =>
 {
     if (t.IsFaulted)
@@ -62,6 +62,6 @@ ParseObject.GetQuery("Note").GetAsync(someObjectId).ContinueWith(t =>
         // Everything went fine!
     }
 })
-</code></pre>
+````
 
 For a list of all possible `ErrorCode` types, scroll down to [Error Codes](#errors), or see the `ParseException.ErrorCode` section of the [.NET API](https://parse.com/docs/dotnet/api/html/T_Parse_ParseException_ErrorCode.htm).

--- a/_includes/unity/objects.md
+++ b/_includes/unity/objects.md
@@ -6,9 +6,9 @@ Storing data on Parse is built around the `ParseObject`. Each `ParseObject` cont
 
 For example, let's say you're tracking high scores for a game. A single `ParseObject` could contain:
 
-<pre><code class="json">
+````json
 score: 1337, playerName: "Sean Plott", cheatMode: false
-</code></pre>
+````
 
 Keys must start with a letter, and can contain alphanumeric characters and underscores. Values can be strings, numbers, booleans, or even arrays and dictionaries - anything that can be JSON-encoded.
 
@@ -18,19 +18,19 @@ Each `ParseObject` has a class name that you can use to distinguish different so
 
 Let's say you want to save the `GameScore` described above to the Parse Cloud. The interface is similar to an `IDictionary<string, object>`, plus the `SaveAsync` method:
 
-<pre><code class="cs">
+````cs
 ParseObject gameScore = new ParseObject("GameScore");
 gameScore["score"] = 1337;
 gameScore["playerName"] = "Sean Plott";
 Task saveTask = gameScore.SaveAsync();
-</code></pre>
+````
 
 After this code runs, you will probably be wondering if anything really happened. To make sure the data was saved, you can look at the Data Browser in your app on Parse. You should see something like this:
 
-<pre><code class="javascript">
+````javascript
 objectId: "xWMyZ4YEGZ", score: 1337, playerName: "Sean Plott", cheatMode: false,
 createdAt:"2011-06-10T18:33:42Z", updatedAt:"2011-06-10T18:33:42Z"
-</code></pre>
+````
 
 There are two things to note here. You didn't have to configure or set up a new Class called `GameScore` before running this code. Your Parse app lazily creates this Class for you when it first encounters it.
 
@@ -54,7 +54,7 @@ So far we've used values with type `string` and `int` assigned to fields of a `P
 
 Some examples:
 
-<pre><code class="cs">
+````cs
 int number = 42;
 string str = "the number is " + number;
 DateTime date = DateTime.Now;
@@ -72,7 +72,7 @@ bigObject["myDate"] = date;
 bigObject["myList"] = list;
 bigObject["myDictionary"] = dictionary;
 Task saveTask = bigObject.SaveAsync();
-</code></pre>
+````
 
 We do not recommend storing large pieces of binary data like images or documents on `ParseObject`. `ParseObject`s should not exceed 128 kilobytes in size. We recommend you use `ParseFile`s to store images, documents, and other types of files. You can do so by instantiating a `ParseFile` object and setting it on a field. See [Files](#files) for more details.
 
@@ -82,25 +82,25 @@ For more information about how Parse handles data, check out our documentation o
 
 Saving data to the cloud is fun, but it's even more fun to get that data out again. If you have the `ObjectId`, you can retrieve the whole `ParseObject` using a `ParseQuery`:
 
-<pre><code class="cs">
+````cs
 ParseQuery<ParseObject> query = ParseObject.GetQuery("GameScore");
 query.GetAsync("xWMyZ4YEGZ").ContinueWith(t =>
 {
     ParseObject gameScore = t.Result;
 });
-</code></pre>
+````
 
 To get the values out of the `ParseObject`, use the `Get<T>` method.
 
-<pre><code class="cs">
+````cs
 int score = gameScore.Get<int>("score");
 string playerName = gameScore.Get<string>("playerName");
 bool cheatMode = gameScore.Get<bool>("cheatMode");
-</code></pre>
+````
 
 Here are some examples for handling the various supported data types:
 
-<pre><code class="cs">
+````cs
 ParseObject bigObject = t.Result;
 int number = bigObject.Get<int>("myNumber");
 string str = bigObject.Get<string>("myString");
@@ -119,27 +119,27 @@ foreach (var item in list) {
 foreach (var key in dictionary.Keys) {
     Debug.Log ("Key: " + key + " Value: " + dictionary[key].ToString());
 }
-</code></pre>
+````
 
 The three special values are provided as properties:
 
-<pre><code class="cs">
+````cs
 string objectId = gameScore.ObjectId;
 DateTime? updatedAt = gameScore.UpdatedAt;
 DateTime? createdAt = gameScore.CreatedAt;
-</code></pre>
+````
 
 If you need to get an object's latest data from Parse, you can call the `FetchAsync` method like so:
 
-<pre><code class="cs">
+````cs
 Task<ParseObject> fetchTask = myObject.FetchAsync();
-</code></pre>
+````
 
 ## Updating Objects
 
 Updating an object is simple. Just set some new data on it and call one of the save methods. For example:
 
-<pre><code class="cs">
+````cs
 // Create the object.
 var gameScore = new ParseObject("GameScore")
 {
@@ -156,7 +156,7 @@ gameScore.SaveAsync().ContinueWith(t =>
     gameScore["score"] = 1338;
     gameScore.SaveAsync();
 });
-</code></pre>
+````
 
 The client automatically figures out which data has changed so only "dirty" fields will be sent to Parse. You don't need to worry about squashing data that you didn't intend to update.
 
@@ -166,10 +166,10 @@ The above example contains a common use case. The "score" field is a counter tha
 
 To help with storing counter-type data, Parse provides methods that atomically increment (or decrement) any number field. So, the same update can be rewritten as:
 
-<pre><code class="cs">
+````cs
 gameScore.Increment("score");
 Task saveTask = gameScore.SaveAsync();
-</code></pre>
+````
 
 You can also increment by any amount using `Increment(key, amount)`.
 
@@ -183,10 +183,10 @@ To help with storing list data, there are three operations that can be used to a
 
 For example, we can add items to the set-like "skills" field like so:
 
-<pre><code class="cs">
+````cs
 gameScore.AddRangeUniqueToList("skills", new[] { "flying", "kungfu" });
 Task saveTask = gameScore.SaveAsync();
-</code></pre>
+````
 
 Note that it is not currently possible to atomically add and remove items from a list in the same save. You will have to call `save` in between every different kind of list operation.
 
@@ -194,19 +194,19 @@ Note that it is not currently possible to atomically add and remove items from a
 
 To delete an object from the cloud:
 
-<pre><code class="cs">
+````cs
 Task deleteTask = myObject.DeleteAsync();
-</code></pre>
+````
 
 You can delete a single field from an object with the `Remove` method:
 
-<pre><code class="cs">
+````cs
 // After this, the playerName field will be empty
 myObject.Remove("playerName");
 
 // Saves the field deletion to the Parse Cloud
 Task saveTask = myObject.SaveAsync();
-</code></pre>
+````
 
 ## Relational Data
 
@@ -214,7 +214,7 @@ Objects can have relationships with other objects. To model one-to-many relation
 
 For example, each `Comment` in a blogging app might correspond to one `Post`. To create a new `Post` with a single `Comment`, you could write:
 
-<pre><code class="cs">
+````cs
 // Create the post
 var myPost = new ParseObject("Post")
 {
@@ -233,48 +233,48 @@ myComment["parent"] = myPost;
 
 // This will save both myPost and myComment
 Task saveTask = myComment.SaveAsync();
-</code></pre>
+````
 
 You can also link objects using just their `ObjectId`s like so:
 
-<pre><code class="cs">
+````cs
 myComment["parent"] = ParseObject.CreateWithoutData("Post", "1zEcyElZ80");
-</code></pre>
+````
 
 By default, when fetching an object, related `ParseObject`s are not fetched.  These objects' values cannot be retrieved until they have been fetched like so:
 
-<pre><code class="cs">
+````cs
 ParseObject post = fetchedComment.Get<ParseObject>("parent");
 Task<ParseObject> fetchTask = post.FetchIfNeededAsync();
-</code></pre>
+````
 
 For a many-to-many relationship, use the `ParseRelation` object.  This works similar to a `List<ParseObject>`, except that you don't need to download all the objects in a relation at once.  This allows `ParseRelation` to scale to many more objects than the `List<ParseObject>` approach.  For example, a `ParseUser` may have many `Post`s that they might like.  In this case, you can store the set of `Post`s that a `ParseUser` likes using `GetRelation`.  In order to add a post to the list, the code would look something like:
 
-<pre><code class="cs">
+````cs
 var user = ParseUser.CurrentUser;
 var relation = user.GetRelation<ParseObject>("likes");
 relation.Add(post);
 Task saveTask = user.SaveAsync();
-</code></pre>
+````
 
 You can remove a post from the `ParseRelation` with something like:
 
-<pre><code class="cs">
+````cs
 relation.Remove(post);
-</code></pre>
+````
 
 By default, the list of objects in this relation are not downloaded.  You can get the list of `Post`s by using calling `FindAsync` on the `ParseQuery` returned by `Query`.  The code would look like:
 
-<pre><code class="cs">
+````cs
 relation.Query.FindAsync().ContinueWith(t =>
 {
     IEnumerable<ParseObject> relatedObjects = t.Result;
 });
-</code></pre>
+````
 
 If you want only a subset of the `Post`s you can add extra constraints to the `ParseQuery` returned by `Query` like this:
 
-<pre><code class="cs">
+````cs
 var query = relation.Query
     .WhereGreaterThan("createdAt", DateTime.Now - TimeSpan.FromDays(10));
     // alternatively, add any other query constraints
@@ -282,7 +282,7 @@ query.FindAsync().ContinueWith(t =>
 {
     IEnumerable<ParseObject> relatedObjects = t.Result;
 });
-</code></pre>
+````
 
 For more details on `ParseQuery` please look at the [query](#queries) portion of this guide.  A `ParseRelation` behaves similar to a `List<ParseObject>`, so any queries you can do on lists of objects you can do on `ParseRelation`s.
 
@@ -290,7 +290,7 @@ For more details on `ParseQuery` please look at the [query](#queries) portion of
 
 Parse is designed to get you up and running as quickly as possible. You can access all of your data using the `ParseObject` class and access any field with `Get<T>()`. In mature codebases, subclasses have many advantages, including terseness, extensibility, type-safety, and support for code completion. Subclassing is completely optional, but can transform this code:
 
-<pre><code class="cs">
+````cs
 // Using dictionary-initialization syntax:
 var shield = new ParseObject("Armor")
 {
@@ -303,11 +303,11 @@ var shield = new ParseObject("Armor")
 Debug.Log(shield.Get<string>("displayName"));
 shield["fireproof"] = true;
 shield["rupees"] = 500;
-</code></pre>
+````
 
 Into this:
 
-<pre><code class="cs">
+````cs
 // Using object-initialization syntax:
 var shield = new Armor
 {
@@ -320,7 +320,7 @@ var shield = new Armor
 Debug.Log(shield.DisplayName);
 shield.IsFireproof = true;
 shield.Rupees = 500;
-</code></pre>
+````
 
 ### Subclassing ParseObject
 
@@ -333,7 +333,7 @@ To create a `ParseObject` subclass:
 
 The following code sucessfully implements and registers the `Armor` subclass of `ParseObject`:
 
-<pre><code class="cs">
+````cs
 // Armor.cs
 using Parse;
 
@@ -354,7 +354,7 @@ public class ExtraParseInitialization : MonoBehaviour
     ParseObject.RegisterSubclass<Armor>();
   }
 }
-</code></pre>
+````
 
 ### Properties and Methods
 
@@ -362,7 +362,7 @@ Adding methods and properties to your `ParseObject` subclass helps encapsulate l
 
 You can add properties for the fields of your `ParseObject` easily. Declare the getter and setter for the field as you normally would, but implement them in terms of `GetProperty<T>()` and `SetProperty<T>()`. Finally, add a `ParseFieldName` attribute to the property to fully integrate the property with Parse, enabling functionality like automatically raising `INotifyPropertyChanged` notifications for your objects. The following example creates a `displayName` field in the `Armor` class:
 
-<pre><code class="cs">
+````cs
 // Armor.cs
 [ParseClassName("Armor")]
 public class Armor : ParseObject
@@ -374,13 +374,13 @@ public class Armor : ParseObject
     set { SetProperty<string>(value, "DisplayName"); }
   }
 }
-</code></pre>
+````
 
 You can now access the displayName field using `armor.DisplayName` and assign to it using `armor.DisplayName = "Wooden Sword"`. This allows your IDE to provide autocompletion as you develop your app and allows typos to be caught at compile-time.
 
 `ParseRelation`-typed properties can also be easily defined using `GetRelationProperty<T>`. For example:
 
-<pre><code class="cs">
+````cs
 // Armor.cs
 [ParseClassName("Armor")]
 public class Armor : ParseObject
@@ -391,11 +391,11 @@ public class Armor : ParseObject
     get { return GetRelationProperty<ArmorAttribute>("Attributes"); }
   }
 }
-</code></pre>
+````
 
 If you need more complicated logic than simple field access, you can declare your own methods as well:
 
-<pre><code class="cs">
+````cs
 public void TakeDamage(int amount) {
   // Decrease the armor's durability and determine whether it has broken
   this.Increment("durability", -amount);
@@ -403,7 +403,7 @@ public void TakeDamage(int amount) {
     this.IsBroken = true;
   }
 }
-</code></pre>
+````
 
 ### Initializing Subclasses
 
@@ -411,19 +411,19 @@ You should create new instances of your subclasses using the constructors you ha
 
 To create a reference to an existing object, use `ParseObject.CreateWithoutData<T>()`:
 
-<pre><code class="cs">
+````cs
 var armorReference = ParseObject.CreateWithoutData<Armor>(armor.ObjectId);
-</code></pre>
+````
 
 ### Queries
 
 You can get a query for objects of a particular subclass using the generic `ParseQuery<T>` class. The following example queries for armors that the user can afford:
 
-<pre><code class="cs">
+````cs
 var query = new ParseQuery<Armor>()
     .WhereLessThanOrEqualTo("rupees", ((Player)ParseUser.CurrentUser).Rupees);
 query.FindAsync().ContinueWith(t =>
 {
     IEnumerable<Armor> result = t.Result;
 });
-</code></pre>
+````

--- a/_includes/unity/push-notifications.md
+++ b/_includes/unity/push-notifications.md
@@ -60,26 +60,26 @@ A channel is identified by a string that starts with a letter and consists of al
 
 An installation's channels can be set using the `Channels` property of `ParseInstallation`. For example, in a baseball score app, we could do:
 
-<pre><code class="cs">
+````cs
 // When users indicate they are Giants fans, we subscribe them to that channel.
 var installation = ParseInstallation.CurrentInstallation;
 installation.Channels = new List<string> { "Giants" };
 installation.SaveAsync();
-</code></pre>
+````
 
 Alternatively, you can insert a channel into `Channels` without affecting the existing channels using the `AddUniqueToList` method of `ParseObject` using the following:
 
-<pre><code class="cs">
+````cs
 var installation = ParseInstallation.CurrentInstallation;
 installation.AddUniqueToList("channels", "Giants");
 installation.SaveAsync();
-</code></pre>
+````
 
 Finally, `ParsePush` provides a shorthand for inserting a channel into `Channels` and saving:
 
-<pre><code class="cs">
+````cs
 ParsePush.SubscribeAsync("Giants");
-</code></pre>
+````
 
 Once subscribed to the "Giants" channel, your `Installation` object should have an updated `channels` field.
 
@@ -87,24 +87,24 @@ Once subscribed to the "Giants" channel, your `Installation` object should have 
 
 Unsubscribing from a channel is just as easy:
 
-<pre><code class="cs">
+````cs
 var installation = ParseInstallation.CurrentInstallation;
 installation.RemoveAllFromList("channels" new List<string> { "Giants" });
 installation.SaveAsync();
-</code></pre>
+````
 
 Or, using ParsePush:
 
-<pre><code class="cs">
+````cs
 ParsePush.UnsubscribeAsync("Giants");
-</code></pre>
+````
 
 The set of subscribed channels is cached in the `CurrentInstallation` object:
 
-<pre><code class="cs">
+````cs
 var installation = ParseInstallation.CurrentInstallation
 IEnumerable<string> subscribedChannels = installation.Channels;
-</code></pre>
+````
 
 If you plan on changing your channels from Cloud Code or the data browser, note that you'll need to call `FetchAsync` prior to this line in order to get the most recent channels.
 
@@ -112,13 +112,13 @@ If you plan on changing your channels from Cloud Code or the data browser, note 
 
 In the .NET SDK, the following code can be used to alert all subscribers of the "Giants" channel that their favorite team just scored. This will display a toast notification to Windows users. iOS users will receive a notification in the notification center and Android users will receive a notification in the system tray.
 
-<pre><code class="cs">
+````cs
 // Send a notification to all devices subscribed to the "Giants" channel.
 var push = new ParsePush();
 push.Channels = new List<string> {"Giants"};
 push.Alert = "The Giants just scored!";
 push.SendAsync();
-</code></pre>
+````
 
 If you want to target multiple channels with a single push notification, you can use any `IEnumerable<string>` of channels.
 
@@ -132,61 +132,61 @@ Since `ParseInstallation` is a subclass of `ParseObject`, you can save any data 
 
 Storing data on an `Installation` object is just as easy as storing [any other data](/docs/unity/guide#objects) on Parse. In our Baseball app, we could allow users to get pushes about game results, scores and injury reports.
 
-<pre><code class="cs">
+````cs
 // Store the category of push notifications the user would like to receive.
 var installation = ParseInstallation.CurrentInstallation;
 installation["scores"] = true;
 installation["gameResults"] = true;
 installation["injuryReports"] = true;
 installation.SaveAsync();
-</code></pre>
+````
 
 You can even create relationships between your `Installation` objects and other classes saved on Parse. To associate an Installation with a particular user, for example, you can simply store the current user on the `ParseInstallation`.
 
-<pre><code class="cs">
+````cs
 // Associate the device with a user
 var installation = ParseInstallation.CurrentInstallation;
 installation["user"] = ParseUser.CurrentUser;
 installation.SaveAsync();
-</code></pre>
+````
 
 #### Sending Pushes to Queries
 
 Once you have your data stored on your `Installation` objects, you can use a `ParseQuery` to target a subset of these devices. `Installation` queries work just like any other [Parse query](/docs/unity/guide#queries), but we use the special static property `ParseInstallation.Query` to create it. We set this query on our `ParsePush` object, before sending the notification.
 
-<pre><code class="cs">
+````cs
 var push = new ParsePush();
 push.Query = ParseInstallation.Query
              .WhereEqualTo("injuryReports", true);
 push.Alert = "Willie Hayes injured by own pop fly.";
 push.SendAsync();
-</code></pre>
+````
 
 We can even use channels with our query. To send a push to all subscribers of the "Giants" channel but filtered by those who want score update, we can do the following:
 
-<pre><code class="cs">
+````cs
 var push = new ParsePush();
 push.Query = ParseInstallation.Query
              .WhereEqualTo("scores", true);
 push.Channels = new List<string> { "Giants" };
 push.Alert = "Giants scored against the A's! It's now 2-2.";
 push.SendAsync();
-</code></pre>
+````
 
 Alternatively, we can use a query that constrains "channels" directly:
 
-<pre><code class="cs">
+````cs
 var push = new ParsePush();
 push.Query = ParseInstallation.Query
              .WhereEqualTo("scores", true)
              .WhereContainsAll("channels", new string[] { "Giants" });
 push.Alert = "Giants scored against the A's! It's now 2-2.";
 push.SendAsync();
-</code></pre>
+````
 
 If we store relationships to other objects in our `Installation` class, we can also use those in our query. For example, we could send a push notification to all users near a given location like this.
 
-<pre><code class="cs">
+````cs
 // Find users in the Seattle metro area
 var userQuery = ParseUser.Query.WhereWithinDistance(
     "location",
@@ -197,7 +197,7 @@ push.Query = ParseInstallation.Query
              .WhereMatchesQuery("user", userQuery);
 push.Alert = "Mariners lost? Free conciliatory hotdogs at the Parse concession stand!";
 push.SendAsync();
-</code></pre>
+````
 
 ## Sending Options
 
@@ -217,7 +217,7 @@ If you want to send more than just a message, you will need to use an `IDictiona
 
 For example, to send a notification that contains a title, you can do the following:
 
-<pre><code class="cs">
+````cs
 var push = new ParsePush();
 push.Channels = new List<string> {"Mets"};
 push.Data = new Dictionary<string, object> {
@@ -225,7 +225,7 @@ push.Data = new Dictionary<string, object> {
   {"alert", "The Mets scored! The game is now tied 1-1!"},
 };
 push.SendAsync();
-</code></pre>
+````
 
 ### Setting an Expiration Date
 
@@ -233,21 +233,21 @@ When a user's device is turned off or not connected to the internet, push notifi
 
 There are two properties provided by the `ParsePush` class to allow setting an expiration date for your notification. The first is `Expiration` which simply takes a `DateTime?` specifying when Parse should stop trying to send the notification.
 
-<pre><code class="cs">
+````cs
 var push = new ParsePush();
 push.Expiration = new DateTime(2015, 8, 14);
 push.Alert = "Season tickets on sale until August 14th!";
 push.SendAsync();
-</code></pre>
+````
 
 There is however a caveat with this method. Since device clocks are not guaranteed to be accurate, you may end up with inaccurate results. For this reason, the `ParsePush` class also provides the `ExpirationInterval` property which accepts a `TimeSpan`. The notification will expire after the specified interval has elapsed.
 
-<pre><code class="cs">
+````cs
 var push = new ParsePush();
 push.ExpirationInterval = TimeSpan.FromDays(7);
 push.Alert = "Season tickets on sale until next week!";
 push.SendAsync();
-</code></pre>
+````
 
 ### Targeting by Platform
 
@@ -255,7 +255,7 @@ If you build a cross platform app, it is possible you may only want to target on
 
 The following example would send a different notification to Android, iOS, and Windows users.
 
-<pre><code class="cs">
+````cs
 // Notification for Android users
 var androidPush = new ParsePush();
 androidPush.Query = ParseInstallation.Query
@@ -286,7 +286,7 @@ wpPush.Query = ParseInstallation.Query
                .WhereContainsAll("channels", new string[] { "suitcaseOwners" })
                .WhereEqualTo("deviceType", "winphone");
 wpPush.SendAsync();
-</code></pre>
+````
 
 ## Scheduling Pushes
 
@@ -296,7 +296,7 @@ Sending scheduled push notifications is not currently supported by the .NET SDK.
 
 If your app is running while a push notification is received, the `ParsePush.ParsePushNotificationReceived` event is fired. You can register for this event. This event provides `ParsePushNotificationEventArgs`.
 
-<pre><code class="cs">
+````cs
 ParsePush.ParsePushNotificationReceived += (sender, args) => {
   var payload = args.Payload;
   object objectId;
@@ -304,10 +304,10 @@ ParsePush.ParsePushNotificationReceived += (sender, args) => {
     DisplayRichMessageWithObjectId(objectId as string);
   }
 };
-</code></pre>
+````
 
 In Unity Android, we provide a helper method that you can utilize as a handler to display a notification. If the app is in background it will display a notification by default.
-<pre><code class="cs">
+````cs
 ParsePush.ParsePushNotificationReceived += (sender, args) => {
 #if UNITY_ANDROID
 	AndroidJavaClass parseUnityHelper = new AndroidJavaClass("com.parse.ParsePushUnityHelper");
@@ -318,15 +318,15 @@ ParsePush.ParsePushNotificationReceived += (sender, args) => {
 	parseUnityHelper.CallStatic("handleParsePushNotificationReceived", currentActivity, args.StringPayload);
 #endif
 }
-</code></pre>
+````
 
 ### Tracking Pushes and App Opens
 
 Tracking push opens is not supported on Unity now. You can track app opens with
 
-<pre><code class="cs">
+````cs
 ParseAnalytics.TrackAppOpenedAsync();
-</code></pre>
+````
 
 ## Push Experiments
 

--- a/_includes/unity/queries.md
+++ b/_includes/unity/queries.md
@@ -10,67 +10,67 @@ The general pattern is to create a `ParseQuery`, constraints to it, and then ret
 
 For example, to retrieve scores with a particular `playerName`, use a "where" clause to constrain the value for a key.
 
-<pre><code class="cs">
+````cs
 var query = ParseObject.GetQuery("GameScore")
     .WhereEqualTo("playerName", "Dan Stemkoski");
 query.FindAsync().ContinueWith(t =>
 {
     IEnumerable<ParseObject> results = t.Result;
 });
-</code></pre>
+````
 
 ## Query Constraints
 
 There are several ways to put constraints on the objects found by a `ParseQuery`. You can filter out objects with a particular key-value pair with a call to `WhereNotEqualTo`:
 
-<pre><code class="cs">
+````cs
 var query = ParseObject.GetQuery("GameScore")
     .WhereNotEqualTo("playerName", "Michael Yabuti");
-</code></pre>
+````
 
 You can give multiple constraints, and objects will only be in the results if they match all of the constraints.  In other words, it's like an AND of constraints.
 
-<pre><code class="cs">
+````cs
 var query = ParseObject.GetQuery("GameScore")
     .WhereNotEqualTo("playerName", "Michael Yabuti")
     .WhereGreaterThan("playerAge", 18);
-</code></pre>
+````
 
 You can limit the number of results by calling `Limit`. By default, results are limited to 100, but anything from 1 to 1000 is a valid limit:
 
-<pre><code class="cs">
+````cs
 query = query.Limit(10); // limit to at most 10 results
-</code></pre>
+````
 
 If you want exactly one result, a more convenient alternative may be to use `FirstAsync` or `FirstOrDefaultAsync` instead of using `FindAsync`.
 
-<pre><code class="cs">
+````cs
 var query = ParseObject.GetQuery("GameScore")
     .WhereEqualTo("playerEmail", "dstemkoski@example.com");
 query.FirstAsync().ContinueWith(t =>
 {
     ParseObject obj = t.Result;
 });
-</code></pre>
+````
 
 You can skip the first results by calling `Skip`. This can be useful for pagination:
 
-<pre><code class="cs">
+````cs
 query = query.Skip(10); // skip the first 10 results
-</code></pre>
+````
 
 For sortable types like numbers and strings, you can control the order in which results are returned:
 
-<pre><code class="cs">
+````cs
 // Sorts the results in ascending order by score and descending order by playerName
 var query = ParseObject.GetQuery("GameScore")
     .OrderBy("score")
     .ThenByDescending("playerName");
-</code></pre>
+````
 
 For sortable types, you can also use comparisons in queries:
 
-<pre><code class="cs">
+````cs
 // Restricts to wins < 50
 query = query.WhereLessThan("wins", 50);
 
@@ -82,29 +82,29 @@ query = query.WhereGreaterThan("wins", 50);
 
 // Restricts to wins >= 50
 query = query.WhereGreaterThanOrEqualTo("wins", 50);
-</code></pre>
+````
 
 If you want to retrieve objects matching several different values, you can use `WhereContainedIn`, providing an list of acceptable values. This is often useful to replace multiple queries with a single query. For example, if you want to retrieve scores made by any player in a particular list:
 
-<pre><code class="cs">
+````cs
 // Finds scores from any of Jonathan, Dario, or Shawn
 var names = new[] { "Jonathan Walsh", "Dario Wunsch", "Shawn Simon" };
 var query = ParseObject.GetQuery("GameScore")
     .WhereContainedIn("playerName", names);
-</code></pre>
+````
 
 If you want to retrieve objects that do not match any of several values you can use `WhereNotContainedIn`, providing an list of acceptable values. For example, if you want to retrieve scores from players besides those in a list:
 
-<pre><code class="cs">
+````cs
 // Finds scores from any of Jonathan, Dario, or Shawn
 var names = new[] { "Jonathan Walsh", "Dario Wunsch", "Shawn Simon" };
 var query = ParseObject.GetQuery("GameScore")
     .WhereNotContainedIn("playerName", names);
-</code></pre>
+````
 
 If you want to retrieve objects that have a particular key set, you can use `WhereExists`. Conversely, if you want to retrieve objects without a particular key set, you can use `WhereDoesNotExist`.
 
-<pre><code class="cs">
+````cs
 // Finds objects that have the score set
 var query = ParseObject.GetQuery("GameScore")
     .WhereExists("score");
@@ -112,11 +112,11 @@ var query = ParseObject.GetQuery("GameScore")
 // Finds objects that don't have the score set
 var query = ParseObject.GetQuery("GameScore")
     .WhereDoesNotExist("score");
-</code></pre>
+````
 
 You can use the `WhereMatchesKeyInQuery` method to get objects where a key matches the value of a key in a set of objects resulting from another query.  For example, if you have a class containing sports teams and you store a user's hometown in the user class, you can issue one query to find the list of users whose hometown teams have winning records.  The query would look like:
 
-<pre><code class="cs">
+````cs
 var teamQuery = ParseQuery.GetQuery("Team")
     .WhereGreaterThan("winPct", 0.5);
 var userQuery = ParseUser.Query
@@ -126,17 +126,17 @@ userQuery.FindAsync(t =>
     IEnumerable<ParseUser> results = t.Result;
 });
 // results will contain users with a hometown team with a winning record
-</code></pre>
+````
 
 ## Queries on List Values
 
 For keys with an array type, you can find objects where the key's array value contains 2 by:
 
-<pre><code class="cs">
+````cs
 // Find objects where the list in listKey contains 2.
 var query = ParseObject.GetQuery("MyClass")
     .WhereEqualTo("listKey", 2);
-</code></pre>
+````
 
 ## Queries on String Values
 
@@ -146,11 +146,11 @@ var query = ParseObject.GetQuery("MyClass")
 
 Use `WhereStartsWith` to restrict to string values that start with a particular string. Similar to a MySQL LIKE operator, this is indexed so it is efficient for large datasets:
 
-<pre><code class="cs">
+````cs
 // Finds barbecue sauces that start with "Big Daddy's".
 var query = ParseObject.GetQuery("BarbecueSauce")
     .WhereStartsWith("name", "Big Daddy's");
-</code></pre>
+````
 
 The above example will match any `BarbecueSauce` objects where the value in the "name" String key starts with "Big Daddy's". For example, both "Big Daddy's" and "Big Daddy's BBQ" will match, but "big daddy's" or "BBQ Sauce: Big Daddy's" will not.
 
@@ -161,7 +161,7 @@ Queries that have regular expression constraints are very expensive. Refer to th
 
 There are several ways to issue queries for relational data. If you want to retrieve objects where a field matches a particular `ParseObject`, you can use `WhereEqualTo` just like for other data types. For example, if each `Comment` has a `Post` object in its `post` field, you can fetch comments for a particular `Post`:
 
-<pre><code class="cs">
+````cs
 // Assume ParseObject myPost was previously created.
 var query = ParseObject.GetQuery("Comment")
     .WhereEqualTo("post", myPost);
@@ -171,18 +171,18 @@ query.FindAsync().ContinueWith(t =>
     IEnumerable<ParseObject> comments = t.Result;
     // comments now contains the comments for myPost
 });
-</code></pre>
+````
 
 You can also do relational queries by `ObjectId`:
 
-<pre><code class="cs">
+````cs
 var query = ParseObject.GetQuery("Comment")
     .WhereEqualTo("post", ParseObject.CreateWithoutData("Post", "1zEcyElZ80"));
-</code></pre>
+````
 
 If you want to retrieve objects where a field contains a `ParseObject` that matches a different query, you can use `WhereMatchesQuery`. Note that the default limit of 100 and maximum limit of 1000 apply to the inner query as well, so with large data sets you may need to construct queries carefully to get the desired behavior. In order to find comments for posts with images, you can do:
 
-<pre><code class="cs">
+````cs
 var imagePosts = ParseObject.GetQuery("Post")
     .WhereExists("image");
 var query = ParseObject.GetQuery("Comment")
@@ -193,11 +193,11 @@ query.FindAsync().ContinueWith(t =>
     IEnumerable<ParseObject> comments = t.Result;
     // comments now contains the comments for posts with images
 });
-</code></pre>
+````
 
 If you want to retrieve objects where a field contains a `ParseObject` that does not match a different query, you can use `WhereDoesNotMatchQuery`.  In order to find comments for posts without images, you can do:
 
-<pre><code class="cs">
+````cs
 var imagePosts = ParseObject.GetQuery("Post")
     .WhereExists("image");
 var query = ParseObject.GetQuery("Comment")
@@ -208,11 +208,11 @@ query.FindAsync().ContinueWith(t =>
     IEnumerable<ParseObject> comments = t.Result;
     // comments now contains the cmoments for posts without images
 });
-</code></pre>
+````
 
 In some situations, you want to return multiple types of related objects in one query. You can do this with the `Include` method. For example, let's say you are retrieving the last ten comments, and you want to retrieve their related posts at the same time:
 
-<pre><code class="cs">
+````cs
 // Retrieve the most recent comments
 var query = ParseObject.GetQuery("Comment")
     .OrderByDescending("createdAt")
@@ -238,13 +238,13 @@ query.FindAsync().ContinueWith(t =>
         Debug.Log("Post title: " + post["title"]);
     }
 });
-</code></pre>
+````
 
 You can also do multi level includes using dot notation.  If you wanted to include the post for a comment and the post's author as well you can do:
 
-<pre><code class="cs">
+````cs
 query = query.Include("post.author");
-</code></pre>
+````
 
 You can issue a query with multiple fields included by calling `Include` multiple times. This functionality also works with `ParseQuery` helpers like `FirstAsync` and `GetAsync`
 
@@ -254,7 +254,7 @@ Caveat: Count queries are rate limited to a maximum of 160 requests per minute. 
 
 If you just need to count how many objects match a query, but you do not need to retrieve the objects that match, you can use `CountAsync` instead of `FindAsync`. For example, to count how many games have been played by a particular player:
 
-<pre><code class="cs">
+````cs
 // First set up a callback.
 var query = ParseObject.GetQuery("GameScore")
     .WhereEqualTo("playerName", "Sean Plott");
@@ -262,13 +262,13 @@ query.CountAsync().ContinueWith(t =>
 {
     int count = t.Result;
 });
-</code></pre>
+````
 
 ## Compound Queries
 
 If you want to find objects that match one of several queries, you can use the `Or` method.  For instance, if you want to find players that either have a lot of wins or a few wins, you can do:
 
-<pre><code class="cs">
+````cs
 var lotsOfWins = ParseObject.GetQuery("Player")
     .WhereGreaterThan("wins", 150);
 
@@ -277,7 +277,7 @@ var fewWins = ParseObject.GetQuery("Player")
 
 ParseQuery<ParseObject> query = lotsOfWins.Or(fewWins);
 // results contains players with lots of wins or only a few wins.
-</code></pre>
+````
 
 You can add additional constraints to the newly created `ParseQuery` that act as an 'and' operator.
 

--- a/_includes/unity/roles.md
+++ b/_includes/unity/roles.md
@@ -20,17 +20,17 @@ The `ParseRole` uses the same security scheme (ACLs) as all other objects on Par
 
 To create a new `ParseRole`, you would write:
 
-<pre><code class="cs">
+````cs
 // By specifying no write privileges for the ACL, we can ensure the role cannot be altered.
 var roleACL = new ParseACL();
 roleACL.PublicReadAccess = true;
 var role = new ParseRole("Administrator", roleACL);
 Task saveTask = role.SaveAsync();
-</code></pre>
+````
 
 You can add users and roles that should inherit your new role's permissions through the "users" and "roles" relations on `ParseRole`:
 
-<pre><code class="cs">
+````cs
 var role = new ParseRole(roleName, roleACL);
 foreach (ParseUser user in usersToAddToRole)
 {
@@ -41,7 +41,7 @@ foreach (ParseRole childRole in rolesToAddToRole)
     role.Roles.Add(childRole);
 }
 Task saveTask = role.SaveAsync();
-</code></pre>
+````
 
 Take great care when assigning ACLs to your roles so that they can only be modified by those who should have permissions to modify them.
 
@@ -51,7 +51,7 @@ Now that you have created a set of roles for use in your application, you can us
 
 Giving a role read or write permission to an object is straightforward.  You can either use the `ParseRole`:
 
-<pre><code class="cs">
+````cs
 ParseRole.Query
     .WhereEqualTo("name", "Moderators")
     .FirstAsync()
@@ -64,17 +64,17 @@ ParseRole.Query
         wallPost.ACL = postACL;
         return wallPost.SaveAsync();
     });
-</code></pre>
+````
 
 You can avoid querying for a role by specifying its name for the ACL:
 
-<pre><code class="cs">
+````cs
 var wallPost = new ParseObject("WallPost");
 var postACL = new ParseACL();
 postACL.SetRoleWriteAccess("Moderators", true);
 wallPost.ACL = postACL;
 Task saveTask = wallPost.SaveAsync();
-</code></pre>
+````
 
 ## Role Hierarchy
 
@@ -82,9 +82,9 @@ As described above, one role can contain another, establishing a parent-child re
 
 These types of relationships are commonly found in applications with user-managed content, such as forums. Some small subset of users are "Administrators", with the highest level of access to tweaking the application's settings, creating new forums, setting global messages, and so on. Another set of users are "Moderators", who are responsible for ensuring that the content created by users remains appropriate. Any user with Administrator privileges should also be granted the permissions of any Moderator. To establish this relationship, you would make your "Administrators" role a child role of "Moderators", like this:
 
-<pre><code class="cs">
+````cs
 ParseRole administrators = /* Your "Administrators" role */;
 ParseRole moderators = /* Your "Moderators" role */;
 moderators.Roles.Add(administrators);
 Task saveTask = moderators.SaveAsync();
-</code></pre>
+````

--- a/_includes/unity/users.md
+++ b/_includes/unity/users.md
@@ -20,7 +20,7 @@ We'll go through each of these in detail as we run through the various use cases
 
 The first thing your app will do is probably ask the user to sign up. The following code illustrates a typical sign up:
 
-<pre><code class="cs">
+````cs
 var user = new ParseUser()
 {
     Username = "my name",
@@ -32,7 +32,7 @@ var user = new ParseUser()
 user["phone"] = "415-392-0202";
 
 Task signUpTask = user.SignUpAsync();
-</code></pre>
+````
 
 This call will asynchronously create a new user in your Parse App. Before it does this, it also checks to make sure that both the username and email are unique. Also, it securely hashes the password in the cloud using bcrypt. We never store passwords in plaintext, nor will we ever transmit passwords back to the client in plaintext.
 
@@ -46,7 +46,7 @@ You are free to use an email address as the username. Simply ask your users to e
 
 Of course, after you allow users to sign up, you need to let them log in to their account in the future. To do this, you can use the class method `LogInAsync`.
 
-<pre><code class="cs">
+````cs
 ParseUser.LogInAsync("myname", "mypass").ContinueWith(t =>
 {
     if (t.IsFaulted || t.IsCanceled)
@@ -58,7 +58,7 @@ ParseUser.LogInAsync("myname", "mypass").ContinueWith(t =>
         // Login was successful.
     }
 })
-</code></pre>
+````
 
 ## Verifying Emails
 
@@ -76,7 +76,7 @@ It would be bothersome if the user had to log in every time they open your app. 
 
 Whenever you use any signup or login methods, the user is cached on disk. You can treat this cache as a session, and automatically assume the user is logged in:
 
-<pre><code class="cs">
+````cs
 if (ParseUser.CurrentUser != null)
 {
     // do stuff with the user
@@ -85,14 +85,14 @@ else
 {
     // show the signup or login screen
 }
-</code></pre>
+````
 
 You can clear the current user by logging them out:
 
-<pre><code class="cs">
+````cs
 ParseUser.LogOut();
 var currentUser = ParseUser.CurrentUser; // this will now be null
-</code></pre>
+````
 
 ## Security For User Objects
 
@@ -102,7 +102,7 @@ Specifically, you are not able to invoke the `SaveAsync` or `DeleteAsync` method
 
 The following illustrates this security policy:
 
-<pre><code class="cs">
+````cs
 ParseUser user = null;
 ParseUser.LogInAsync("my_username", "my_password").ContinueWith(t =>
 {
@@ -135,7 +135,7 @@ ParseUser.LogInAsync("my_username", "my_password").ContinueWith(t =>
         // This will always fail, since the ParseUser is not authenticated
     }
 });
-</code></pre>
+````
 
 The `ParseUser` obtained from `Current` will always be authenticated.
 
@@ -147,18 +147,18 @@ The same security model that applies to the `ParseUser` can be applied to other 
 
 The simplest way to use a `ParseACL` is to specify that an object may only be read or written by a single user. To create such an object, there must first be a logged in `ParseUser`. Then, the `ParseACL` constructor generates a `ParseACL` that limits access to that user. An object's ACL is updated when the object is saved, like any other property. Thus, to create a private note that can only be accessed by the current user:
 
-<pre><code class="cs">
+````cs
 var privateNote = new ParseObject("Note");
 privateNote["content"] = "This note is private!";
 privateNote.ACL = new ParseACL(ParseUser.CurrentUser);
 Task saveTask = privateNote.SaveAsync();
-</code></pre>
+````
 
 This note will then only be accessible to the current user, although it will be accessible to any device where that user is signed in. This functionality is useful for applications where you want to enable access to user data across multiple devices, like a personal todo list.
 
 Permissions can also be granted on a per-user basis. You can add permissions individually to a `ParseACL` using `SetReadAccess` and `SetWriteAccess`. For example, let's say you have a message that will be sent to a group of several users, where each of them have the rights to read and delete that message:
 
-<pre><code class="cs">
+````cs
 var groupMessage = new ParseObject("Message");
 var groupACL = new ParseACL();
 
@@ -172,11 +172,11 @@ foreach (var user in userList)
 
 groupMessage.ACL = groupACL;
 Task saveTask = groupMessage.SaveAsync();
-</code></pre>
+````
 
 You can also grant permissions to all users at once using the `PublicReadAccess` and `PublicWriteAccess` properties. This allows patterns like posting comments on a message board. For example, to create a post that can only be edited by its author, but can be read by anyone:
 
-<pre><code class="cs">
+````cs
 var publicPost = new ParseObject("Post");
 var postACL = new ParseACL(ParseUser.CurrentUser)
 {
@@ -185,7 +185,7 @@ var postACL = new ParseACL(ParseUser.CurrentUser)
 };
 publicPost.ACL = postACL;
 Task saveTask = publicPost.SaveAsync();
-</code></pre>
+````
 
 Operations that are forbidden, such as deleting an object that you do not have write access to, result in a `ParseException` with an `OtherCause` error code. For security purposes, this prevents clients from distinguishing which object ids exist but are secured, versus which object ids do not exist at all.
 
@@ -195,9 +195,9 @@ As soon as you introduce passwords into a system, users will forget them. In suc
 
 To kick off the password reset flow, ask the user for their email address, and call:
 
-<pre><code class="cs">
+````cs
 Task requestPasswordTask = ParseUser.RequestPasswordResetAsync("email@example.com");
-</code></pre>
+````
 
 This will attempt to match the given email with the user's email or username field, and will send them a password reset email. By doing this, you can opt to have users use their email as their username, or you can collect it separately and store it in the email field.
 
@@ -214,14 +214,14 @@ Note that the messaging in this flow will reference your app by the name that yo
 
 To query for users, you need to use the special user query:
 
-<pre><code class="cs">
+````cs
 ParseUser.Query
     .WhereEqualTo("gender", "female")
     .FindAsync().ContinueWith(t =>
     {
         IEnumerable<ParseUser> women = t.Result;
     });
-</code></pre>
+````
 
 In addition, you can use `GetAsync` to get a `ParseUser` by id.
 
@@ -229,7 +229,7 @@ In addition, you can use `GetAsync` to get a `ParseUser` by id.
 
 Associations involving a `ParseUser` work right out of the box. For example, let's say you're making a blogging app. To store a new post for a user and retrieve all their posts:
 
-<pre><code class="cs">
+````cs
 // Make a new post
 var post = new ParseObject("Post")
 {
@@ -247,7 +247,7 @@ post.SaveAsync().ContinueWith(t =>
 {
     IEnumerable<ParseObject> userPosts = t.Result;
 });
-</code></pre>
+````
 
 ## Facebook Users
 
@@ -268,9 +268,9 @@ There are two main ways to use Facebook with your Parse users: (1) logging in as
 
 `ParseFacebookUtils` provides a way to allow your `ParseUser`s to log in or sign up through Facebook. This is accomplished using the `LogInAsync()` method. Use the Facebook Unity SDK to log into Facebook, then call `LogInAsync()` with the access token information:
 
-<pre><code class="cs">
+````cs
 Task<ParseUser> logInTask = ParseFacebookUtils.LogInAsync(userId, accessToken, tokenExpiration);
-</code></pre>
+````
 
 When this code is run, our SDK receives the Facebook data and saves it to a `ParseUser`. If it's a new user based on the Facebook ID, then that user is created.
 
@@ -285,17 +285,17 @@ When this code is run, the following happens:
 
 If you want to associate an existing `ParseUser` with a Facebook account, you can link it like so:
 
-<pre><code class="cs">
+````cs
 if (!ParseFacebookUtils.IsLinked(user))
 {
     Task linkTask = ParseFacebookUtils.LinkAsync(user, userId, accessToken, tokenExpiration);
 }
-</code></pre>
+````
 
 The steps that happen when linking are very similar to log in. The difference is that on successful login, the existing `ParseUser` is updated with the Facebook information. Future logins via Facebook will now log the user into their existing account.
 
 If you want to unlink a Facebook account from a user, simply do this:
 
-<pre><code class="cs">
+````cs
 Task unlinkTask = ParseFacebookUtils.UnlinkAsync(user);
-</code></pre>
+````


### PR DESCRIPTION
This removes the unneeded `</p>` from https://parseplatform.github.io/docs/js/guide/ and fixes the code blocks in all of the pages still using for example `<pre><code class="php">`. I've replaced them with Github flavoured code fences with the language listed.
