### PR TITLE
Fix for invalid 'platform'

### DIFF
--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -801,7 +801,7 @@
 			hljs.highlightBlock(block);
 	});
 
-	var platform = window.location.pathname.split('/')[2];
+	var platform = window.location.pathname.split('/')[1];
 	if (platform) {
 			new App.Views.Docs.Main({
 					language: 'en',


### PR DESCRIPTION
This is a patch for the observed issue in #442, where common sections with multiple code samples would default to always showing JS no matter the current sdk.

Originally, before the docs were at docs.parseplatform.org they used to be at parseplatform.org/docs (if I believe correctly). When determining which set of code snippets to display the JS pulled the platform 'name' from the url as follows
```js
var platform = window.location.pathname.split('/')[2];
```
Now that docs are served using the **docs** subdomain instead of the docs directory this retrieves the directory 1 _past_ the intended platform name. The new result was just returning `guide` for every page. Since this is not a valid platform the 'common' language block to show would fall back to the default case, which also happens to be the JS case.
```js
case 'js':
default:
    $('.common-lang-block.js').show();
```
The fix is just a one liner accounting for the now absent `docs` directory, simply changing the index of the split pathname to 1 instead of 2.