### PR TITLE
Update Android SDK installation and setup

### DIFF
--- a/_includes/android/getting-started.md
+++ b/_includes/android/getting-started.md
@@ -1,3 +1,68 @@
 # Getting Started
 
-If you haven't installed the SDK yet, please [head over to the QuickStart guide]({{ page.quickstart }}#parse_data/mobile/android/native/new) to get our SDK up and running in Android Studio. Note that we support Android 2.3 and higher. You can also check out our [API Reference](/Parse-SDK-Android/api/) for more detailed information about our SDK.
+Note that we support Android 2.3 and higher. You can also check out our [API Reference](/Parse-SDK-Android/api/) for more detailed information about our SDK.
+
+## Installation
+**Step 1:** Download `Parse-SDK-Android`
+
+- **Option 1:** Add dependency to the application level `build.gradle` file.
+
+```groovy
+dependencies {
+  compile 'com.parse:parse-android:1.14.0'
+}
+```
+
+- **Option 2:** Download [latest JAR](https://search.maven.org/remote_content?g=com.parse&a=parse-android&v=LATEST)
+
+**Step 2:** Setup Parse
+
+- **Option 1:** Setup in the Manifest
+
+You may define `com.parse.SERVER_URL` and `com.parse.APPLICATION_ID` meta-data in your `AndroidManifest.xml`:
+
+```xml
+<application ...>
+  <meta-data
+    android:name="com.parse.SERVER_URL"
+    android:value="@string/parse_server_url" />
+  <meta-data
+    android:name="com.parse.APPLICATION_ID"
+    android:value="@string/parse_app_id" />
+  ...
+</application>
+```
+
+Initializing Parse in the `Application`
+
+```java
+import com.parse.Parse;
+import android.app.Application;
+
+public class App extends Application {
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    Parse.initialize(this);
+  }
+}
+```
+
+- **Option 2:** Setup in the `Application`
+
+```java
+import com.parse.Parse;
+import android.app.Application;
+
+public class App extends Application {
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    Parse.initialize(new Parse.Configuration.Builder(this)
+      .applicationId("YOUR_APP_ID")
+      .server("http://localhost:1337/parse/")
+      .build()
+    );
+  }
+}
+```

--- a/_includes/android/local-datastore.md
+++ b/_includes/android/local-datastore.md
@@ -12,7 +12,7 @@ public class App extends Application {
     super.onCreate();
 
     Parse.enableLocalDatastore(this);
-    Parse.initialize(this, PARSE_APPLICATION_ID, PARSE_CLIENT_KEY);
+    Parse.initialize(this);
   }
 }
 ```

--- a/_includes/android/objects.md
+++ b/_includes/android/objects.md
@@ -404,7 +404,7 @@ public class App extends Application {
     super.onCreate();
 
     ParseObject.registerSubclass(Armor.class);
-    Parse.initialize(this, PARSE_APPLICATION_ID, PARSE_CLIENT_KEY);
+    Parse.initialize(this);
   }
 }
 ```

--- a/_includes/parse-server/using-parse-sdks.md
+++ b/_includes/parse-server/using-parse-sdks.md
@@ -30,11 +30,8 @@ _Objective-C_
 ```java
 Parse.initialize(new Parse.Configuration.Builder(myContext)
     .applicationId("YOUR_APP_ID")
-    .clientKey(null)
-    .server("http://localhost:1337/parse/") // The trailing slash is important.
-
+    .server("http://localhost:1337/parse/")
     ...
-
     .build()
 );
 ```


### PR DESCRIPTION
Update Android SDK setup
1. Add installation section in Getting Started
2. Manifest setup is supported after [`v.1.14.0` ](https://github.com/ParsePlatform/Parse-SDK-Android/releases/tag/1.14.0) (ParsePlatform/Parse-SDK-Android#600)
