### PR TITLE
Fixes lists floating through search box

### DIFF
--- a/css/lib/multisite/_wysiwyg.scss
+++ b/css/lib/multisite/_wysiwyg.scss
@@ -108,17 +108,17 @@
         li{
             margin: 0.9em 0;
             padding: 0 0 0 25px;
-            position: relative;
             line-height: 1.4;
 
             &:before{
-                display:block;
+                display:inline-block;
                 content: "";
-                position: absolute;
                 left: 0; top:3px;
                 width: 15px; height: 11px;
                 background: url($svg-plus) left top no-repeat;
                 background-size: 9px auto;
+                margin-left: -30px;
+                margin-right: 15px;
             }
         }
 


### PR DESCRIPTION
Some of the CSS that's used to render the Algolia autocomplete box doesn't exactly play very nicely with what's in the docs. This modifies the list CSS slightly to correct this issue. I've observed this in Firefox/Chrome/Safari, haven't checked Edge/IE but I suspect it may be in at least Edge as well.

The fix applied here is removing the `relative` positioning for `li` elements in the doc. This is to allow the `+` symbol to be absolutely positioned in front. With that change this also adjusts the `before` selector to create and position an `inline-block` entry that is _not_ absolutely positioned. This puts it back in line, but to reposition it to how it was before the additional left & right margins were added.

Just for reference this is how it should look:

![good1](https://user-images.githubusercontent.com/5070304/28480134-26023942-6e14-11e7-8f4c-3ddd600ad92f.png)

And this is how it looks when you happen to be over a list:

![bad1](https://user-images.githubusercontent.com/5070304/28480139-2b090b5a-6e14-11e7-8ba8-05665310e401.png)

Note that this also happens with anchors:

![bad2](https://user-images.githubusercontent.com/5070304/28480149-32ad9b8c-6e14-11e7-8eba-1c846c7514df.png)

This addresses the lists only for now, if this isn't merged in before I'll go back and take a look at the anchors too.