### PR TITLE
Include reminder for a common mistake

### DIFF
--- a/_includes/ios/getting-started.md
+++ b/_includes/ios/getting-started.md
@@ -11,7 +11,7 @@ And you're off! Take a look at the public [documentation][docs] and start buildi
    ```ruby
    pod 'Parse'
    ```
-   Run `pod install`, and you should now have the latest parse release.
+   Run `pod install`, and you should now have the latest parse release.  CocoaPods will generate a .xcworkspace for you.  You must open the .xcworkspace in Xcode or you will get a linker error.
     
     
  - **[Carthage](https://github.com/carthage/carthage)**


### PR DESCRIPTION
CocoaPods new users often forget to use the newly generated xcworkspace, leading to a strange linker error that is hard to debug.