### PR TITLE
Remove references to querying with object ids

### DIFF
--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -269,7 +269,7 @@ You can run custom Cloud Code before an object is deleted. You can do this with 
 ```javascript
 Parse.Cloud.beforeDelete("Album", function(request, response) {
   query = new Parse.Query("Photo");
-  query.equalTo("album", request.object.id);
+  query.equalTo("album", request.object);
   query.count({
     success: function(count) {
       if (count > 0) {

--- a/_includes/common/performance.md
+++ b/_includes/common/performance.md
@@ -893,8 +893,7 @@ Suppose you are displaying movie information in your app and your data model con
 ```javascript
 var Review = Parse.Object.extend("Review");
 var query = new Parse.Query("Review");
-// movieId corresponds to a given movie's id
-query.equalTo(“movie”, movieId);
+query.equalTo(“movie”, movie);
 query.count().then(function(count) {
   // Request succeeded
 });
@@ -903,8 +902,7 @@ query.count().then(function(count) {
 
 <pre><code class="objectivec">
 PFQuery *query = [PFQuery queryWithClassName:@"Review"];
-// movieId corresponds to a given movie's id
-[query whereKey:@"movie" equalTo:movieId];
+[query whereKey:@"movie" equalTo:movie];
 [query countObjectsInBackgroundWithBlock:^(int number, NSError *error) {
   if (!error) {
     // Request succeeded
@@ -915,8 +913,7 @@ PFQuery *query = [PFQuery queryWithClassName:@"Review"];
 
 <pre><code class="swift">
 let query = PFQuery.queryWithClassName("Review")
-// movieId corresponds to a given movie's id
-query.whereKey("movie", equalTo: movieId)
+query.whereKey("movie", equalTo: movie)
 query.countObjectsInBackgroundWithBlock {
   (number, error) in
   if !error {

--- a/_includes/js/promises.md
+++ b/_includes/js/promises.md
@@ -199,7 +199,7 @@ Promises are convenient when you want to do a series of tasks in a row, each one
 
 <pre><code class="javascript">
 var query = new Parse.Query("Comments");
-query.equalTo("post", 123);
+query.equalTo("post", post);
 
 query.find().then(function(results) {
   // Create a trivial resolved promise as a base case.
@@ -223,7 +223,7 @@ You can also use promises to perform several tasks in parallel, using the `when`
 
 <pre><code class="javascript">
 var query = new Parse.Query("Comments");
-query.equalTo("post", 123);
+query.equalTo("post", post);
 
 query.find().then(function(results) {
   // Collect one promise for each delete into an array.

--- a/_includes/js/push-notifications.md
+++ b/_includes/js/push-notifications.md
@@ -329,7 +329,7 @@ You can schedule a push in advance by specifying a `push_time`. For example, if 
 var tomorrowDate = new Date(...);
 
 var query = new Parse.Query(Parse.Installation);
-query.equalTo('user_id', 'user_123');
+query.equalTo('user', user);
 
 Parse.Push.send({
   where: query,


### PR DESCRIPTION
Using `equalTo` with object id is no longer supported in Parse Server. Having references to querying with an object id is misleading.