### PR TITLE
Fixed issue where icons are half cut off on Firefox

### DIFF
--- a/css/lib/docs/components/_docs-platform.scss
+++ b/css/lib/docs/components/_docs-platform.scss
@@ -69,8 +69,7 @@
         svg, img{
             display:block;
             position: absolute;
-            top: 50%;
-            transform: translateY(-50%);
+            top: 25%;
             right: $docs-platform-uniform-padding-h;
         }
     }


### PR DESCRIPTION
This resolves an issue where icons are about 50% cut off on firefox on [the current site](docs.parseplatform.org). It appears that the SVG being rendered was being chopped due to the `transform` applying a `translateY(-50%)`, approximately cutting off just the top half of the image by shifting it up. Removing the `transform` property altogether and halving the `top` property to 25% does the trick.

It doesn't look like this was present in any of the other major browsers. Checking across Chrome, Safari and Edge all seem to be good. Just seems to be an isolated rendering issue with the Gecko engine utilized by Firefox specifically. Also this preserves the existing look as it was across the other browsers.