### PR TITLE
Added MongoDB 3.2 as supported database version

### DIFF
--- a/_includes/parse-server/database.md
+++ b/_includes/parse-server/database.md
@@ -4,7 +4,7 @@ Parse Server uses [MongoDB](https://www.mongodb.org/) as the database for your a
 
 The Mongo requirements for Parse Server are:
 
-* MongoDB version 2.6.X or 3.0.X
+* MongoDB version 2.6.X, 3.0.X, or 3.2.X
 * An SSL connection is recommended (but not required).
 
 If this is your first time setting up a production MongoDB instance, we recommend using either [mLab](http://www.mLab.com) or [ObjectRocket](https://objectrocket.com/). These are database-as-a-service companies which provide fully managed MongoDB instances, and can help you scale up as needed.


### PR DESCRIPTION
Added MongoDB 3.2 as a supported database version, per https://github.com/ParsePlatform/parse-server/issues/1867.