### PR TITLE
Add information about different redis databases

### DIFF
--- a/_includes/parse-server/cache-adapters.md
+++ b/_includes/parse-server/cache-adapters.md
@@ -21,7 +21,7 @@ var api = new ParseServer({
   appId: process.env.APP_ID || 'APPLICATION_ID',
   masterKey: process.env.MASTER_KEY || 'MASTER_KEY',
   ...
-  cacheAdapter: cacheAdapter,
+  cacheAdapter: redisCache,
   ...
 });
 ```

--- a/_includes/parse-server/cache-adapters.md
+++ b/_includes/parse-server/cache-adapters.md
@@ -29,3 +29,5 @@ var api = new ParseServer({
 The `redisOptions` are passed directly to the redis.createClient method. For more informations, refer to the [redis.createClient](https://www.npmjs.com/package/redis#rediscreateclient) documentation.
 
 Note that at the moment, only passing a single argument is supported.
+
+The cache adapter can flush the redis database at anytime. It is best to not use the same redis database for other services. A different redis database can be chosen by providing a different database number to redisOptions. By default redis has 16 databases (indexed from 0 to 15).

--- a/_includes/parse-server/cache-adapters.md
+++ b/_includes/parse-server/cache-adapters.md
@@ -30,4 +30,4 @@ The `redisOptions` are passed directly to the redis.createClient method. For mor
 
 Note that at the moment, only passing a single argument is supported.
 
-The cache adapter can flush the redis database at anytime. It is best to not use the same redis database for other services. A different redis database can be chosen by providing a different database number to redisOptions. By default redis has 16 databases (indexed from 0 to 15).
+The cache adapter can flush the redis database at anytime. It is best to not use the same redis database for other services. A different redis database can be chosen by providing a different database number to `redisOptions`. By default redis has 16 databases (indexed from 0 to 15).

--- a/_includes/parse-server/live-query.md
+++ b/_includes/parse-server/live-query.md
@@ -157,6 +157,7 @@ var parseLiveQueryServer = ParseServer.createLiveQueryServer(httpServer,  {
   redisURL: 'redis://localhost:6379'
 });
 ```
+This redis database should be different from the redis database used for `RedisCacheAdapter`.
 
 The architecture of the whole LiveQuery system after you use Redis should be like this:
 


### PR DESCRIPTION
Both, LiveQuery and RedisCacheAdapter use a redisURL. As the CacheAdapter might flush the database, it's recommended to use two different databases. Added this information to the docs.
This is also important if you run additional services like kue on redis.

Thanks for the help @JeremyPlease