### PR TITLE
Changes references to api.parse.com and /1/

### DIFF
--- a/_app/main.js
+++ b/_app/main.js
@@ -650,6 +650,9 @@ App.Views = {};
 			// deal with common-lang-blocks
 			this.toggleCommonLangBlocks();
 
+      // setup the server/mount path editor
+      this.setupServerFieldCustomization();
+
 			// add toggles to code blocks if necessary
 			if (this.platform === "ios" || this.platform === "osx" || this.platform === "macos") {
 				new App.Views.Docs.Toggle({
@@ -729,6 +732,67 @@ App.Views = {};
 			}
 		},
 
+    setupServerFieldCustomization: function setupServerFieldCustomization() {
+
+		  if(this.platform !== 'rest') {
+		    // only customizes for rest currently
+		    return;
+      }
+
+      // constant class name for both
+      const className = "custom-server-option";
+
+		  var html="<span class='custom-server-description'>Your Server Settings</span>";
+
+      // server url
+      var title     = "Set your parse server url here.";
+      var value     = "YOUR.PARSE-SERVER.HERE";
+      var id        = 'parse-server-custom-url';
+      var holder    = 'your.parse-server.com';
+      html+="<input id='"+id+"' class='"+className+"' type='text' placeholder='"+holder+"' value='"+value+"' title='"+title+"'>";
+
+      // mount path
+      title   = "Set your parse server mount path here.";
+      value   = "parse";
+      id      = 'parse-server-custom-mount';
+      holder  = 'parse';
+      html+="<input id='"+id+"' class='"+className+"' type='text' placeholder='"+holder+"' value='"+value+"' title='"+title+"'>";
+
+      html+="<br/>";
+
+      // add right before the first side bar section
+      document.getElementsByClassName('ui_live_toc')[0].insertAdjacentHTML('beforebegin', html);
+
+      // set url listener
+      $('#parse-server-custom-url').keyup(function() {
+        var url = $('#parse-server-custom-url').val();
+        if(!url.match(/^[-_a-z0-9\.]+$/i)) {
+          // not a valid url
+          return;
+        }
+        $(".custom-parse-server-url").html(url);
+      });
+
+      // set mount listener
+      $('#parse-server-custom-mount').keyup(function() {
+        var mount = $('#parse-server-custom-mount').val();
+        if(!mount.match(/^[-_a-z0-9\/]+$/i) && mount !== '') {
+          // not a valid mount path, and not empty
+          return;
+        }
+        if(!mount.match(/^\//)) {
+          // add leading slash
+          mount = '/'+mount;
+        }
+        if(!mount.match(/\/$/)) {
+          // add trailing slash
+          mount = mount+'/';
+        }
+        $(".custom-parse-server-mount").html(mount);
+      });
+
+    },
+
 		// we recalculate the header heights for the TOC
 		// highlighting when the height of the content changes
 		handleToggleChange: function() {
@@ -753,7 +817,7 @@ $('pre code').each(function(i, block) {
   hljs.highlightBlock(block);
 });
 
-var platform = window.location.pathname.split('/')[2];
+var platform = window.location.pathname.split('/')[1];
 if (platform) {
   new App.Views.Docs.Main({
     language: 'en',

--- a/_app/main.js
+++ b/_app/main.js
@@ -807,6 +807,10 @@ App.Views = {};
       // set protocol listener
       $('#parse-server-custom-protocol').change(function() {
         const protocol = $('#parse-server-custom-protocol').val();
+        if(!protocol.match(/^[a-z]+$/)) {
+          // not a valid protocol
+          return;
+        }
         $(".custom-parse-server-protocol").html(protocol);
         if (typeof(Storage) !== "undefined") {
           localStorage.setItem('parse-server-custom-protocol', protocol);
@@ -815,7 +819,13 @@ App.Views = {};
 
       // set appId listener
       $('#parse-server-custom-appid').keyup(function() {
-        const appId = $('#parse-server-custom-appid').val();
+        var appId = $('#parse-server-custom-appid').val();
+        if(!appId.match(/^[^\s]+$/i)) {
+          // not a valid appId
+          return;
+        }
+        // encode any html
+        appId = appId.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
         $(".custom-parse-server-appid").html(appId);
         if (typeof(Storage) !== "undefined") {
           localStorage.setItem('parse-server-custom-appid', appId);
@@ -824,7 +834,13 @@ App.Views = {};
 
       // set clientKey listener
       $('#parse-server-custom-clientkey').keyup(function() {
-        const clientKey = $('#parse-server-custom-clientkey').val();
+        var clientKey = $('#parse-server-custom-clientkey').val();
+        if(!clientKey.match(/^[^\s]+$/i)) {
+          // not a valid appId
+          return;
+        }
+        // encode any html
+        clientKey = clientKey.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
         $(".custom-parse-server-clientkey").html(clientKey);
         if (typeof(Storage) !== "undefined") {
           localStorage.setItem('parse-server-custom-clientkey', clientKey);

--- a/_app/main.js
+++ b/_app/main.js
@@ -734,43 +734,53 @@ App.Views = {};
 
     setupServerFieldCustomization: function setupServerFieldCustomization() {
 
-		  if(this.platform !== 'rest') {
-		    // only customizes for rest currently
+		  if(!document.getElementById('parse-server-custom-url')) {
+		    // no customization available on this page
 		    return;
       }
 
-      // constant class name for both
-      const className = "custom-server-option";
+      if (typeof(Storage) !== "undefined") {
+        // apply previous values from local storage
+        const _url        = localStorage.getItem('parse-server-custom-url');
+        const _mount      = localStorage.getItem('parse-server-custom-mount');
+        const _protocol   = localStorage.getItem('parse-server-custom-protocol');
+        const _appId      = localStorage.getItem('parse-server-custom-appid');
+        const _clientKey  = localStorage.getItem('parse-server-custom-clientkey');
 
-		  var html="<span class='custom-server-description'>Your Server Settings</span>";
-
-      // server url
-      var title     = "Set your parse server url here.";
-      var value     = "YOUR.PARSE-SERVER.HERE";
-      var id        = 'parse-server-custom-url';
-      var holder    = 'your.parse-server.com';
-      html+="<input id='"+id+"' class='"+className+"' type='text' placeholder='"+holder+"' value='"+value+"' title='"+title+"'>";
-
-      // mount path
-      title   = "Set your parse server mount path here.";
-      value   = "parse";
-      id      = 'parse-server-custom-mount';
-      holder  = 'parse';
-      html+="<input id='"+id+"' class='"+className+"' type='text' placeholder='"+holder+"' value='"+value+"' title='"+title+"'>";
-
-      html+="<br/>";
-
-      // add right before the first side bar section
-      document.getElementsByClassName('ui_live_toc')[0].insertAdjacentHTML('beforebegin', html);
+        // set existing entries
+        if (_url) {
+          $(".custom-parse-server-url").html(_url);
+          $("#parse-server-custom-url").val(_url);
+        }
+        if (_mount) {
+          $(".custom-parse-server-mount").html(_mount);
+          $("#parse-server-custom-mount").val(_mount);
+        }
+        if (_protocol) {
+          $(".custom-parse-server-protocol").html(_protocol);
+          $("#parse-server-custom-protocol").val(_protocol);
+        }
+        if (_appId) {
+          $(".custom-parse-server-appid").html(_appId);
+          $("#parse-server-custom-appid").val(_appId);
+        }
+        if (_clientKey) {
+          $(".custom-parse-server-clientkey").html(_clientKey);
+          $("#parse-server-custom-clientkey").val(_clientKey);
+        }
+      }
 
       // set url listener
       $('#parse-server-custom-url').keyup(function() {
-        var url = $('#parse-server-custom-url').val();
-        if(!url.match(/^[-_a-z0-9\.]+$/i)) {
+        const url = $('#parse-server-custom-url').val();
+        if(!url.match(/^[-_a-z0-9\.]+(?::[0-9]+)?$/i)) {
           // not a valid url
           return;
         }
         $(".custom-parse-server-url").html(url);
+        if (typeof(Storage) !== "undefined") {
+          localStorage.setItem('parse-server-custom-url', url);
+        }
       });
 
       // set mount listener
@@ -789,6 +799,36 @@ App.Views = {};
           mount = mount+'/';
         }
         $(".custom-parse-server-mount").html(mount);
+        if (typeof(Storage) !== "undefined") {
+          localStorage.setItem('parse-server-custom-mount', mount);
+        }
+      });
+
+      // set protocol listener
+      $('#parse-server-custom-protocol').change(function() {
+        const protocol = $('#parse-server-custom-protocol').val();
+        $(".custom-parse-server-protocol").html(protocol);
+        if (typeof(Storage) !== "undefined") {
+          localStorage.setItem('parse-server-custom-protocol', protocol);
+        }
+      });
+
+      // set appId listener
+      $('#parse-server-custom-appid').keyup(function() {
+        const appId = $('#parse-server-custom-appid').val();
+        $(".custom-parse-server-appid").html(appId);
+        if (typeof(Storage) !== "undefined") {
+          localStorage.setItem('parse-server-custom-appid', appId);
+        }
+      });
+
+      // set clientKey listener
+      $('#parse-server-custom-clientkey').keyup(function() {
+        const clientKey = $('#parse-server-custom-clientkey').val();
+        $(".custom-parse-server-clientkey").html(clientKey);
+        if (typeof(Storage) !== "undefined") {
+          localStorage.setItem('parse-server-custom-clientkey', clientKey);
+        }
       });
 
     },

--- a/_includes/android/push-notifications.md
+++ b/_includes/android/push-notifications.md
@@ -480,7 +480,7 @@ curl -X GET \
 -G \
 --data-urlencode 'limit=1000' \
 --data-urlencode 'where={ "city": "San Francisco", "deviceType": { "$in": [ "ios", "android", "winphone", "embedded" ] } }' \
-https://api.parse.com/1/installations
+https://YOUR.PARSE-SERVER.HERE/parse/installations
 ```
 
 If you type the above into a console, you should be able to see the first 1,000 objects that match your query. Note that constraints are always ANDed, so if you want to further reduce the search scope, you can add a constraint that matches the specific installation for your device:
@@ -493,7 +493,7 @@ curl -X GET \
 -G \
 --data-urlencode 'limit=1' \
 --data-urlencode 'where={ “objectId”: {YOUR_INSTALLATION_OBJECT_ID}, "city": "San Francisco", "deviceType": { "$in": [ "ios", "android", "winphone", "embedded" ] } }' \
-https://api.parse.com/1/installations
+https://YOUR.PARSE-SERVER.HERE/parse/installations
 ```
 
 If the above query returns no results, it is likely that your installation does not meet the targeting criteria for your campaign.

--- a/_includes/arduino/other.md
+++ b/_includes/arduino/other.md
@@ -5,7 +5,7 @@ Because the Arduino SDK was designed to minimize memory footprint, it doesn't pr
 For example, you could sign up a user from Arduino through a REST call:
 
 ```cpp
-ParseResponse response = Parse.sendRequest("POST", "/1/users", "{\"username\":\"cooldude6\",\"password\":\"p_n7!-e8\"}", "");
+ParseResponse response = Parse.sendRequest("POST", "/parse/users", "{\"username\":\"cooldude6\",\"password\":\"p_n7!-e8\"}", "");
 ```
 
 In this case, the response will contain the objectId of the created user, assuming it was created successfully.

--- a/_includes/arduino/requests.md
+++ b/_includes/arduino/requests.md
@@ -5,7 +5,7 @@ Because the Arduino SDK was designed to minimize memory footprint, it doesn't pr
 For example, you could sign up a user from Arduino through a REST call:
 
 ```cpp
-ParseResponse response = Parse.sendRequest("POST", "/1/users", "{\"username\":\"cooldude6\",\"password\":\"p_n7!-e8\"}", "");
+ParseResponse response = Parse.sendRequest("POST", "/parse/users", "{\"username\":\"cooldude6\",\"password\":\"p_n7!-e8\"}", "");
 ```
 
 In this case, the response will contain the objectId of the created user, assuming it was created successfully.

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -98,7 +98,7 @@ curl -X POST \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{ "movie": "The Matrix" }' \
-  https://api.parse.com/1/functions/averageStars
+  https://YOUR.PARSE-SERVER.HERE/parse/functions/averageStars
 ```
 
 And finally, to call the same function from a JavaScript app:

--- a/_includes/common/security.md
+++ b/_includes/common/security.md
@@ -456,9 +456,9 @@ There are some special classes in Parse that don't follow all of the same securi
 |Delete|normal behavior [5]|master key only [7]|
 |Add Field|normal behavior|normal behavior|
 
-1. Logging in, or `/1/login` in the REST API, does not respect the Get CLP on the user class. Login works just based on username and password, and cannot be disabled using CLPs.
+1. Logging in, or `/parse/login` in the REST API, does not respect the Get CLP on the user class. Login works just based on username and password, and cannot be disabled using CLPs.
 
-2. Retrieving the current user, or becoming a User based on a session token, which are both `/1/users/me` in the REST API, do not respect the Get CLP on the user class.
+2. Retrieving the current user, or becoming a User based on a session token, which are both `/parse/users/me` in the REST API, do not respect the Get CLP on the user class.
 
 3. Read ACLs do not apply to the logged in user. For example, if all users have ACLs with Read disabled, then doing a find query over users will still return the logged in user. However, if the Find CLP is disabled, then trying to perform a find on users will still return an error.
 

--- a/_includes/common/server-customize.md
+++ b/_includes/common/server-customize.md
@@ -11,13 +11,13 @@ Protocol:<br/>
     <option value='http'>http</option>
 </select><br/>
 Domain:
-<input id='parse-server-custom-url' class='custom-server-option' type='text' placeholder='your.domain.com, your.domain.com:1337' value='YOUR.PARSE-SERVER.HERE' title='Set your parse server domain here.' autocorrect='off'>
+<input id='parse-server-custom-url' class='custom-server-option' type='text' placeholder='your.domain.com, your.domain.com:1337' value='YOUR.PARSE-SERVER.HERE' title='Set your parse server domain here.' autocorrect='off' spellcheck='false'>
 Mount Path:
-<input id='parse-server-custom-mount' class='custom-server-option' type='text' placeholder='your-mount-path, /your-mount-path/' value='parse' title='Set your mount path here.' autocorrect='off'>
+<input id='parse-server-custom-mount' class='custom-server-option' type='text' placeholder='your-mount-path, /your-mount-path/' value='parse' title='Set your mount path here.' autocorrect='off' spellcheck='false'>
 App Id:
-<input id='parse-server-custom-appid' class='custom-server-option' type='text' placeholder='your-app-id-here' value='APPLICATION_ID' title='Set your app id here.' autocorrect='off'>
+<input id='parse-server-custom-appid' class='custom-server-option' type='text' placeholder='your-app-id-here' value='APPLICATION_ID' title='Set your app id here.' autocorrect='off' spellcheck='false'>
 Client Key:
-<input id='parse-server-custom-clientkey' class='custom-server-option' type='text' placeholder='your-client-key-here' value='CLIENT_KEY' title='Set your client here here.' autocorrect='off'>
+<input id='parse-server-custom-clientkey' class='custom-server-option' type='text' placeholder='your-client-key-here' value='CLIENT_KEY' title='Set your client here here.' autocorrect='off' spellcheck='false'>
 
 - serverUrl: <code class="highlighter-rouge"><span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span></code>
 - appId: <code class="highlighter-rouge"><span class="custom-parse-server-appid">APPLICATION_ID</span></code>

--- a/_includes/common/server-customize.md
+++ b/_includes/common/server-customize.md
@@ -11,13 +11,13 @@ Protocol:<br/>
     <option value='http'>http</option>
 </select><br/>
 Domain:
-<input id='parse-server-custom-url' class='custom-server-option' type='text' placeholder='your.domain.com, your.domain.com:1337' value='YOUR.PARSE-SERVER.HERE' title='Set your parse server domain here.'>
+<input id='parse-server-custom-url' class='custom-server-option' type='text' placeholder='your.domain.com, your.domain.com:1337' value='YOUR.PARSE-SERVER.HERE' title='Set your parse server domain here.' autocorrect='off'>
 Mount Path:
-<input id='parse-server-custom-mount' class='custom-server-option' type='text' placeholder='your-mount-path, /your-mount-path/' value='parse' title='Set your mount path here.'>
+<input id='parse-server-custom-mount' class='custom-server-option' type='text' placeholder='your-mount-path, /your-mount-path/' value='parse' title='Set your mount path here.' autocorrect='off'>
 App Id:
-<input id='parse-server-custom-appid' class='custom-server-option' type='text' placeholder='your-app-id-here' value='APPLICATION_ID' title='Set your app id here.'>
+<input id='parse-server-custom-appid' class='custom-server-option' type='text' placeholder='your-app-id-here' value='APPLICATION_ID' title='Set your app id here.' autocorrect='off'>
 Client Key:
-<input id='parse-server-custom-clientkey' class='custom-server-option' type='text' placeholder='your-client-key-here' value='CLIENT_KEY' title='Set your client here here.'>
+<input id='parse-server-custom-clientkey' class='custom-server-option' type='text' placeholder='your-client-key-here' value='CLIENT_KEY' title='Set your client here here.' autocorrect='off'>
 
 - serverUrl: <code class="highlighter-rouge"><span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span></code>
 - appId: <code class="highlighter-rouge"><span class="custom-parse-server-appid">APPLICATION_ID</span></code>

--- a/_includes/common/server-customize.md
+++ b/_includes/common/server-customize.md
@@ -1,0 +1,24 @@
+# Your Configuration
+
+<noscript>
+<p style='padding:8px;color:#fff;background:#f06;border-radius:4px;font-weight:bold'>Customization requires Javascript to be enabled!</p>
+</noscript>
+Customize our docs with your server configuration.
+
+Protocol:<br/>
+<select id='parse-server-custom-protocol' class='custom-server-option' style='border:none' title='Set your access protocol here.'>
+    <option value='https'>https</option>
+    <option value='http'>http</option>
+</select><br/>
+Domain:
+<input id='parse-server-custom-url' class='custom-server-option' type='text' placeholder='your.domain.com, your.domain.com:1337' value='YOUR.PARSE-SERVER.HERE' title='Set your parse server domain here.'>
+Mount Path:
+<input id='parse-server-custom-mount' class='custom-server-option' type='text' placeholder='your-mount-path, /your-mount-path/' value='parse' title='Set your mount path here.'>
+App Id:
+<input id='parse-server-custom-appid' class='custom-server-option' type='text' placeholder='your-app-id-here' value='APPLICATION_ID' title='Set your app id here.'>
+Client Key:
+<input id='parse-server-custom-clientkey' class='custom-server-option' type='text' placeholder='your-client-key-here' value='CLIENT_KEY' title='Set your client here here.'>
+
+- serverUrl: <code class="highlighter-rouge"><span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span></code>
+- appId: <code class="highlighter-rouge"><span class="custom-parse-server-appid">APPLICATION_ID</span></code>
+- clientKey: <code class="highlighter-rouge"><span class="custom-parse-server-clientkey">CLIENT_KEY</span></code>

--- a/_includes/embedded_c/cloud-code.md
+++ b/_includes/embedded_c/cloud-code.md
@@ -20,5 +20,5 @@ void myCloudFunctionCallback(ParseClient client, int error, int httpStatus, cons
 		// httpResponseBody holds the Cloud Function response
 	}
 }
-parseSendRequest(client, "POST", "/1/functions/hello", "{\"value\":\"echo\"}", myCloudFunctionCallback);
+parseSendRequest(client, "POST", "/parse/functions/hello", "{\"value\":\"echo\"}", myCloudFunctionCallback);
 ```

--- a/_includes/embedded_c/requests.md
+++ b/_includes/embedded_c/requests.md
@@ -3,7 +3,7 @@
 The main way you'll be interacting with Parse is through the `parseSendRequest` function, which sends a request to the REST API. For example, here's how to save an object with some data:
 
 ```cpp
-char data[] = "{ \"temperature\": 165 }"; parseSendRequest(client, "POST", "/1/classes/Temperature", data, NULL);
+char data[] = "{ \"temperature\": 165 }"; parseSendRequest(client, "POST", "/parse/classes/Temperature", data, NULL);
 ```
 
 For some requests you will be interested in data returned for the request. In such a case you need to setup a callback and pass it to `parseSendRequest`.
@@ -15,7 +15,7 @@ void mySaveCallback(ParseClient client, int error, int httpStatus, const char* h
 	}
 }
 
-parseSendRequest(client, "GET", "/1/classes/TestObject/gsMHOY3MAx", NULL, myCallback);
+parseSendRequest(client, "GET", "/parse/classes/TestObject/gsMHOY3MAx", NULL, myCallback);
 ```
 
 Using this function, you have full access to the REST API to create objects, delete objects, send analytics events, and more. Take a look at the [REST API Guide]({{ site.baseUrl }}/rest/guide) to find out all the details.

--- a/_includes/ios/push-notifications.md
+++ b/_includes/ios/push-notifications.md
@@ -875,7 +875,7 @@ curl -X GET \
 -G \
 --data-urlencode 'limit=1000' \
 --data-urlencode 'where={ "city": "San Francisco", "deviceType": { "$in": [ "ios", "android", "winphone", "embedded" ] } }' \
-https://api.parse.com/1/installations
+https://YOUR.PARSE-SERVER.HERE/parse/installations
 </code></pre>
 
 If you type the above into a console, you should be able to see the first 1,000 objects that match your query. Note that constraints are always ANDed, so if you want to further reduce the search scope, you can add a constraint that matches the specific installation for your device:
@@ -888,7 +888,7 @@ curl -X GET \
 -G \
 --data-urlencode 'limit=1' \
 --data-urlencode 'where={ “objectId”: {YOUR_INSTALLATION_OBJECT_ID}, "city": "San Francisco", "deviceType": { "$in": [ "ios", "android", "winphone", "embedded" ] } }' \
-https://api.parse.com/1/installations
+https://YOUR.PARSE-SERVER.HERE/parse/installations
 </code></pre>
 
 If the above query returns no results, it is likely that your installation does not meet the targeting criteria for your campaign.

--- a/_includes/js/users.md
+++ b/_includes/js/users.md
@@ -464,7 +464,7 @@ Parse then verifies that the provided `authData` is valid and checks to see if a
 
 <pre><code class="javascript">
 Status: 200 OK
-Location: https://api.parse.com/1/users/uMz0YZeAqc
+Location: https://YOUR.PARSE-SERVER.HERE/parse/users/uMz0YZeAqc
 </code></pre>
 
 With a response body like:
@@ -492,7 +492,7 @@ If the user has never been linked with this account, you will instead receive a 
 
 <pre><code class="javascript">
 Status: 201 Created
-Location: https://api.parse.com/1/users/uMz0YZeAqc
+Location: https://YOUR.PARSE-SERVER.HERE/parse/users/uMz0YZeAqc
 </code></pre>
 The body of the response will contain the `objectId`, `createdAt`, `sessionToken`, and an automatically-generated unique `username`.  For example:
 

--- a/_includes/rest/analytics.md
+++ b/_includes/rest/analytics.md
@@ -25,12 +25,12 @@ In the example below, the `at` parameter is optional. If omitted, the current se
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>events/AppOpened
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>events/AppOpened
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -38,7 +38,7 @@ connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR
 connection.connect()
 connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>events/AppOpened', json.dumps({
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -57,7 +57,7 @@ Say your app offers search functionality for apartment listings, and you want to
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -67,7 +67,7 @@ curl -X POST \
           "dayType": "weekday"
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>events/Search
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>events/Search
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -80,7 +80,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          "dayType": "weekday"
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -92,7 +92,7 @@ Parse Analytics can even be used as a lightweight error tracker — simply invok
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -100,7 +100,7 @@ curl -X POST \
           "code": "404"
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>events/Error
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>events/Error
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -111,7 +111,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          "code": "404"
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -119,4 +119,4 @@ result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
 
-Note that Parse currently only stores the first eight dimension pairs per call to `<span class="custom-parse-server-mount">/parse/</span>events/<eventName>`.
+Note that Parse currently only stores the first eight dimension pairs per call to <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>events/&lt;eventName&gt;</code>.

--- a/_includes/rest/analytics.md
+++ b/_includes/rest/analytics.md
@@ -30,13 +30,13 @@ curl -X POST \
   -H "Content-Type: application/json" \
   -d '{
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/events/AppOpened
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>events/AppOpened
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/events/AppOpened', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>events/AppOpened', json.dumps({
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
@@ -67,13 +67,13 @@ curl -X POST \
           "dayType": "weekday"
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/events/Search
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>events/Search
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/events/Search', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>events/Search', json.dumps({
        "dimensions": {
          "priceRange": "1000-1500",
          "source": "craigslist",
@@ -100,13 +100,13 @@ curl -X POST \
           "code": "404"
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/events/Error
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>events/Error
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/events/Error', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>events/Error', json.dumps({
        "dimensions": {
          "code": "404"
        }
@@ -119,4 +119,4 @@ result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
 
-Note that Parse currently only stores the first eight dimension pairs per call to `/parse/events/<eventName>`.
+Note that Parse currently only stores the first eight dimension pairs per call to `<span class="custom-parse-server-mount">/parse/</span>events/<eventName>`.

--- a/_includes/rest/analytics.md
+++ b/_includes/rest/analytics.md
@@ -30,13 +30,13 @@ curl -X POST \
   -H "Content-Type: application/json" \
   -d '{
       }' \
-  https://api.parse.com/1/events/AppOpened
+  https://YOUR.PARSE-SERVER.HERE/parse/events/AppOpened
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/events/AppOpened', json.dumps({
+connection.request('POST', '/parse/events/AppOpened', json.dumps({
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
@@ -67,13 +67,13 @@ curl -X POST \
           "dayType": "weekday"
         }
       }' \
-  https://api.parse.com/1/events/Search
+  https://YOUR.PARSE-SERVER.HERE/parse/events/Search
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/events/Search', json.dumps({
+connection.request('POST', '/parse/events/Search', json.dumps({
        "dimensions": {
          "priceRange": "1000-1500",
          "source": "craigslist",
@@ -100,13 +100,13 @@ curl -X POST \
           "code": "404"
         }
       }' \
-  https://api.parse.com/1/events/Error
+  https://YOUR.PARSE-SERVER.HERE/parse/events/Error
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/events/Error', json.dumps({
+connection.request('POST', '/parse/events/Error', json.dumps({
        "dimensions": {
          "code": "404"
        }
@@ -119,4 +119,4 @@ result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
 
-Note that Parse currently only stores the first eight dimension pairs per call to `/1/events/<eventName>`.
+Note that Parse currently only stores the first eight dimension pairs per call to `/parse/events/<eventName>`.

--- a/_includes/rest/cloud-code.md
+++ b/_includes/rest/cloud-code.md
@@ -10,13 +10,13 @@ curl -X POST \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{}' \
-  https://api.parse.com/1/functions/hello
+  https://YOUR.PARSE-SERVER.HERE/parse/functions/hello
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/functions/hello', json.dumps({
+connection.request('POST', '/parse/functions/hello', json.dumps({
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
@@ -40,13 +40,13 @@ curl -X POST \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"plan":"paid"}' \
-  https://api.parse.com/1/jobs/userMigration
+  https://YOUR.PARSE-SERVER.HERE/parse/jobs/userMigration
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/jobs/userMigration', json.dumps({
+connection.request('POST', '/parse/jobs/userMigration', json.dumps({
        "plan": "paid"
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",

--- a/_includes/rest/cloud-code.md
+++ b/_includes/rest/cloud-code.md
@@ -10,13 +10,13 @@ curl -X POST \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/functions/hello
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>functions/hello
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/functions/hello', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>functions/hello', json.dumps({
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
@@ -40,13 +40,13 @@ curl -X POST \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"plan":"paid"}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/jobs/userMigration
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>jobs/userMigration
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/jobs/userMigration', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>jobs/userMigration', json.dumps({
        "plan": "paid"
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",

--- a/_includes/rest/cloud-code.md
+++ b/_includes/rest/cloud-code.md
@@ -6,11 +6,11 @@ Cloud Functions can be called using the REST API. For example, to call the Cloud
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>functions/hello
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>functions/hello
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -18,7 +18,7 @@ connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR
 connection.connect()
 connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>functions/hello', json.dumps({
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -36,11 +36,11 @@ Similarly, you can trigger a background job from the REST API. For example, to t
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"plan":"paid"}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>jobs/userMigration
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>jobs/userMigration
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -49,7 +49,7 @@ connection.connect()
 connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>jobs/userMigration', json.dumps({
        "plan": "paid"
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })

--- a/_includes/rest/config.md
+++ b/_includes/rest/config.md
@@ -8,16 +8,16 @@ After that you will be able to fetch the config on the client by sending a `GET`
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>config
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>config
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>config', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -39,10 +39,10 @@ You can also update the config by sending a `PUT` request to config URL. Here is
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -d "{\"params\":{\"winningNumber\":43}}"
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>config
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>config
 </code></pre>
 <pre><code class="javascript">
 var request = require('request');

--- a/_includes/rest/config.md
+++ b/_includes/rest/config.md
@@ -10,13 +10,13 @@ After that you will be able to fetch the config on the client by sending a `GET`
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://api.parse.com/1/config
+  https://YOUR.PARSE-SERVER.HERE/parse/config
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/config', '', {
+connection.request('GET', '/parse/config', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -42,7 +42,7 @@ curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -d "{\"params\":{\"winningNumber\":43}}"
-  https://api.parse.com/1/config
+  https://YOUR.PARSE-SERVER.HERE/parse/config
 </code></pre>
 <pre><code class="javascript">
 var request = require('request');

--- a/_includes/rest/config.md
+++ b/_includes/rest/config.md
@@ -10,13 +10,13 @@ After that you will be able to fetch the config on the client by sending a `GET`
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://YOUR.PARSE-SERVER.HERE/parse/config
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>config
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/config', '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>config', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -42,7 +42,7 @@ curl -X PUT \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -d "{\"params\":{\"winningNumber\":43}}"
-  https://YOUR.PARSE-SERVER.HERE/parse/config
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>config
 </code></pre>
 <pre><code class="javascript">
 var request = require('request');

--- a/_includes/rest/files.md
+++ b/_includes/rest/files.md
@@ -10,13 +10,13 @@ curl -X POST \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: text/plain" \
   -d 'Hello, World!' \
-  https://YOUR.PARSE-SERVER.HERE/parse/files/hello.txt
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>files/hello.txt
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/files/hello.txt', 'Hello, World!', {
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>files/hello.txt', 'Hello, World!', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "text/plain"
@@ -49,13 +49,13 @@ curl -X POST \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: image/jpeg" \
   --data-binary '@myPicture.jpg' \
-  https://YOUR.PARSE-SERVER.HERE/parse/files/pic.jpg
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>files/pic.jpg
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/files/pic.jpg', open('myPicture.jpg', 'rb').read(), {
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>files/pic.jpg', open('myPicture.jpg', 'rb').read(), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "image/jpeg"
@@ -81,13 +81,13 @@ curl -X POST \
           "__type": "File"
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/PlayerProfile
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/PlayerProfile
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/classes/PlayerProfile', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>classes/PlayerProfile', json.dumps({
        "name": "Andrew",
        "picture": {
          "name": "...profile.png",
@@ -114,13 +114,13 @@ Users holding the master key are allowed to delete files using the REST API. To 
 curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
-  https://YOUR.PARSE-SERVER.HERE/parse/files/...profile.png
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>files/...profile.png
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('DELETE', '/parse/files/...profile.png', '', {
+connection.request('DELETE', '<span class="custom-parse-server-mount">/parse/</span>files/...profile.png', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}"
      })

--- a/_includes/rest/files.md
+++ b/_includes/rest/files.md
@@ -10,13 +10,13 @@ curl -X POST \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: text/plain" \
   -d 'Hello, World!' \
-  https://api.parse.com/1/files/hello.txt
+  https://YOUR.PARSE-SERVER.HERE/parse/files/hello.txt
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/files/hello.txt', 'Hello, World!', {
+connection.request('POST', '/parse/files/hello.txt', 'Hello, World!', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "text/plain"
@@ -49,13 +49,13 @@ curl -X POST \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: image/jpeg" \
   --data-binary '@myPicture.jpg' \
-  https://api.parse.com/1/files/pic.jpg
+  https://YOUR.PARSE-SERVER.HERE/parse/files/pic.jpg
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/files/pic.jpg', open('myPicture.jpg', 'rb').read(), {
+connection.request('POST', '/parse/files/pic.jpg', open('myPicture.jpg', 'rb').read(), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "image/jpeg"
@@ -81,13 +81,13 @@ curl -X POST \
           "__type": "File"
         }
       }' \
-  https://api.parse.com/1/classes/PlayerProfile
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/PlayerProfile
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/classes/PlayerProfile', json.dumps({
+connection.request('POST', '/parse/classes/PlayerProfile', json.dumps({
        "name": "Andrew",
        "picture": {
          "name": "...profile.png",
@@ -114,13 +114,13 @@ Users holding the master key are allowed to delete files using the REST API. To 
 curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
-  https://api.parse.com/1/files/...profile.png
+  https://YOUR.PARSE-SERVER.HERE/parse/files/...profile.png
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('DELETE', '/1/files/...profile.png', '', {
+connection.request('DELETE', '/parse/files/...profile.png', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}"
      })

--- a/_includes/rest/files.md
+++ b/_includes/rest/files.md
@@ -6,18 +6,18 @@ To upload a file to Parse, send a POST request to the files URL, postfixed with 
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: text/plain" \
   -d 'Hello, World!' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>files/hello.txt
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>files/hello.txt
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>files/hello.txt', 'Hello, World!', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "text/plain"
      })
@@ -45,18 +45,18 @@ To upload an image, the syntax is a little bit different. Here's an example that
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: image/jpeg" \
   --data-binary '@myPicture.jpg' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>files/pic.jpg
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>files/pic.jpg
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>files/pic.jpg', open('myPicture.jpg', 'rb').read(), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "image/jpeg"
      })
@@ -70,7 +70,7 @@ After files are uploaded, you can associate them with Parse objects:
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -81,7 +81,7 @@ curl -X POST \
           "__type": "File"
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/PlayerProfile
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/PlayerProfile
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -95,7 +95,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          "__type": "File"
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -112,16 +112,16 @@ Users holding the master key are allowed to delete files using the REST API. To 
 
 <pre><code class="bash">
 curl -X DELETE \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>files/...profile.png
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>files/...profile.png
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('DELETE', '<span class="custom-parse-server-mount">/parse/</span>files/...profile.png', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}"
      })
 result = json.loads(connection.getresponse().read())

--- a/_includes/rest/geopoints.md
+++ b/_includes/rest/geopoints.md
@@ -18,13 +18,13 @@ curl -X POST \
           "longitude": -30.0
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/PlaceObject
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/PlaceObject
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/classes/PlaceObject', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>classes/PlaceObject', json.dumps({
        "location": {
          "__type": "GeoPoint",
          "latitude": 40.0,
@@ -58,11 +58,11 @@ curl -X GET \
           }
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/PlaceObject
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/PlaceObject
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"limit":10,"where":json.dumps({
        "location": {
          "$nearSphere": {
@@ -73,7 +73,7 @@ params = urllib.urlencode({"limit":10,"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/PlaceObject?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/PlaceObject?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -127,11 +127,11 @@ curl -X GET \
           "$maxDistanceInMiles": 10.0
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/PlaceObject
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/PlaceObject
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "location": {
          "$nearSphere": {
@@ -143,7 +143,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/PlaceObject?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/PlaceObject?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -176,11 +176,11 @@ curl -X GET \
           }
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/PizzaPlaceObject
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/PizzaPlaceObject
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "location": {
          "$within": {
@@ -200,7 +200,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/PizzaPlaceObject?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/PizzaPlaceObject?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })

--- a/_includes/rest/geopoints.md
+++ b/_includes/rest/geopoints.md
@@ -18,13 +18,13 @@ curl -X POST \
           "longitude": -30.0
         }
       }' \
-  https://api.parse.com/1/classes/PlaceObject
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/PlaceObject
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/classes/PlaceObject', json.dumps({
+connection.request('POST', '/parse/classes/PlaceObject', json.dumps({
        "location": {
          "__type": "GeoPoint",
          "latitude": 40.0,
@@ -58,11 +58,11 @@ curl -X GET \
           }
         }
       }' \
-  https://api.parse.com/1/classes/PlaceObject
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/PlaceObject
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"limit":10,"where":json.dumps({
        "location": {
          "$nearSphere": {
@@ -73,7 +73,7 @@ params = urllib.urlencode({"limit":10,"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/1/classes/PlaceObject?%s' % params, '', {
+connection.request('GET', '/parse/classes/PlaceObject?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -127,11 +127,11 @@ curl -X GET \
           "$maxDistanceInMiles": 10.0
         }
       }' \
-  https://api.parse.com/1/classes/PlaceObject
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/PlaceObject
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "location": {
          "$nearSphere": {
@@ -143,7 +143,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/1/classes/PlaceObject?%s' % params, '', {
+connection.request('GET', '/parse/classes/PlaceObject?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -176,11 +176,11 @@ curl -X GET \
           }
         }
       }' \
-  https://api.parse.com/1/classes/PizzaPlaceObject
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/PizzaPlaceObject
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "location": {
          "$within": {
@@ -200,7 +200,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/1/classes/PizzaPlaceObject?%s' % params, '', {
+connection.request('GET', '/parse/classes/PizzaPlaceObject?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })

--- a/_includes/rest/geopoints.md
+++ b/_includes/rest/geopoints.md
@@ -8,7 +8,7 @@ To associate a point with an object you will need to embed a `GeoPoint` data typ
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -18,7 +18,7 @@ curl -X POST \
           "longitude": -30.0
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/PlaceObject
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/PlaceObject
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -31,7 +31,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          "longitude": -30.0
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -45,7 +45,7 @@ Now that you have a bunch of objects with spatial coordinates, it would be nice 
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'limit=10' \
@@ -58,7 +58,7 @@ curl -X GET \
           }
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/PlaceObject
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/PlaceObject
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -74,7 +74,7 @@ params = urllib.urlencode({"limit":10,"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/PlaceObject?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -114,7 +114,7 @@ To limit the search to a maximum distance add a `$maxDistanceInMiles` (for miles
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={
@@ -127,7 +127,7 @@ curl -X GET \
           "$maxDistanceInMiles": 10.0
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/PlaceObject
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/PlaceObject
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -144,7 +144,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/PlaceObject?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -155,7 +155,7 @@ It's also possible to query for the set of objects that are contained within a p
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={
@@ -176,7 +176,7 @@ curl -X GET \
           }
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/PizzaPlaceObject
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/PizzaPlaceObject
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -201,7 +201,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/PizzaPlaceObject?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())

--- a/_includes/rest/hooks.md
+++ b/_includes/rest/hooks.md
@@ -56,13 +56,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://YOUR.PARSE-SERVER.HERE/parse/hooks/functions
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/hooks/functions', '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>hooks/functions', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
@@ -90,13 +90,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://YOUR.PARSE-SERVER.HERE/parse/hooks/functions/sendMessage
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions/sendMessage
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/hooks/functions/sendMessage', '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>hooks/functions/sendMessage', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
@@ -123,13 +123,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://YOUR.PARSE-SERVER.HERE/parse/hooks/triggers
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/hooks/triggers', '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>hooks/triggers', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
@@ -164,13 +164,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://YOUR.PARSE-SERVER.HERE/parse/hooks/triggers/Scores/beforeSave
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Scores/beforeSave
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/hooks/triggers/Scores/beforeSave', '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Scores/beforeSave', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
@@ -204,7 +204,7 @@ To create cloud code functions or cloud code triggers you can modify your cloud 
 and perform a `parse deploy` the usual way.
 
 ## Create function webhook
-To create a new function webhook post to `/parse/hooks/functions` with payload in the format
+To create a new function webhook post to `<span class="custom-parse-server-mount">/parse/</span>hooks/functions` with payload in the format
 <pre><code class="bash">
 {"functionName" : x, "url" : y}
 </code></pre>
@@ -217,13 +217,13 @@ curl -X POST \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"functionName":"baz","url":"https://api.example.com/baz"}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/hooks/functions
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/hooks/functions', json.dumps(
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>hooks/functions', json.dumps(
        {"functionName":"baz","url":"https://api.example.com/baz"}
      ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -250,13 +250,13 @@ curl -X POST \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"functionName":"bar","url":"https://api.example.com/bar"}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/hooks/functions
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/hooks/functions', json.dumps(
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>hooks/functions', json.dumps(
        {"functionName":"bar","url":"https://api.example.com/bar"}
      ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -277,7 +277,7 @@ The output may look like this:
 </code></pre>
 
 ## Create trigger webhook
-To create a new function webhook post to `/parse/hooks/triggers` with payload in the format
+To create a new function webhook post to `<span class="custom-parse-server-mount">/parse/</span>hooks/triggers` with payload in the format
 <pre><code class="bash">
 {"className": x, "triggerName": y, "url": z}
 </code></pre>
@@ -292,13 +292,13 @@ curl -X POST \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"className": "Game", "triggerName": "beforeSave", "url": "https://api.example.com/Game/beforeSave"}' \
-https://YOUR.PARSE-SERVER.HERE/parse/hooks/triggers
+https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/hooks/triggers', json.dumps(
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>hooks/triggers', json.dumps(
        {"className": "Game", "triggerName": "beforeSave", "url": "https://api.example.com/Game/beforeSave"}
      ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -329,13 +329,13 @@ curl -X POST \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"className": "Tournament", "triggerName": "beforeDelete", "url": "https://api.example.com/Scores/beforeDelete"}' \
-https://YOUR.PARSE-SERVER.HERE/parse/hooks/triggers
+https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/hooks/triggers', json.dumps(
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>hooks/triggers', json.dumps(
        {"className": "Tournament", "triggerName": "beforeDelete", "url": "https://api.example.com/Scores/beforeDelete"}
      ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -366,13 +366,13 @@ curl -X PUT \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"url":"https://api.example.com/_baz"}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/hooks/functions/baz
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions/baz
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/hooks/functions/baz', json.dumps(
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>hooks/functions/baz', json.dumps(
     {"url":"https://api.example.com/_baz"}
       ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -399,13 +399,13 @@ curl -X PUT \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"url":"https://api.example.com/_bar"}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/hooks/functions/bar
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions/bar
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/hooks/functions/bar', json.dumps(
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>hooks/functions/bar', json.dumps(
       {"url":"https://api.example.com/_bar"}
       ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -434,13 +434,13 @@ curl -X PUT \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"url": "https://api.example.com/Game/_beforeSave"}' \
-https://YOUR.PARSE-SERVER.HERE/parse/hooks/triggers/Game/beforeSave
+https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Game/beforeSave
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/hooks/triggers/Game/beforeSave', json.dumps(
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Game/beforeSave', json.dumps(
       {"url": "https://api.example.com/Game/_beforeSave"}
       ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -471,13 +471,13 @@ curl -X PUT \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"url": "https://api.example.com/Scores/beforeDelete"}' \
-https://YOUR.PARSE-SERVER.HERE/parse/hooks/triggers/Tournament/beforeDelete
+https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Tournament/beforeDelete
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/hooks/triggers/Tournament/beforeDelete', json.dumps(
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Tournament/beforeDelete', json.dumps(
       {"url": "https://api.example.com/Scores/beforeDelete"}
       ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -507,13 +507,13 @@ curl -X PUT \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"__op": "Delete"}' \
-https://YOUR.PARSE-SERVER.HERE/parse/hooks/functions/foo
+https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions/foo
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/hooks/functions/foo', json.dumps(
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>hooks/functions/foo', json.dumps(
       {"__op": "Delete"}
       ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -538,13 +538,13 @@ curl -X PUT \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{ "__op": "Delete" }' \
-https://YOUR.PARSE-SERVER.HERE/parse/hooks/functions/sendMessage
+https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions/sendMessage
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/hooks/functions/sendMessage', json.dumps(
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>hooks/functions/sendMessage', json.dumps(
       {"__op": "Delete"}
       ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -569,13 +569,13 @@ curl -X PUT \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{ "__op": "Delete" }' \
-https://YOUR.PARSE-SERVER.HERE/parse/hooks/triggers/Game/beforeSave
+https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Game/beforeSave
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/hooks/triggers/Game/beforeSave', json.dumps(
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Game/beforeSave', json.dumps(
       {"__op": "Delete"}
       ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -600,13 +600,13 @@ curl -X PUT \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{ "__op": "Delete" }' \
-https://YOUR.PARSE-SERVER.HERE/parse/hooks/triggers/Tournament/beforeDelete
+https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Tournament/beforeDelete
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/hooks/triggers/Tournament/beforeDelete', json.dumps(
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Tournament/beforeDelete', json.dumps(
       {"__op": "Delete"}
       ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",

--- a/_includes/rest/hooks.md
+++ b/_includes/rest/hooks.md
@@ -53,17 +53,17 @@ To fetch the list of all cloud functions you deployed or created, use:
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>hooks/functions', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -87,17 +87,17 @@ To fetch a single cloud function with a given name, use:
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions/sendMessage
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions/sendMessage
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>hooks/functions/sendMessage', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -120,17 +120,17 @@ The output is a json object with one key: "results" whose value is a list of clo
 To fetch the list of all cloud triggers you deployed or created, use:
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>hooks/triggers', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -161,17 +161,17 @@ The output is a json object with one key: "results" whose value is a list of clo
 To fetch a single cloud trigger, use:
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Scores/beforeSave
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Scores/beforeSave
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Scores/beforeSave', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -204,20 +204,21 @@ To create cloud code functions or cloud code triggers you can modify your cloud 
 and perform a `parse deploy` the usual way.
 
 ## Create function webhook
-To create a new function webhook post to `<span class="custom-parse-server-mount">/parse/</span>hooks/functions` with payload in the format
-<pre><code class="bash">
+To create a new function webhook post to <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>hooks/functions</code> with payload in the format
+
+```json
 {"functionName" : x, "url" : y}
-</code></pre>
+```
 
 Post example,
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"functionName":"baz","url":"https://api.example.com/baz"}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -226,7 +227,7 @@ connection.connect()
 connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>hooks/functions', json.dumps(
        {"functionName":"baz","url":"https://api.example.com/baz"}
      ), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -246,11 +247,11 @@ If you try to create a function webhook and a cloud code function with the same 
 For example,
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"functionName":"bar","url":"https://api.example.com/bar"}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -259,7 +260,7 @@ connection.connect()
 connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>hooks/functions', json.dumps(
        {"functionName":"bar","url":"https://api.example.com/bar"}
      ), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -277,7 +278,7 @@ The output may look like this:
 </code></pre>
 
 ## Create trigger webhook
-To create a new function webhook post to `<span class="custom-parse-server-mount">/parse/</span>hooks/triggers` with payload in the format
+To create a new function webhook post to <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>hooks/triggers</code> with payload in the format
 <pre><code class="bash">
 {"className": x, "triggerName": y, "url": z}
 </code></pre>
@@ -288,11 +289,11 @@ To create a new function webhook post to `<span class="custom-parse-server-mount
 Post example,
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"className": "Game", "triggerName": "beforeSave", "url": "https://api.example.com/Game/beforeSave"}' \
-https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers
+<span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -301,7 +302,7 @@ connection.connect()
 connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>hooks/triggers', json.dumps(
        {"className": "Game", "triggerName": "beforeSave", "url": "https://api.example.com/Game/beforeSave"}
      ), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -325,11 +326,11 @@ If you try to create a trigger webhook and a cloud code trigger with the same na
 For example,
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"className": "Tournament", "triggerName": "beforeDelete", "url": "https://api.example.com/Scores/beforeDelete"}' \
-https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers
+<span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -338,7 +339,7 @@ connection.connect()
 connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>hooks/triggers', json.dumps(
        {"className": "Tournament", "triggerName": "beforeDelete", "url": "https://api.example.com/Scores/beforeDelete"}
      ), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -362,11 +363,11 @@ To edit the url of a function webhook that was already created use the put metho
 Put example,
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"url":"https://api.example.com/_baz"}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions/baz
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions/baz
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -375,7 +376,7 @@ connection.connect()
 connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>hooks/functions/baz', json.dumps(
     {"url":"https://api.example.com/_baz"}
       ), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -395,11 +396,11 @@ If you try to update a function webhook and a cloud code function with the same 
 For example,
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"url":"https://api.example.com/_bar"}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions/bar
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions/bar
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -408,7 +409,7 @@ connection.connect()
 connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>hooks/functions/bar', json.dumps(
       {"url":"https://api.example.com/_bar"}
       ), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -430,11 +431,11 @@ To edit the url of a trigger webhook that was already crated use the put method.
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"url": "https://api.example.com/Game/_beforeSave"}' \
-https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Game/beforeSave
+<span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Game/beforeSave
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -443,7 +444,7 @@ connection.connect()
 connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Game/beforeSave', json.dumps(
       {"url": "https://api.example.com/Game/_beforeSave"}
       ), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -467,11 +468,11 @@ If you try to update a trigger webhook and a cloud code trigger with the same na
 For example,
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"url": "https://api.example.com/Scores/beforeDelete"}' \
-https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Tournament/beforeDelete
+<span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Tournament/beforeDelete
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -480,7 +481,7 @@ connection.connect()
 connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Tournament/beforeDelete', json.dumps(
       {"url": "https://api.example.com/Scores/beforeDelete"}
       ), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -503,11 +504,11 @@ To delete a function webhook use the put method.
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"__op": "Delete"}' \
-https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions/foo
+<span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions/foo
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -516,7 +517,7 @@ connection.connect()
 connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>hooks/functions/foo', json.dumps(
       {"__op": "Delete"}
       ), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -534,11 +535,11 @@ Since the overriding webhook was just deleted, this cloud code function will be 
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{ "__op": "Delete" }' \
-https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions/sendMessage
+<span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/functions/sendMessage
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -547,7 +548,7 @@ connection.connect()
 connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>hooks/functions/sendMessage', json.dumps(
       {"__op": "Delete"}
       ), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -565,11 +566,11 @@ To delete a trigger webhook use the put method.
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{ "__op": "Delete" }' \
-https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Game/beforeSave
+<span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Game/beforeSave
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -578,7 +579,7 @@ connection.connect()
 connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Game/beforeSave', json.dumps(
       {"__op": "Delete"}
       ), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -596,11 +597,11 @@ Since the overriding webhook was just deleted, this cloud code trigger will be r
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{ "__op": "Delete" }' \
-https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Tournament/beforeDelete
+<span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Tournament/beforeDelete
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -609,7 +610,7 @@ connection.connect()
 connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>hooks/triggers/Tournament/beforeDelete', json.dumps(
       {"__op": "Delete"}
       ), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })

--- a/_includes/rest/hooks.md
+++ b/_includes/rest/hooks.md
@@ -56,13 +56,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://api.parse.com/1/hooks/functions
+  https://YOUR.PARSE-SERVER.HERE/parse/hooks/functions
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/hooks/functions', '', {
+connection.request('GET', '/parse/hooks/functions', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
@@ -90,13 +90,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://api.parse.com/1/hooks/functions/sendMessage
+  https://YOUR.PARSE-SERVER.HERE/parse/hooks/functions/sendMessage
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/hooks/functions/sendMessage', '', {
+connection.request('GET', '/parse/hooks/functions/sendMessage', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
@@ -123,13 +123,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://api.parse.com/1/hooks/triggers
+  https://YOUR.PARSE-SERVER.HERE/parse/hooks/triggers
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/hooks/triggers', '', {
+connection.request('GET', '/parse/hooks/triggers', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
@@ -164,13 +164,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://api.parse.com/1/hooks/triggers/Scores/beforeSave
+  https://YOUR.PARSE-SERVER.HERE/parse/hooks/triggers/Scores/beforeSave
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/hooks/triggers/Scores/beforeSave', '', {
+connection.request('GET', '/parse/hooks/triggers/Scores/beforeSave', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
@@ -204,7 +204,7 @@ To create cloud code functions or cloud code triggers you can modify your cloud 
 and perform a `parse deploy` the usual way.
 
 ## Create function webhook
-To create a new function webhook post to `/1/hooks/functions` with payload in the format
+To create a new function webhook post to `/parse/hooks/functions` with payload in the format
 <pre><code class="bash">
 {"functionName" : x, "url" : y}
 </code></pre>
@@ -217,13 +217,13 @@ curl -X POST \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"functionName":"baz","url":"https://api.example.com/baz"}' \
-  https://api.parse.com/1/hooks/functions
+  https://YOUR.PARSE-SERVER.HERE/parse/hooks/functions
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/hooks/functions', json.dumps(
+connection.request('POST', '/parse/hooks/functions', json.dumps(
        {"functionName":"baz","url":"https://api.example.com/baz"}
      ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -250,13 +250,13 @@ curl -X POST \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"functionName":"bar","url":"https://api.example.com/bar"}' \
-  https://api.parse.com/1/hooks/functions
+  https://YOUR.PARSE-SERVER.HERE/parse/hooks/functions
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/hooks/functions', json.dumps(
+connection.request('POST', '/parse/hooks/functions', json.dumps(
        {"functionName":"bar","url":"https://api.example.com/bar"}
      ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -277,7 +277,7 @@ The output may look like this:
 </code></pre>
 
 ## Create trigger webhook
-To create a new function webhook post to `/1/hooks/triggers` with payload in the format
+To create a new function webhook post to `/parse/hooks/triggers` with payload in the format
 <pre><code class="bash">
 {"className": x, "triggerName": y, "url": z}
 </code></pre>
@@ -292,13 +292,13 @@ curl -X POST \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"className": "Game", "triggerName": "beforeSave", "url": "https://api.example.com/Game/beforeSave"}' \
-https://api.parse.com/1/hooks/triggers
+https://YOUR.PARSE-SERVER.HERE/parse/hooks/triggers
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/hooks/triggers', json.dumps(
+connection.request('POST', '/parse/hooks/triggers', json.dumps(
        {"className": "Game", "triggerName": "beforeSave", "url": "https://api.example.com/Game/beforeSave"}
      ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -329,13 +329,13 @@ curl -X POST \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"className": "Tournament", "triggerName": "beforeDelete", "url": "https://api.example.com/Scores/beforeDelete"}' \
-https://api.parse.com/1/hooks/triggers
+https://YOUR.PARSE-SERVER.HERE/parse/hooks/triggers
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/hooks/triggers', json.dumps(
+connection.request('POST', '/parse/hooks/triggers', json.dumps(
        {"className": "Tournament", "triggerName": "beforeDelete", "url": "https://api.example.com/Scores/beforeDelete"}
      ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -366,13 +366,13 @@ curl -X PUT \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"url":"https://api.example.com/_baz"}' \
-  https://api.parse.com/1/hooks/functions/baz
+  https://YOUR.PARSE-SERVER.HERE/parse/hooks/functions/baz
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/hooks/functions/baz', json.dumps(
+connection.request('PUT', '/parse/hooks/functions/baz', json.dumps(
     {"url":"https://api.example.com/_baz"}
       ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -399,13 +399,13 @@ curl -X PUT \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"url":"https://api.example.com/_bar"}' \
-  https://api.parse.com/1/hooks/functions/bar
+  https://YOUR.PARSE-SERVER.HERE/parse/hooks/functions/bar
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/hooks/functions/bar', json.dumps(
+connection.request('PUT', '/parse/hooks/functions/bar', json.dumps(
       {"url":"https://api.example.com/_bar"}
       ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -434,13 +434,13 @@ curl -X PUT \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"url": "https://api.example.com/Game/_beforeSave"}' \
-https://api.parse.com/1/hooks/triggers/Game/beforeSave
+https://YOUR.PARSE-SERVER.HERE/parse/hooks/triggers/Game/beforeSave
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/hooks/triggers/Game/beforeSave', json.dumps(
+connection.request('PUT', '/parse/hooks/triggers/Game/beforeSave', json.dumps(
       {"url": "https://api.example.com/Game/_beforeSave"}
       ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -471,13 +471,13 @@ curl -X PUT \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"url": "https://api.example.com/Scores/beforeDelete"}' \
-https://api.parse.com/1/hooks/triggers/Tournament/beforeDelete
+https://YOUR.PARSE-SERVER.HERE/parse/hooks/triggers/Tournament/beforeDelete
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/hooks/triggers/Tournament/beforeDelete', json.dumps(
+connection.request('PUT', '/parse/hooks/triggers/Tournament/beforeDelete', json.dumps(
       {"url": "https://api.example.com/Scores/beforeDelete"}
       ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -507,13 +507,13 @@ curl -X PUT \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"__op": "Delete"}' \
-https://api.parse.com/1/hooks/functions/foo
+https://YOUR.PARSE-SERVER.HERE/parse/hooks/functions/foo
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/hooks/functions/foo', json.dumps(
+connection.request('PUT', '/parse/hooks/functions/foo', json.dumps(
       {"__op": "Delete"}
       ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -538,13 +538,13 @@ curl -X PUT \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{ "__op": "Delete" }' \
-https://api.parse.com/1/hooks/functions/sendMessage
+https://YOUR.PARSE-SERVER.HERE/parse/hooks/functions/sendMessage
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/hooks/functions/sendMessage', json.dumps(
+connection.request('PUT', '/parse/hooks/functions/sendMessage', json.dumps(
       {"__op": "Delete"}
       ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -569,13 +569,13 @@ curl -X PUT \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{ "__op": "Delete" }' \
-https://api.parse.com/1/hooks/triggers/Game/beforeSave
+https://YOUR.PARSE-SERVER.HERE/parse/hooks/triggers/Game/beforeSave
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/hooks/triggers/Game/beforeSave', json.dumps(
+connection.request('PUT', '/parse/hooks/triggers/Game/beforeSave', json.dumps(
       {"__op": "Delete"}
       ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -600,13 +600,13 @@ curl -X PUT \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{ "__op": "Delete" }' \
-https://api.parse.com/1/hooks/triggers/Tournament/beforeDelete
+https://YOUR.PARSE-SERVER.HERE/parse/hooks/triggers/Tournament/beforeDelete
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/hooks/triggers/Tournament/beforeDelete', json.dumps(
+connection.request('PUT', '/parse/hooks/triggers/Tournament/beforeDelete', json.dumps(
       {"__op": "Delete"}
       ), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",

--- a/_includes/rest/objects.md
+++ b/_includes/rest/objects.md
@@ -36,19 +36,19 @@ When you retrieve objects from Parse, some fields are automatically added: `crea
 In the REST API, the class-level operations operate on a resource based on just the class name. For example, if the class name is `GameScore`, the class URL is:
 
 <pre><code class="javascript">
-https://api.parse.com/1/classes/GameScore
+https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
 </code></pre>
 
 Users have a special class-level url:
 
 <pre><code class="javascript">
-https://api.parse.com/1/users
+https://YOUR.PARSE-SERVER.HERE/parse/users
 </code></pre>
 
 The operations specific to a single object are available a nested URL. For example, operations specific to the `GameScore` above with `objectId` equal to `Ed1nuqPvcm` would use the object URL:
 
 <pre><code class="javascript">
-https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
+https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
 </code></pre>
 
 
@@ -62,14 +62,14 @@ To create a new object on Parse, send a POST request to the class URL containing
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"score":1337,"playerName":"Sean Plott","cheatMode":false}' \
-  https://api.parse.com/1/classes/GameScore
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
 </code></pre>
 
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/classes/GameScore', json.dumps({
+connection.request('POST', '/parse/classes/GameScore', json.dumps({
        "score": 1337,
        "playerName": "Sean Plott",
        "cheatMode": False
@@ -86,7 +86,7 @@ When the creation is successful, the HTTP response is a `201 Created` and the `L
 
 <pre><code class="javascript">
 Status: 201 Created
-Location: https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
+Location: https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
 </code></pre>
 
 The response body is a JSON object containing the `objectId` and the `createdAt` timestamp of the newly-created object:
@@ -106,13 +106,13 @@ Once you've created an object, you can retrieve its contents by sending a GET re
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/classes/GameScore/Ed1nuqPvcm', '', {
+connection.request('GET', '/parse/classes/GameScore/Ed1nuqPvcm', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -145,14 +145,14 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'include=game' \
-  https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"include":"game"})
 connection.connect()
-connection.request('GET', '/1/classes/GameScore/Ed1nuqPvcm?%s' % params, '', {
+connection.request('GET', '/parse/classes/GameScore/Ed1nuqPvcm?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -170,13 +170,13 @@ curl -X PUT \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"score":73453}' \
-  https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/classes/GameScore/Ed1nuqPvcm', json.dumps({
+connection.request('PUT', '/parse/classes/GameScore/Ed1nuqPvcm', json.dumps({
        "score": 73453
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -205,13 +205,13 @@ curl -X PUT \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"score":{"__op":"Increment","amount":1}}' \
-  https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/classes/GameScore/Ed1nuqPvcm', json.dumps({
+connection.request('PUT', '/parse/classes/GameScore/Ed1nuqPvcm', json.dumps({
        "score": {
          "__op": "Increment",
          "amount": 1
@@ -233,13 +233,13 @@ curl -X PUT \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"score":{"__op":"Increment","amount":-1}}' \
-  https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/classes/GameScore/Ed1nuqPvcm', json.dumps({
+connection.request('PUT', '/parse/classes/GameScore/Ed1nuqPvcm', json.dumps({
        "score": {
          "__op": "Increment",
          "amount": -1
@@ -269,13 +269,13 @@ curl -X PUT \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"skills":{"__op":"AddUnique","objects":["flying","kungfu"]}}' \
-  https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/classes/GameScore/Ed1nuqPvcm', json.dumps({
+connection.request('PUT', '/parse/classes/GameScore/Ed1nuqPvcm', json.dumps({
        "skills": {
          "__op": "AddUnique",
          "objects": [
@@ -302,13 +302,13 @@ curl -X PUT \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"opponents":{"__op":"AddRelation","objects":[{"__type":"Pointer","className":"Player","objectId":"Vx4nudeWn"}]}}' \
-  https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/classes/GameScore/Ed1nuqPvcm', json.dumps({
+connection.request('PUT', '/parse/classes/GameScore/Ed1nuqPvcm', json.dumps({
        "opponents": {
          "__op": "AddRelation",
          "objects": [
@@ -336,13 +336,13 @@ curl -X PUT \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"opponents":{"__op":"RemoveRelation","objects":[{"__type":"Pointer","className":"Player","objectId":"Vx4nudeWn"}]}}' \
-  https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/classes/GameScore/Ed1nuqPvcm', json.dumps({
+connection.request('PUT', '/parse/classes/GameScore/Ed1nuqPvcm', json.dumps({
        "opponents": {
          "__op": "RemoveRelation",
          "objects": [
@@ -370,13 +370,13 @@ To delete an object from the Parse Cloud, send a DELETE request to its object UR
 curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('DELETE', '/1/classes/GameScore/Ed1nuqPvcm', '', {
+connection.request('DELETE', '/parse/classes/GameScore/Ed1nuqPvcm', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -392,13 +392,13 @@ curl -X PUT \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"opponents":{"__op":"Delete"}}' \
-  https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/classes/GameScore/Ed1nuqPvcm', json.dumps({
+connection.request('PUT', '/parse/classes/GameScore/Ed1nuqPvcm', json.dumps({
        "opponents": {
          "__op": "Delete"
        }
@@ -426,7 +426,7 @@ curl -X POST \
         "requests": [
           {
             "method": "POST",
-            "path": "/1/classes/GameScore",
+            "path": "/parse/classes/GameScore",
             "body": {
               "score": 1337,
               "playerName": "Sean Plott"
@@ -434,7 +434,7 @@ curl -X POST \
           },
           {
             "method": "POST",
-            "path": "/1/classes/GameScore",
+            "path": "/parse/classes/GameScore",
             "body": {
               "score": 1338,
               "playerName": "ZeroCool"
@@ -442,17 +442,17 @@ curl -X POST \
           }
         ]
       }' \
-  https://api.parse.com/1/batch
+  https://YOUR.PARSE-SERVER.HERE/parse/batch
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/batch', json.dumps({
+connection.request('POST', '/parse/batch', json.dumps({
        "requests": [
          {
            "method": "POST",
-           "path": "/1/classes/GameScore",
+           "path": "/parse/classes/GameScore",
            "body": {
              "score": 1337,
              "playerName": "Sean Plott"
@@ -460,7 +460,7 @@ connection.request('POST', '/1/batch', json.dumps({
          },
          {
            "method": "POST",
-           "path": "/1/classes/GameScore",
+           "path": "/parse/classes/GameScore",
            "body": {
              "score": 1338,
              "playerName": "ZeroCool"
@@ -509,35 +509,35 @@ curl -X POST \
         "requests": [
           {
             "method": "PUT",
-            "path": "/1/classes/GameScore/Ed1nuqPvcm",
+            "path": "/parse/classes/GameScore/Ed1nuqPvcm",
             "body": {
               "score": 999999
             }
           },
           {
             "method": "DELETE",
-            "path": "/1/classes/GameScore/Cpl9lrueY5"
+            "path": "/parse/classes/GameScore/Cpl9lrueY5"
           }
         ]
       }' \
-  https://api.parse.com/1/batch
+  https://YOUR.PARSE-SERVER.HERE/parse/batch
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/batch', json.dumps({
+connection.request('POST', '/parse/batch', json.dumps({
        "requests": [
          {
            "method": "PUT",
-           "path": "/1/classes/GameScore/Ed1nuqPvcm",
+           "path": "/parse/classes/GameScore/Ed1nuqPvcm",
            "body": {
              "score": 999999
            }
          },
          {
            "method": "DELETE",
-           "path": "/1/classes/GameScore/Cpl9lrueY5"
+           "path": "/parse/classes/GameScore/Cpl9lrueY5"
          }
        ]
      }), {
@@ -583,11 +583,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"createdAt":{"$gte":{"__type":"Date","iso":"2011-08-21T18:02:52.249Z"}}}' \
-  https://api.parse.com/1/classes/GameScore
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "createdAt": {
          "$gte": {
@@ -597,7 +597,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
+connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })

--- a/_includes/rest/objects.md
+++ b/_includes/rest/objects.md
@@ -36,19 +36,19 @@ When you retrieve objects from Parse, some fields are automatically added: `crea
 In the REST API, the class-level operations operate on a resource based on just the class name. For example, if the class name is `GameScore`, the class URL is:
 
 <pre><code class="javascript">
-https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
+<span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 
 Users have a special class-level url:
 
 <pre><code class="javascript">
-https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users
+<span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users
 </code></pre>
 
 The operations specific to a single object are available a nested URL. For example, operations specific to the `GameScore` above with `objectId` equal to `Ed1nuqPvcm` would use the object URL:
 
 <pre><code class="javascript">
-https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
+<span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 
 
@@ -58,11 +58,11 @@ To create a new object on Parse, send a POST request to the class URL containing
 
 <pre><code class="bash">
   curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"score":1337,"playerName":"Sean Plott","cheatMode":false}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 
 <pre><code class="python">
@@ -74,7 +74,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
        "playerName": "Sean Plott",
        "cheatMode": False
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -86,7 +86,7 @@ When the creation is successful, the HTTP response is a `201 Created` and the `L
 
 <pre><code class="javascript">
 Status: 201 Created
-Location: https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
+Location: <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 
 The response body is a JSON object containing the `objectId` and the `createdAt` timestamp of the newly-created object:
@@ -104,16 +104,16 @@ Once you've created an object, you can retrieve its contents by sending a GET re
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -141,11 +141,11 @@ When retrieving objects that have pointers to children, you can fetch child obje
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'include=game' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -153,7 +153,7 @@ connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR
 params = urllib.urlencode({"include":"game"})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -166,11 +166,11 @@ To change the data on an object that already exists, send a PUT request to the o
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"score":73453}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -179,7 +179,7 @@ connection.connect()
 connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm', json.dumps({
        "score": 73453
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -201,11 +201,11 @@ To help with storing counter-type data, Parse provides the ability to atomically
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"score":{"__op":"Increment","amount":1}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -217,7 +217,7 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
          "amount": 1
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -229,11 +229,11 @@ To decrement the counter, use the `Increment` operator with a negative number:
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"score":{"__op":"Increment","amount":-1}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -245,7 +245,7 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
          "amount": -1
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -265,11 +265,11 @@ Each method takes an array of objects to add or remove in the "objects" key. For
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"skills":{"__op":"AddUnique","objects":["flying","kungfu"]}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -284,7 +284,7 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
          ]
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -298,11 +298,11 @@ print result
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"opponents":{"__op":"AddRelation","objects":[{"__type":"Pointer","className":"Player","objectId":"Vx4nudeWn"}]}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -320,7 +320,7 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
          ]
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -332,11 +332,11 @@ To remove an object from a relation, you can do:
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"opponents":{"__op":"RemoveRelation","objects":[{"__type":"Pointer","className":"Player","objectId":"Vx4nudeWn"}]}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -354,7 +354,7 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
          ]
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -368,16 +368,16 @@ To delete an object from the Parse Cloud, send a DELETE request to its object UR
 
 <pre><code class="bash">
 curl -X DELETE \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('DELETE', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -388,11 +388,11 @@ You can delete a single field from an object by using the `Delete` operation:
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"opponents":{"__op":"Delete"}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -403,7 +403,7 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
          "__op": "Delete"
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -419,7 +419,7 @@ Each command in a batch has `method`, `path`, and `body` parameters that specify
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -442,7 +442,7 @@ curl -X POST \
           }
         ]
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>batch
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>batch
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -468,7 +468,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          }
        ]
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -502,7 +502,7 @@ Other commands that work in a batch are `update` and `delete`.
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -520,7 +520,7 @@ curl -X POST \
           }
         ]
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>batch
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>batch
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -541,7 +541,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          }
        ]
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -579,11 +579,11 @@ Dates are useful in combination with the built-in `createdAt` and `updatedAt` fi
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"createdAt":{"$gte":{"__type":"Date","iso":"2011-08-21T18:02:52.249Z"}}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -598,7 +598,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())

--- a/_includes/rest/objects.md
+++ b/_includes/rest/objects.md
@@ -36,19 +36,19 @@ When you retrieve objects from Parse, some fields are automatically added: `crea
 In the REST API, the class-level operations operate on a resource based on just the class name. For example, if the class name is `GameScore`, the class URL is:
 
 <pre><code class="javascript">
-https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
+https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 
 Users have a special class-level url:
 
 <pre><code class="javascript">
-https://YOUR.PARSE-SERVER.HERE/parse/users
+https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users
 </code></pre>
 
 The operations specific to a single object are available a nested URL. For example, operations specific to the `GameScore` above with `objectId` equal to `Ed1nuqPvcm` would use the object URL:
 
 <pre><code class="javascript">
-https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
+https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 
 
@@ -62,14 +62,14 @@ To create a new object on Parse, send a POST request to the class URL containing
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"score":1337,"playerName":"Sean Plott","cheatMode":false}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/classes/GameScore', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore', json.dumps({
        "score": 1337,
        "playerName": "Sean Plott",
        "cheatMode": False
@@ -86,7 +86,7 @@ When the creation is successful, the HTTP response is a `201 Created` and the `L
 
 <pre><code class="javascript">
 Status: 201 Created
-Location: https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
+Location: https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 
 The response body is a JSON object containing the `objectId` and the `createdAt` timestamp of the newly-created object:
@@ -106,13 +106,13 @@ Once you've created an object, you can retrieve its contents by sending a GET re
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/classes/GameScore/Ed1nuqPvcm', '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -145,14 +145,14 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'include=game' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"include":"game"})
 connection.connect()
-connection.request('GET', '/parse/classes/GameScore/Ed1nuqPvcm?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -170,13 +170,13 @@ curl -X PUT \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"score":73453}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/classes/GameScore/Ed1nuqPvcm', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm', json.dumps({
        "score": 73453
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -205,13 +205,13 @@ curl -X PUT \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"score":{"__op":"Increment","amount":1}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/classes/GameScore/Ed1nuqPvcm', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm', json.dumps({
        "score": {
          "__op": "Increment",
          "amount": 1
@@ -233,13 +233,13 @@ curl -X PUT \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"score":{"__op":"Increment","amount":-1}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/classes/GameScore/Ed1nuqPvcm', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm', json.dumps({
        "score": {
          "__op": "Increment",
          "amount": -1
@@ -269,13 +269,13 @@ curl -X PUT \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"skills":{"__op":"AddUnique","objects":["flying","kungfu"]}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/classes/GameScore/Ed1nuqPvcm', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm', json.dumps({
        "skills": {
          "__op": "AddUnique",
          "objects": [
@@ -302,13 +302,13 @@ curl -X PUT \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"opponents":{"__op":"AddRelation","objects":[{"__type":"Pointer","className":"Player","objectId":"Vx4nudeWn"}]}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/classes/GameScore/Ed1nuqPvcm', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm', json.dumps({
        "opponents": {
          "__op": "AddRelation",
          "objects": [
@@ -336,13 +336,13 @@ curl -X PUT \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"opponents":{"__op":"RemoveRelation","objects":[{"__type":"Pointer","className":"Player","objectId":"Vx4nudeWn"}]}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/classes/GameScore/Ed1nuqPvcm', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm', json.dumps({
        "opponents": {
          "__op": "RemoveRelation",
          "objects": [
@@ -370,13 +370,13 @@ To delete an object from the Parse Cloud, send a DELETE request to its object UR
 curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('DELETE', '/parse/classes/GameScore/Ed1nuqPvcm', '', {
+connection.request('DELETE', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -392,13 +392,13 @@ curl -X PUT \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"opponents":{"__op":"Delete"}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/classes/GameScore/Ed1nuqPvcm', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm', json.dumps({
        "opponents": {
          "__op": "Delete"
        }
@@ -426,7 +426,7 @@ curl -X POST \
         "requests": [
           {
             "method": "POST",
-            "path": "/parse/classes/GameScore",
+            "path": "<span class="custom-parse-server-mount">/parse/</span>classes/GameScore",
             "body": {
               "score": 1337,
               "playerName": "Sean Plott"
@@ -434,7 +434,7 @@ curl -X POST \
           },
           {
             "method": "POST",
-            "path": "/parse/classes/GameScore",
+            "path": "<span class="custom-parse-server-mount">/parse/</span>classes/GameScore",
             "body": {
               "score": 1338,
               "playerName": "ZeroCool"
@@ -442,17 +442,17 @@ curl -X POST \
           }
         ]
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/batch
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>batch
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/batch', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>batch', json.dumps({
        "requests": [
          {
            "method": "POST",
-           "path": "/parse/classes/GameScore",
+           "path": "<span class="custom-parse-server-mount">/parse/</span>classes/GameScore",
            "body": {
              "score": 1337,
              "playerName": "Sean Plott"
@@ -460,7 +460,7 @@ connection.request('POST', '/parse/batch', json.dumps({
          },
          {
            "method": "POST",
-           "path": "/parse/classes/GameScore",
+           "path": "<span class="custom-parse-server-mount">/parse/</span>classes/GameScore",
            "body": {
              "score": 1338,
              "playerName": "ZeroCool"
@@ -509,35 +509,35 @@ curl -X POST \
         "requests": [
           {
             "method": "PUT",
-            "path": "/parse/classes/GameScore/Ed1nuqPvcm",
+            "path": "<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm",
             "body": {
               "score": 999999
             }
           },
           {
             "method": "DELETE",
-            "path": "/parse/classes/GameScore/Cpl9lrueY5"
+            "path": "<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Cpl9lrueY5"
           }
         ]
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/batch
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>batch
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/batch', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>batch', json.dumps({
        "requests": [
          {
            "method": "PUT",
-           "path": "/parse/classes/GameScore/Ed1nuqPvcm",
+           "path": "<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm",
            "body": {
              "score": 999999
            }
          },
          {
            "method": "DELETE",
-           "path": "/parse/classes/GameScore/Cpl9lrueY5"
+           "path": "<span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Cpl9lrueY5"
          }
        ]
      }), {
@@ -583,11 +583,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"createdAt":{"$gte":{"__type":"Date","iso":"2011-08-21T18:02:52.249Z"}}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "createdAt": {
          "$gte": {
@@ -597,7 +597,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })

--- a/_includes/rest/push-notifications.md
+++ b/_includes/rest/push-notifications.md
@@ -30,7 +30,7 @@ Creating an installation object is similar to creating a generic object, but the
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -40,7 +40,7 @@ curl -X POST \
           ""
         ]
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -53,7 +53,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          ""
        ]
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -65,7 +65,7 @@ When the creation is successful, the HTTP response is a `201 Created` and the `L
 
 <pre><code class="javascript">
 Status: 201 Created
-Location: https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
+Location: <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
 </code></pre>
 
 The response body is a JSON object containing the `objectId` and the `createdAt` timestamp of the newly-created installation:
@@ -88,7 +88,7 @@ You could create and object with these fields using a command like this:
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -100,7 +100,7 @@ curl -X POST \
           ""
         ]
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -115,7 +115,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          ""
        ]
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -131,16 +131,16 @@ You can retrieve the contents of an installation object by sending a GET request
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -168,7 +168,7 @@ Installation objects can be updated by sending a PUT request to the installation
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -179,7 +179,7 @@ curl -X PUT \
           "foo"
         ]
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -193,7 +193,7 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
          "foo"
        ]
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -211,16 +211,16 @@ Without any URL parameters, a GET request simply lists installations:
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>installations', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -265,16 +265,16 @@ To delete an installation from the Parse Cloud, send a DELETE request to its URL
 
 <pre><code class="bash">
 curl -X DELETE \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('DELETE', '<span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -299,7 +299,7 @@ Subscribing to a channel via the REST API can be done by updating the `Installat
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -307,7 +307,7 @@ curl -X PUT \
           "Giants"
         ]
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -318,7 +318,7 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
          "Giants"
        ]
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -338,7 +338,7 @@ With the REST API, the following code can be used to alert all subscribers of th
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -350,7 +350,7 @@ curl -X POST \
           "alert": "The Giants won against the Mets 2-3."
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -365,7 +365,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          "alert": "The Giants won against the Mets 2-3."
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -385,7 +385,7 @@ Storing arbitrary data on an `Installation` object is done in the same way we st
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -393,7 +393,7 @@ curl -X PUT \
         "gameResults": true,
         "injuryReports": true
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -404,7 +404,7 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
        "gameResults": True,
        "injuryReports": True
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -416,7 +416,7 @@ You can even create relationships between your `Installation` objects and other 
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -426,7 +426,7 @@ curl -X PUT \
           "objectId": "vmRZXZ1Dvo"
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -439,7 +439,7 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
          "objectId": "vmRZXZ1Dvo"
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -453,7 +453,7 @@ Once you have your data stored on your `Installation` objects, you can use a que
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -464,7 +464,7 @@ curl -X POST \
           "alert": "Willie Hayes injured by own pop fly."
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -478,7 +478,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          "alert": "Willie Hayes injured by own pop fly."
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -490,7 +490,7 @@ We can even use channels with our query. To send a push to all subscribers of th
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -502,7 +502,7 @@ curl -X POST \
           "alert": "The Giants scored a run! The score is now 2-2."
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -517,7 +517,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          "alert": "The Giants scored a run! The score is now 2-2."
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -529,7 +529,7 @@ If we store relationships to other objects in our `Installation` class, we can a
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -551,7 +551,7 @@ curl -X POST \
           "alert": "Free hotdogs at the Parse concession stand!"
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -576,7 +576,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          "alert": "Free hotdogs at the Parse concession stand!"
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -606,7 +606,7 @@ For example, to send a notification that increases the current badge number by 1
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -620,7 +620,7 @@ curl -X POST \
           "title": "Mets Score!"
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -637,7 +637,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          "title": "Mets Score!"
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -664,7 +664,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          "newsItem": "Man bites dog"
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -680,7 +680,7 @@ There are two parameters provided by Parse to allow setting an expiration date f
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -689,7 +689,7 @@ curl -X POST \
           "alert": "Season tickets on sale until March 19, 2015"
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -701,7 +701,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          "alert": "Season tickets on sale until March 19, 2015"
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -713,7 +713,7 @@ Alternatively, you can use the `expiration_interval` parameter to specify a dura
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -723,7 +723,7 @@ curl -X POST \
           "alert": "Season tickets on sale until March 19, 2015"
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -736,7 +736,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          "alert": "Season tickets on sale until March 19, 2015"
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -751,7 +751,7 @@ The following examples would send a different notification to Android, iOS, and 
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -762,7 +762,7 @@ curl -X POST \
           "alert": "Your suitcase has been filled with tiny robots!"
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -776,7 +776,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          "alert": "Your suitcase has been filled with tiny robots!"
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -786,7 +786,7 @@ print result
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -797,7 +797,7 @@ curl -X POST \
           "alert": "Your suitcase has been filled with tiny apples!"
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -811,7 +811,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          "alert": "Your suitcase has been filled with tiny apples!"
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -821,7 +821,7 @@ print result
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -832,7 +832,7 @@ curl -X POST \
           "alert": "Your suitcase has been filled with tiny glass!"
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -846,7 +846,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          "alert": "Your suitcase has been filled with tiny glass!"
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -856,7 +856,7 @@ print result
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -867,7 +867,7 @@ curl -X POST \
           "alert": "Your suitcase is very hip; very metro."
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -881,7 +881,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          "alert": "Your suitcase is very hip; very metro."
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -895,7 +895,7 @@ You can schedule a push in advance by specifying a `push_time`. For example, if 
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -907,7 +907,7 @@ curl -X POST \
           "alert": "You previously created a reminder for the game today"
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -922,7 +922,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          "alert": "You previously created a reminder for the game today"
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })

--- a/_includes/rest/push-notifications.md
+++ b/_includes/rest/push-notifications.md
@@ -40,13 +40,13 @@ curl -X POST \
           ""
         ]
       }' \
-  https://api.parse.com/1/installations
+  https://YOUR.PARSE-SERVER.HERE/parse/installations
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/installations', json.dumps({
+connection.request('POST', '/parse/installations', json.dumps({
        "deviceType": "ios",
        "deviceToken": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
        "channels": [
@@ -65,7 +65,7 @@ When the creation is successful, the HTTP response is a `201 Created` and the `L
 
 <pre><code class="javascript">
 Status: 201 Created
-Location: https://api.parse.com/1/installations/mrmBZvsErB
+Location: https://YOUR.PARSE-SERVER.HERE/parse/installations/mrmBZvsErB
 </code></pre>
 
 The response body is a JSON object containing the `objectId` and the `createdAt` timestamp of the newly-created installation:
@@ -100,13 +100,13 @@ curl -X POST \
           ""
         ]
       }' \
-  https://api.parse.com/1/installations
+  https://YOUR.PARSE-SERVER.HERE/parse/installations
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/installations', json.dumps({
+connection.request('POST', '/parse/installations', json.dumps({
        "deviceType": "android",
        "pushType": "gcm",
        "deviceToken": "APA91bFMvbrGg4cp3KUV_7dhU1gmwE_...",
@@ -133,13 +133,13 @@ You can retrieve the contents of an installation object by sending a GET request
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://api.parse.com/1/installations/mrmBZvsErB
+  https://YOUR.PARSE-SERVER.HERE/parse/installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/installations/mrmBZvsErB', '', {
+connection.request('GET', '/parse/installations/mrmBZvsErB', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -179,13 +179,13 @@ curl -X PUT \
           "foo"
         ]
       }' \
-  https://api.parse.com/1/installations/mrmBZvsErB
+  https://YOUR.PARSE-SERVER.HERE/parse/installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/installations/mrmBZvsErB', json.dumps({
+connection.request('PUT', '/parse/installations/mrmBZvsErB', json.dumps({
        "deviceType": "ios",
        "deviceToken": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
        "channels": [
@@ -213,13 +213,13 @@ Without any URL parameters, a GET request simply lists installations:
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
-  https://api.parse.com/1/installations
+  https://YOUR.PARSE-SERVER.HERE/parse/installations
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/installations', '', {
+connection.request('GET', '/parse/installations', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}"
      })
@@ -267,13 +267,13 @@ To delete an installation from the Parse Cloud, send a DELETE request to its URL
 curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
-  https://api.parse.com/1/installations/mrmBZvsErB
+  https://YOUR.PARSE-SERVER.HERE/parse/installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('DELETE', '/1/installations/mrmBZvsErB', '', {
+connection.request('DELETE', '/parse/installations/mrmBZvsErB', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}"
      })
@@ -307,13 +307,13 @@ curl -X PUT \
           "Giants"
         ]
       }' \
-  https://api.parse.com/1/installations/mrmBZvsErB
+  https://YOUR.PARSE-SERVER.HERE/parse/installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/installations/mrmBZvsErB', json.dumps({
+connection.request('PUT', '/parse/installations/mrmBZvsErB', json.dumps({
        "channels": [
          "Giants"
        ]
@@ -350,13 +350,13 @@ curl -X POST \
           "alert": "The Giants won against the Mets 2-3."
         }
       }' \
-  https://api.parse.com/1/push
+  https://YOUR.PARSE-SERVER.HERE/parse/push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/push', json.dumps({
+connection.request('POST', '/parse/push', json.dumps({
        "channels": [
          "Giants",
          "Mets"
@@ -393,13 +393,13 @@ curl -X PUT \
         "gameResults": true,
         "injuryReports": true
       }' \
-  https://api.parse.com/1/installations/mrmBZvsErB
+  https://YOUR.PARSE-SERVER.HERE/parse/installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/installations/mrmBZvsErB', json.dumps({
+connection.request('PUT', '/parse/installations/mrmBZvsErB', json.dumps({
        "scores": True,
        "gameResults": True,
        "injuryReports": True
@@ -426,13 +426,13 @@ curl -X PUT \
           "objectId": "vmRZXZ1Dvo"
         }
       }' \
-  https://api.parse.com/1/installations/mrmBZvsErB
+  https://YOUR.PARSE-SERVER.HERE/parse/installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/installations/mrmBZvsErB', json.dumps({
+connection.request('PUT', '/parse/installations/mrmBZvsErB', json.dumps({
        "user": {
          "__type": "Pointer",
          "className": "_User",
@@ -464,13 +464,13 @@ curl -X POST \
           "alert": "Willie Hayes injured by own pop fly."
         }
       }' \
-  https://api.parse.com/1/push
+  https://YOUR.PARSE-SERVER.HERE/parse/push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/push', json.dumps({
+connection.request('POST', '/parse/push', json.dumps({
        "where": {
          "injuryReports": True
        },
@@ -502,13 +502,13 @@ curl -X POST \
           "alert": "The Giants scored a run! The score is now 2-2."
         }
       }' \
-  https://api.parse.com/1/push
+  https://YOUR.PARSE-SERVER.HERE/parse/push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/push', json.dumps({
+connection.request('POST', '/parse/push', json.dumps({
        "where": {
          "channels": "Giants",
          "scores": True
@@ -551,13 +551,13 @@ curl -X POST \
           "alert": "Free hotdogs at the Parse concession stand!"
         }
       }' \
-  https://api.parse.com/1/push
+  https://YOUR.PARSE-SERVER.HERE/parse/push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/push', json.dumps({
+connection.request('POST', '/parse/push', json.dumps({
        "where": {
          "user": {
            "$inQuery": {
@@ -620,13 +620,13 @@ curl -X POST \
           "title": "Mets Score!"
         }
       }' \
-  https://api.parse.com/1/push
+  https://YOUR.PARSE-SERVER.HERE/parse/push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/push', json.dumps({
+connection.request('POST', '/parse/push', json.dumps({
        "channels": [
          "Mets"
        ],
@@ -651,9 +651,9 @@ It is also possible to specify your own data in this dictionary. As explained in
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/push', json.dumps({
+connection.request('POST', '/parse/push', json.dumps({
        "channels": [
          "Indians"
        ],
@@ -689,13 +689,13 @@ curl -X POST \
           "alert": "Season tickets on sale until March 19, 2015"
         }
       }' \
-  https://api.parse.com/1/push
+  https://YOUR.PARSE-SERVER.HERE/parse/push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/push', json.dumps({
+connection.request('POST', '/parse/push', json.dumps({
        "expiration_time": "2015-03-19T22:05:08Z",
        "data": {
          "alert": "Season tickets on sale until March 19, 2015"
@@ -723,13 +723,13 @@ curl -X POST \
           "alert": "Season tickets on sale until March 19, 2015"
         }
       }' \
-  https://api.parse.com/1/push
+  https://YOUR.PARSE-SERVER.HERE/parse/push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/push', json.dumps({
+connection.request('POST', '/parse/push', json.dumps({
        "push_time": "2015-03-13T22:05:08Z",
        "expiration_interval": 518400,
        "data": {
@@ -762,13 +762,13 @@ curl -X POST \
           "alert": "Your suitcase has been filled with tiny robots!"
         }
       }' \
-  https://api.parse.com/1/push
+  https://YOUR.PARSE-SERVER.HERE/parse/push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/push', json.dumps({
+connection.request('POST', '/parse/push', json.dumps({
        "where": {
          "deviceType": "android"
        },
@@ -797,13 +797,13 @@ curl -X POST \
           "alert": "Your suitcase has been filled with tiny apples!"
         }
       }' \
-  https://api.parse.com/1/push
+  https://YOUR.PARSE-SERVER.HERE/parse/push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/push', json.dumps({
+connection.request('POST', '/parse/push', json.dumps({
        "where": {
          "deviceType": "ios"
        },
@@ -832,13 +832,13 @@ curl -X POST \
           "alert": "Your suitcase has been filled with tiny glass!"
         }
       }' \
-  https://api.parse.com/1/push
+  https://YOUR.PARSE-SERVER.HERE/parse/push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/push', json.dumps({
+connection.request('POST', '/parse/push', json.dumps({
        "where": {
          "deviceType": "winrt"
        },
@@ -867,13 +867,13 @@ curl -X POST \
           "alert": "Your suitcase is very hip; very metro."
         }
       }' \
-  https://api.parse.com/1/push
+  https://YOUR.PARSE-SERVER.HERE/parse/push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/push', json.dumps({
+connection.request('POST', '/parse/push', json.dumps({
        "where": {
          "deviceType": "winphone"
        },
@@ -907,13 +907,13 @@ curl -X POST \
           "alert": "You previously created a reminder for the game today"
         }
       }' \
-  https://api.parse.com/1/push
+  https://YOUR.PARSE-SERVER.HERE/parse/push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/push', json.dumps({
+connection.request('POST', '/parse/push', json.dumps({
        "where": {
          "user_id": "user_123"
        },

--- a/_includes/rest/push-notifications.md
+++ b/_includes/rest/push-notifications.md
@@ -40,13 +40,13 @@ curl -X POST \
           ""
         ]
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/installations
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/installations', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>installations', json.dumps({
        "deviceType": "ios",
        "deviceToken": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
        "channels": [
@@ -65,7 +65,7 @@ When the creation is successful, the HTTP response is a `201 Created` and the `L
 
 <pre><code class="javascript">
 Status: 201 Created
-Location: https://YOUR.PARSE-SERVER.HERE/parse/installations/mrmBZvsErB
+Location: https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
 </code></pre>
 
 The response body is a JSON object containing the `objectId` and the `createdAt` timestamp of the newly-created installation:
@@ -100,13 +100,13 @@ curl -X POST \
           ""
         ]
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/installations
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/installations', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>installations', json.dumps({
        "deviceType": "android",
        "pushType": "gcm",
        "deviceToken": "APA91bFMvbrGg4cp3KUV_7dhU1gmwE_...",
@@ -133,13 +133,13 @@ You can retrieve the contents of an installation object by sending a GET request
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://YOUR.PARSE-SERVER.HERE/parse/installations/mrmBZvsErB
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/installations/mrmBZvsErB', '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -179,13 +179,13 @@ curl -X PUT \
           "foo"
         ]
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/installations/mrmBZvsErB
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/installations/mrmBZvsErB', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB', json.dumps({
        "deviceType": "ios",
        "deviceToken": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
        "channels": [
@@ -213,13 +213,13 @@ Without any URL parameters, a GET request simply lists installations:
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
-  https://YOUR.PARSE-SERVER.HERE/parse/installations
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/installations', '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>installations', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}"
      })
@@ -267,13 +267,13 @@ To delete an installation from the Parse Cloud, send a DELETE request to its URL
 curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
-  https://YOUR.PARSE-SERVER.HERE/parse/installations/mrmBZvsErB
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('DELETE', '/parse/installations/mrmBZvsErB', '', {
+connection.request('DELETE', '<span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}"
      })
@@ -307,13 +307,13 @@ curl -X PUT \
           "Giants"
         ]
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/installations/mrmBZvsErB
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/installations/mrmBZvsErB', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB', json.dumps({
        "channels": [
          "Giants"
        ]
@@ -350,13 +350,13 @@ curl -X POST \
           "alert": "The Giants won against the Mets 2-3."
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/push
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/push', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>push', json.dumps({
        "channels": [
          "Giants",
          "Mets"
@@ -393,13 +393,13 @@ curl -X PUT \
         "gameResults": true,
         "injuryReports": true
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/installations/mrmBZvsErB
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/installations/mrmBZvsErB', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB', json.dumps({
        "scores": True,
        "gameResults": True,
        "injuryReports": True
@@ -426,13 +426,13 @@ curl -X PUT \
           "objectId": "vmRZXZ1Dvo"
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/installations/mrmBZvsErB
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/installations/mrmBZvsErB', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>installations/mrmBZvsErB', json.dumps({
        "user": {
          "__type": "Pointer",
          "className": "_User",
@@ -464,13 +464,13 @@ curl -X POST \
           "alert": "Willie Hayes injured by own pop fly."
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/push
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/push', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>push', json.dumps({
        "where": {
          "injuryReports": True
        },
@@ -502,13 +502,13 @@ curl -X POST \
           "alert": "The Giants scored a run! The score is now 2-2."
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/push
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/push', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>push', json.dumps({
        "where": {
          "channels": "Giants",
          "scores": True
@@ -551,13 +551,13 @@ curl -X POST \
           "alert": "Free hotdogs at the Parse concession stand!"
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/push
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/push', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>push', json.dumps({
        "where": {
          "user": {
            "$inQuery": {
@@ -620,13 +620,13 @@ curl -X POST \
           "title": "Mets Score!"
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/push
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/push', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>push', json.dumps({
        "channels": [
          "Mets"
        ],
@@ -651,9 +651,9 @@ It is also possible to specify your own data in this dictionary. As explained in
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/push', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>push', json.dumps({
        "channels": [
          "Indians"
        ],
@@ -689,13 +689,13 @@ curl -X POST \
           "alert": "Season tickets on sale until March 19, 2015"
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/push
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/push', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>push', json.dumps({
        "expiration_time": "2015-03-19T22:05:08Z",
        "data": {
          "alert": "Season tickets on sale until March 19, 2015"
@@ -723,13 +723,13 @@ curl -X POST \
           "alert": "Season tickets on sale until March 19, 2015"
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/push
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/push', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>push', json.dumps({
        "push_time": "2015-03-13T22:05:08Z",
        "expiration_interval": 518400,
        "data": {
@@ -762,13 +762,13 @@ curl -X POST \
           "alert": "Your suitcase has been filled with tiny robots!"
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/push
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/push', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>push', json.dumps({
        "where": {
          "deviceType": "android"
        },
@@ -797,13 +797,13 @@ curl -X POST \
           "alert": "Your suitcase has been filled with tiny apples!"
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/push
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/push', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>push', json.dumps({
        "where": {
          "deviceType": "ios"
        },
@@ -832,13 +832,13 @@ curl -X POST \
           "alert": "Your suitcase has been filled with tiny glass!"
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/push
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/push', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>push', json.dumps({
        "where": {
          "deviceType": "winrt"
        },
@@ -867,13 +867,13 @@ curl -X POST \
           "alert": "Your suitcase is very hip; very metro."
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/push
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/push', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>push', json.dumps({
        "where": {
          "deviceType": "winphone"
        },
@@ -907,13 +907,13 @@ curl -X POST \
           "alert": "You previously created a reminder for the game today"
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/push
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>push
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/push', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>push', json.dumps({
        "where": {
          "user_id": "user_123"
        },

--- a/_includes/rest/queries.md
+++ b/_includes/rest/queries.md
@@ -8,13 +8,13 @@ You can retrieve multiple objects at once by sending a GET request to the class 
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://api.parse.com/1/classes/GameScore
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/classes/GameScore', '', {
+connection.request('GET', '/parse/classes/GameScore', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -58,17 +58,17 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"playerName":"Sean Plott","cheatMode":false}' \
-  https://api.parse.com/1/classes/GameScore
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "playerName": "Sean Plott",
        "cheatMode": False
      })})
 connection.connect()
-connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
+connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -101,11 +101,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"score":{"$gte":1000,"$lte":3000}}' \
-  https://api.parse.com/1/classes/GameScore
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "score": {
          "$gte": 1000,
@@ -113,7 +113,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
+connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -129,11 +129,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"score":{"$in":[1,3,5,7,9]}}' \
-  https://api.parse.com/1/classes/GameScore
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "score": {
          "$in": [
@@ -146,7 +146,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
+connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -170,11 +170,11 @@ curl -X GET \
      ]
    }
   }' \
-  https://api.parse.com/1/classes/GameScore
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "playerName": {
          "$nin": [
@@ -185,7 +185,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
+connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -201,18 +201,18 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"score":{"$exists":true}}' \
-  https://api.parse.com/1/classes/GameScore
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "score": {
          "$exists": True
        }
      })})
 connection.connect()
-connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
+connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -228,18 +228,18 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"score":{"$exists":false}}' \
-  https://api.parse.com/1/classes/GameScore
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "score": {
          "$exists": False
        }
      })})
 connection.connect()
-connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
+connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -255,11 +255,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"hometown":{"$select":{"query":{"className":"Team","where":{"winPct":{"$gt":0.5}}},"key":"city"}}}' \
-  https://api.parse.com/1/classes/_User
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/_User
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "hometown": {
          "$select": {
@@ -276,7 +276,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/1/classes/_User?%s' % params, '', {
+connection.request('GET', '/parse/classes/_User?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -302,14 +302,14 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'order=score' \
-  https://api.parse.com/1/classes/GameScore
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"order":"score"})
 connection.connect()
-connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
+connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -325,14 +325,14 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'order=-score' \
-  https://api.parse.com/1/classes/GameScore
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"order":"-score"})
 connection.connect()
-connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
+connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -348,14 +348,14 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'order=score,-name' \
-  https://api.parse.com/1/classes/GameScore
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"order":"score,-name"})
 connection.connect()
-connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
+connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -372,14 +372,14 @@ curl -X GET \
   -G \
   --data-urlencode 'limit=200' \
   --data-urlencode 'skip=400' \
-  https://api.parse.com/1/classes/GameScore
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"limit":200,"skip":400})
 connection.connect()
-connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
+connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -395,14 +395,14 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'keys=score,playerName' \
-  https://api.parse.com/1/classes/GameScore
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"keys":"score,playerName"})
 connection.connect()
-connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
+connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -430,11 +430,11 @@ curl -X GET \
   --data-urlencode 'limit=200' \
   --data-urlencode 'skip=400' \
   --data-urlencode 'keys=score,playerName' \
-  https://api.parse.com/1/classes/GameScore
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({
     "where":json.dumps({
       "playerName": {
@@ -450,7 +450,7 @@ params = urllib.urlencode({
     "skip":400,
     "keys":"score,playerName"})
 connection.connect()
-connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
+connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -469,16 +469,16 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"arrayKey":2}' \
-  https://api.parse.com/1/classes/RandomObject
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/RandomObject
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "arrayKey": 2
      })})
 connection.connect()
-connection.request('GET', '/1/classes/RandomObject?%s' % params, '', {
+connection.request('GET', '/parse/classes/RandomObject?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -494,11 +494,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"arrayKey":{"$all":[2,3,4]}}' \
-  https://api.parse.com/1/classes/RandomObject
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/RandomObject
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "arrayKey": {
          "$all": [
@@ -509,7 +509,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/1/classes/RandomObject?%s' % params, '', {
+connection.request('GET', '/parse/classes/RandomObject?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -532,19 +532,19 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"name":{"$regex":"^Big Daddy"}}' \
-  https://api.parse.com/1/classes/BarbecueSauce
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/BarbecueSauce
 </code></pre>
 <pre><code class="python">
 # Finds barbecue sauces that start with "Big Daddy"
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "name": {
          "$regex": "^Big Daddy"
        }
      })})
 connection.connect()
-connection.request('GET', '/1/classes/BarbecueSauce?%s' % params, '', {
+connection.request('GET', '/parse/classes/BarbecueSauce?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -567,11 +567,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"post":{"__type":"Pointer","className":"Post","objectId":"8TOXdXf3tz"}}' \
-  https://api.parse.com/1/classes/Comment
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/Comment
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "post": {
          "__type": "Pointer",
@@ -580,7 +580,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/1/classes/Comment?%s' % params, '', {
+connection.request('GET', '/parse/classes/Comment?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -596,11 +596,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"post":{"$inQuery":{"where":{"image":{"$exists":true}},"className":"Post"}}}' \
-  https://api.parse.com/1/classes/Comment
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/Comment
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "post": {
          "$inQuery": {
@@ -614,7 +614,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/1/classes/Comment?%s' % params, '', {
+connection.request('GET', '/parse/classes/Comment?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -630,11 +630,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"post":{"$notInQuery":{"where":{"image":{"$exists":true}},"className":"Post"}}}' \
-  https://api.parse.com/1/classes/Comment
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/Comment
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "post": {
          "$notInQuery": {
@@ -648,7 +648,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/1/classes/Comment?%s' % params, '', {
+connection.request('GET', '/parse/classes/Comment?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -664,11 +664,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"$relatedTo":{"object":{"__type":"Pointer","className":"Post","objectId":"8TOXdXf3tz"},"key":"likes"}}' \
-  https://api.parse.com/1/users
+  https://YOUR.PARSE-SERVER.HERE/parse/users
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "$relatedTo": {
          "object": {
@@ -680,7 +680,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/1/users?%s' % params, '', {
+connection.request('GET', '/parse/users?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -698,14 +698,14 @@ curl -X GET \
   --data-urlencode 'order=-createdAt' \
   --data-urlencode 'limit=10' \
   --data-urlencode 'include=post' \
-  https://api.parse.com/1/classes/Comment
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/Comment
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"order":"-createdAt","limit":10,"include":"post"})
 connection.connect()
-connection.request('GET', '/1/classes/Comment?%s' % params, '', {
+connection.request('GET', '/parse/classes/Comment?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -746,14 +746,14 @@ curl -X GET \
   --data-urlencode 'order=-createdAt' \
   --data-urlencode 'limit=10' \
   --data-urlencode 'include=post.author' \
-  https://api.parse.com/1/classes/Comment
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/Comment
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"order":"-createdAt","limit":10,"include":"post.author"})
 connection.connect()
-connection.request('GET', '/1/classes/Comment?%s' % params, '', {
+connection.request('GET', '/parse/classes/Comment?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -778,16 +778,16 @@ curl -X GET \
   --data-urlencode 'where={"playerName":"Jonathan Walsh"}' \
   --data-urlencode 'count=1' \
   --data-urlencode 'limit=0' \
-  https://api.parse.com/1/classes/GameScore
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "playerName": "Jonathan Walsh"
      }),"count":1,"limit":0})
 connection.connect()
-connection.request('GET', '/1/classes/GameScore?%s' % params, '', {
+connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -816,11 +816,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"$or":[{"wins":{"$gt":150}},{"wins":{"$lt":5}}]}' \
-  https://api.parse.com/1/classes/Player
+  https://YOUR.PARSE-SERVER.HERE/parse/classes/Player
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"where":json.dumps({
        "$or": [
          {
@@ -836,7 +836,7 @@ params = urllib.urlencode({"where":json.dumps({
        ]
      })})
 connection.connect()
-connection.request('GET', '/1/classes/Player?%s' % params, '', {
+connection.request('GET', '/parse/classes/Player?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })

--- a/_includes/rest/queries.md
+++ b/_includes/rest/queries.md
@@ -8,13 +8,13 @@ You can retrieve multiple objects at once by sending a GET request to the class 
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/classes/GameScore', '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -58,17 +58,17 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"playerName":"Sean Plott","cheatMode":false}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "playerName": "Sean Plott",
        "cheatMode": False
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -101,11 +101,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"score":{"$gte":1000,"$lte":3000}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "score": {
          "$gte": 1000,
@@ -113,7 +113,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -129,11 +129,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"score":{"$in":[1,3,5,7,9]}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "score": {
          "$in": [
@@ -146,7 +146,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -170,11 +170,11 @@ curl -X GET \
      ]
    }
   }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "playerName": {
          "$nin": [
@@ -185,7 +185,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -201,18 +201,18 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"score":{"$exists":true}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "score": {
          "$exists": True
        }
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -228,18 +228,18 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"score":{"$exists":false}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "score": {
          "$exists": False
        }
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -255,11 +255,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"hometown":{"$select":{"query":{"className":"Team","where":{"winPct":{"$gt":0.5}}},"key":"city"}}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/_User
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/_User
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "hometown": {
          "$select": {
@@ -276,7 +276,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/_User?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/_User?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -302,14 +302,14 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'order=score' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"order":"score"})
 connection.connect()
-connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -325,14 +325,14 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'order=-score' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"order":"-score"})
 connection.connect()
-connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -348,14 +348,14 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'order=score,-name' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"order":"score,-name"})
 connection.connect()
-connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -372,14 +372,14 @@ curl -X GET \
   -G \
   --data-urlencode 'limit=200' \
   --data-urlencode 'skip=400' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"limit":200,"skip":400})
 connection.connect()
-connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -395,14 +395,14 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'keys=score,playerName' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"keys":"score,playerName"})
 connection.connect()
-connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -430,11 +430,11 @@ curl -X GET \
   --data-urlencode 'limit=200' \
   --data-urlencode 'skip=400' \
   --data-urlencode 'keys=score,playerName' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({
     "where":json.dumps({
       "playerName": {
@@ -450,7 +450,7 @@ params = urllib.urlencode({
     "skip":400,
     "keys":"score,playerName"})
 connection.connect()
-connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -469,16 +469,16 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"arrayKey":2}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/RandomObject
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/RandomObject
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "arrayKey": 2
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/RandomObject?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/RandomObject?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -494,11 +494,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"arrayKey":{"$all":[2,3,4]}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/RandomObject
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/RandomObject
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "arrayKey": {
          "$all": [
@@ -509,7 +509,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/RandomObject?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/RandomObject?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -532,19 +532,19 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"name":{"$regex":"^Big Daddy"}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/BarbecueSauce
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/BarbecueSauce
 </code></pre>
 <pre><code class="python">
 # Finds barbecue sauces that start with "Big Daddy"
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "name": {
          "$regex": "^Big Daddy"
        }
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/BarbecueSauce?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/BarbecueSauce?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -567,11 +567,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"post":{"__type":"Pointer","className":"Post","objectId":"8TOXdXf3tz"}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/Comment
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Comment
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "post": {
          "__type": "Pointer",
@@ -580,7 +580,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/Comment?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/Comment?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -596,11 +596,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"post":{"$inQuery":{"where":{"image":{"$exists":true}},"className":"Post"}}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/Comment
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Comment
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "post": {
          "$inQuery": {
@@ -614,7 +614,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/Comment?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/Comment?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -630,11 +630,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"post":{"$notInQuery":{"where":{"image":{"$exists":true}},"className":"Post"}}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/Comment
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Comment
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "post": {
          "$notInQuery": {
@@ -648,7 +648,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/Comment?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/Comment?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -664,11 +664,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"$relatedTo":{"object":{"__type":"Pointer","className":"Post","objectId":"8TOXdXf3tz"},"key":"likes"}}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/users
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "$relatedTo": {
          "object": {
@@ -680,7 +680,7 @@ params = urllib.urlencode({"where":json.dumps({
        }
      })})
 connection.connect()
-connection.request('GET', '/parse/users?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>users?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -698,14 +698,14 @@ curl -X GET \
   --data-urlencode 'order=-createdAt' \
   --data-urlencode 'limit=10' \
   --data-urlencode 'include=post' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/Comment
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Comment
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"order":"-createdAt","limit":10,"include":"post"})
 connection.connect()
-connection.request('GET', '/parse/classes/Comment?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/Comment?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -746,14 +746,14 @@ curl -X GET \
   --data-urlencode 'order=-createdAt' \
   --data-urlencode 'limit=10' \
   --data-urlencode 'include=post.author' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/Comment
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Comment
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"order":"-createdAt","limit":10,"include":"post.author"})
 connection.connect()
-connection.request('GET', '/parse/classes/Comment?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/Comment?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -778,16 +778,16 @@ curl -X GET \
   --data-urlencode 'where={"playerName":"Jonathan Walsh"}' \
   --data-urlencode 'count=1' \
   --data-urlencode 'limit=0' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/GameScore
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "playerName": "Jonathan Walsh"
      }),"count":1,"limit":0})
 connection.connect()
-connection.request('GET', '/parse/classes/GameScore?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -816,11 +816,11 @@ curl -X GET \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"$or":[{"wins":{"$gt":150}},{"wins":{"$lt":5}}]}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/classes/Player
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Player
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"where":json.dumps({
        "$or": [
          {
@@ -836,7 +836,7 @@ params = urllib.urlencode({"where":json.dumps({
        ]
      })})
 connection.connect()
-connection.request('GET', '/parse/classes/Player?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/Player?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })

--- a/_includes/rest/queries.md
+++ b/_includes/rest/queries.md
@@ -6,16 +6,16 @@ You can retrieve multiple objects at once by sending a GET request to the class 
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -54,11 +54,11 @@ There are several ways to put constraints on the objects found, using the `where
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"playerName":"Sean Plott","cheatMode":false}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -69,7 +69,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -97,11 +97,11 @@ For example, to retrieve scores between 1000 and 3000, including the endpoints, 
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"score":{"$gte":1000,"$lte":3000}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -114,7 +114,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -125,11 +125,11 @@ To retrieve scores equal to an odd number below 10, we could issue:
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"score":{"$in":[1,3,5,7,9]}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -147,7 +147,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -158,7 +158,7 @@ To retrieve scores not by a given list of players we could issue:
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={
@@ -170,7 +170,7 @@ curl -X GET \
      ]
    }
   }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -186,7 +186,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -197,11 +197,11 @@ To retrieve documents with the score set, we could issue:
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"score":{"$exists":true}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -213,7 +213,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -224,11 +224,11 @@ To retrieve documents without the score set, we could issue:
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"score":{"$exists":false}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -240,7 +240,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -251,11 +251,11 @@ If you have a class containing sports teams and you store a user's hometown in t
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"hometown":{"$select":{"query":{"className":"Team","where":{"winPct":{"$gt":0.5}}},"key":"city"}}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/_User
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/_User
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -277,7 +277,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/_User?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -298,11 +298,11 @@ You can use the `order` parameter to specify a field to sort by. Prefixing with 
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'order=score' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -310,7 +310,7 @@ connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR
 params = urllib.urlencode({"order":"score"})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -321,11 +321,11 @@ And to retrieve scores in descending order:
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'order=-score' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -333,7 +333,7 @@ connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR
 params = urllib.urlencode({"order":"-score"})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -344,11 +344,11 @@ You can sort by multiple fields by passing `order` a comma-separated list. To re
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'order=score,-name' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -356,7 +356,7 @@ connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR
 params = urllib.urlencode({"order":"score,-name"})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -367,12 +367,12 @@ You can use the `limit` and `skip` parameters for pagination. `limit` defaults t
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'limit=200' \
   --data-urlencode 'skip=400' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -380,7 +380,7 @@ connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR
 params = urllib.urlencode({"limit":200,"skip":400})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -391,11 +391,11 @@ You can restrict the fields returned by passing `keys` a comma-separated list. T
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'keys=score,playerName' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -403,7 +403,7 @@ connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR
 params = urllib.urlencode({"keys":"score,playerName"})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -414,7 +414,7 @@ All of these parameters can be used in combination with each other. For example:
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={
@@ -430,7 +430,7 @@ curl -X GET \
   --data-urlencode 'limit=200' \
   --data-urlencode 'skip=400' \
   --data-urlencode 'keys=score,playerName' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -451,7 +451,7 @@ params = urllib.urlencode({
     "keys":"score,playerName"})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -465,11 +465,11 @@ For keys with an array type, you can find objects where the key's array value co
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"arrayKey":2}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/RandomObject
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/RandomObject
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -479,7 +479,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/RandomObject?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -490,11 +490,11 @@ You can also use the `$all` operator to find objects with an array field which c
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"arrayKey":{"$all":[2,3,4]}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/RandomObject
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/RandomObject
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -510,7 +510,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/RandomObject?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -528,11 +528,11 @@ Use the `$regex` operator to restrict to string values that match a regular expr
 <pre><code class="bash">
 # Finds barbecue sauces that start with "Big Daddy"
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"name":{"$regex":"^Big Daddy"}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/BarbecueSauce
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/BarbecueSauce
 </code></pre>
 <pre><code class="python">
 # Finds barbecue sauces that start with "Big Daddy"
@@ -545,7 +545,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/BarbecueSauce?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -563,11 +563,11 @@ There are several ways to issue queries for relational data. If you want to retr
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"post":{"__type":"Pointer","className":"Post","objectId":"8TOXdXf3tz"}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Comment
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Comment
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -581,7 +581,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/Comment?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -592,11 +592,11 @@ If you want to retrieve objects where a field contains an object that matches an
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"post":{"$inQuery":{"where":{"image":{"$exists":true}},"className":"Post"}}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Comment
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Comment
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -615,7 +615,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/Comment?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -626,11 +626,11 @@ If you want to retrieve objects where a field contains an object that does not m
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"post":{"$notInQuery":{"where":{"image":{"$exists":true}},"className":"Post"}}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Comment
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Comment
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -649,7 +649,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/Comment?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -660,11 +660,11 @@ If you want to retrieve objects that are members of `Relation` field of a parent
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"$relatedTo":{"object":{"__type":"Pointer","className":"Post","objectId":"8TOXdXf3tz"},"key":"likes"}}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -681,7 +681,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>users?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -692,13 +692,13 @@ In some situations, you want to return multiple types of related objects in one 
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'order=-createdAt' \
   --data-urlencode 'limit=10' \
   --data-urlencode 'include=post' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Comment
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Comment
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -706,7 +706,7 @@ connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR
 params = urllib.urlencode({"order":"-createdAt","limit":10,"include":"post"})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/Comment?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -740,13 +740,13 @@ You can also do multi level includes using dot notation.  If you wanted to inclu
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'order=-createdAt' \
   --data-urlencode 'limit=10' \
   --data-urlencode 'include=post.author' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Comment
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Comment
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -754,7 +754,7 @@ connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR
 params = urllib.urlencode({"order":"-createdAt","limit":10,"include":"post.author"})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/Comment?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -772,13 +772,13 @@ If you are limiting your query, or if there are a very large number of results, 
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"playerName":"Jonathan Walsh"}' \
   --data-urlencode 'count=1' \
   --data-urlencode 'limit=0' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -788,7 +788,7 @@ params = urllib.urlencode({"where":json.dumps({
      }),"count":1,"limit":0})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/GameScore?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -812,11 +812,11 @@ With a nonzero limit, that request would return results as well as the count.
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -G \
   --data-urlencode 'where={"$or":[{"wins":{"$gt":150}},{"wins":{"$lt":5}}]}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Player
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/Player
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -837,7 +837,7 @@ params = urllib.urlencode({"where":json.dumps({
      })})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>classes/Player?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())

--- a/_includes/rest/quick-reference.md
+++ b/_includes/rest/quick-reference.md
@@ -4,7 +4,7 @@ All API access is provided via the domain to your parse server instance. In case
 
 The relative path prefix `/parse/` is the default mount path for most installations. If you are using a different mount path be sure to change this to accommodate for your instance. If you are using a hosted service this may be something other than the expected `/parse/`, be sure to check before you proceed.
 
-API access can be provided over **HTTPS** and **HTTP**. We recommend utilizing **HTTPS** for anything other than local development. If you are using a hosted service you will almost certainly be accessing your API exclusively over **HTTPS**.
+API access can be provided over **HTTPS** and **HTTP**. We recommend utilizing **HTTPS** for anything other than local development. If you are using a hosted service you will almost certainly be accessing your API exclusively over **HTTPS**. In our examples we will be primarily using **HTTPS**.
 
 ## Objects API
 

--- a/_includes/rest/quick-reference.md
+++ b/_includes/rest/quick-reference.md
@@ -1,8 +1,10 @@
 # Quick Reference
 
-All API access is provided via the domain to your parse server instance. In cases where a domain is used to access the API we will reference `https://YOUR.PARSE-SERVER.HERE`, which should be replaced with your domain for your parse server instance. 
+All API access is provided via the domain to your parse server instance. In cases where a domain is used to access the API we will reference `YOUR.PARSE-SERVER.HERE`{: .custom-parse-server-url}, which should be replaced with your domain for your parse server instance.
 
-The relative path prefix `/parse/` is the default mount path for most installations. If you are using a different mount path be sure to change this to accommodate for your instance. If you are using a hosted service this may be something other than the expected `/parse/`, be sure to check before you proceed.
+The relative path prefix `parse`{: .custom-parse-server-mount} is the default mount path for most installations. If you are using a different mount path be sure to change this to accommodate for your instance. If you are using a hosted service this may be something other than the expected `parse`{: .custom-parse-server-mount}, be sure to check before you proceed.
+
+For your convenience you can customize the **Server Settings** values in the left hand navbar to change both the default server url and mount path to match your personal setup.
 
 API access can be provided over **HTTPS** and **HTTP**. We recommend utilizing **HTTPS** for anything other than local development. If you are using a hosted service you will almost certainly be accessing your API exclusively over **HTTPS**. In our examples we will be primarily using **HTTPS**.
 
@@ -10,121 +12,121 @@ API access can be provided over **HTTPS** and **HTTP**. We recommend utilizing *
 
 | URL                                 | HTTP Verb | Functionality                                      |
 |-------------------------------------|-----------|----------------------------------------------------|
-| `/parse/classes/<className>`            | POST      | [Creating Objects](#creating-objects)      |
-| `/parse/classes/<className>/<objectId>` | GET       | [Retrieving Objects](#retrieving-objects)  |
-| `/parse/classes/<className>/<objectId>` | PUT       | [Updating Objects](#updating-objects)      |
-| `/parse/classes/<className>`            | GET       | [Queries](#queries)                                |
-| `/parse/classes/<className>/<objectId>` | DELETE    | [Deleting Objects](#deleting-objects)      |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>classes/&lt;className&gt;</code>            | POST      | [Creating Objects](#creating-objects)      |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>classes/&lt;className&gt;/&lt;objectId&gt;</code> | GET       | [Retrieving Objects](#retrieving-objects)  |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>classes/&lt;className&gt;/&lt;objectId&gt;</code> | PUT       | [Updating Objects](#updating-objects)      |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>classes/&lt;className&gt;</code>            | GET       | [Queries](#queries)                                |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>classes/&lt;className&gt;/&lt;objectId&gt;</code> | DELETE    | [Deleting Objects](#deleting-objects)      |
 {: .docs_table}
 
 ## Users API
 
 | URL                       | HTTP Verb | Functionality                                                      |
 |---------------------------|-----------|--------------------------------------------------------------------|
-| `/parse/users`                | POST      | [Signing Up](#signing-up) <br/>[Linking Users](#linking-users) |
-| `/parse/login`                | GET       | [Logging In](#logging-in)                                    |
-| `/parse/logout`               | POST      | [Logging Out](#deleting-sessions)                         |
-| `/parse/users/<objectId>`     | GET       | [Retrieving Users](#retrieving-users)                        |
-| `/parse/users/me`             | GET       | [Validating Session Tokens](#validating-session-tokens--retrieving-current-user) <br/>[Retrieving Current User](#retrieving-users)                                        |
-| `/parse/users/<objectId>`     | PUT       | [Updating Users](#updating-users) <br/>[Linking Users](#linking-users) <br/>[Verifying Emails](#verifying-emails) |
-| `/parse/users`                | GET       | [Querying Users](#querying)                                  |
-| `/parse/users/<objectId>`     | DELETE    | [Deleting Users](#deleting-users)                            |
-| `/parse/requestPasswordReset` | POST      | [Requesting A Password Reset](#requesting-a-password-reset)  |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>users</code>                | POST      | [Signing Up](#signing-up) <br/>[Linking Users](#linking-users) |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>login</code>                | GET       | [Logging In](#logging-in)                                    |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>logout</code>               | POST      | [Logging Out](#deleting-sessions)                         |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>users/&lt;objectId&gt;</code>     | GET       | [Retrieving Users](#retrieving-users)                        |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>users/me</code>             | GET       | [Validating Session Tokens](#validating-session-tokens--retrieving-current-user) <br/>[Retrieving Current User](#retrieving-users)                                        |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>users/&lt;objectId&gt;</code>     | PUT       | [Updating Users](#updating-users) <br/>[Linking Users](#linking-users) <br/>[Verifying Emails](#verifying-emails) |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>users</code>                | GET       | [Querying Users](#querying)                                  |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>users/&lt;objectId&gt;</code>     | DELETE    | [Deleting Users](#deleting-users)                            |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>requestPasswordReset</code> | POST      | [Requesting A Password Reset](#requesting-a-password-reset)  |
 {: .docs_table}
 
 ## Sessions API
 
 | URL                       | HTTP Verb |Functionality                               |
 |---------------------------|-----------|--------------------------------------------|
-| `/parse/sessions`             | POST      | [Creating Restricted Sessions](#creating-sessions) |
-| `/parse/sessions/<objectId>`  | GET       | [Retrieving Sessions](#retrieving-sessions) |
-| `/parse/sessions/me`          | GET       | [Retrieving Current Session](#retrieving-sessions) |
-| `/parse/sessions/<objectId>`  | PUT       | [Updating Sessions](#updating-sessions) |
-| `/parse/sessions`             | GET       | [Querying Sessions](#querying-sessions) |
-| `/parse/sessions/<objectId>`  | DELETE    | [Deleting Sessions](#deleting-sessions) |
-| `/parse/sessions/me`          | PUT       | [Pairing with Installation](#pairing-session-with-installation) |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>sessions</code>             | POST      | [Creating Restricted Sessions](#creating-sessions) |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>sessions/&lt;objectId&gt;</code>  | GET       | [Retrieving Sessions](#retrieving-sessions) |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>sessions/me</code>          | GET       | [Retrieving Current Session](#retrieving-sessions) |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>sessions/&lt;objectId&gt;</code>  | PUT       | [Updating Sessions](#updating-sessions) |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>sessions</code>             | GET       | [Querying Sessions](#querying-sessions) |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>sessions/&lt;objectId&gt;</code>  | DELETE    | [Deleting Sessions](#deleting-sessions) |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>sessions/me</code>          | PUT       | [Pairing with Installation](#pairing-session-with-installation) |
 {: .docs_table}
 
 ## Roles API
 
 | URL                   | HTTP Verb | Functionality                               |
 |-----------------------|-----------|---------------------------------------------|
-| `/parse/roles`            | POST      | [Creating Roles](#creating-roles)     |
-| `/parse/roles/<objectId>` | GET       | [Retrieving Roles](#retrieving-roles) |
-| `/parse/roles/<objectId>` | PUT       | [Updating Roles](#updating-roles)     |
-| `/parse/roles/<objectId>` | DELETE    | [Deleting Roles](#deleting-roles)     |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>roles</code>            | POST      | [Creating Roles](#creating-roles)     |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>roles/&lt;objectId&gt;</code> | GET       | [Retrieving Roles](#retrieving-roles) |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>roles/&lt;objectId&gt;</code> | PUT       | [Updating Roles](#updating-roles)     |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>roles/&lt;objectId&gt;</code> | DELETE    | [Deleting Roles](#deleting-roles)     |
 {: .docs_table}
 
 ## Files API
 
 | URL                   | HTTP Verb | Functionality                             |
 |-----------------------|-----------|-------------------------------------------|
-| `/parse/files/<fileName>` | POST      | [Uploading Files](#uploading-files) |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>files/&lt;fileName&gt;</code> | POST      | [Uploading Files](#uploading-files) |
 {: .docs_table}
 
 ## Analytics API
 
 | URL                     | HTTP Verb | Functionality                                   |
 |-------------------------|-----------|-------------------------------------------------|
-| `/parse/events/AppOpened`   | POST      | [Analytics](#app-open-analytics)      |
-| `/parse/events/<eventName>` | POST      | [Custom Analytics](#custom-analytics) |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>events/AppOpened</code>   | POST      | [Analytics](#app-open-analytics)      |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>events/&lt;eventName&gt;</code> | POST      | [Custom Analytics](#custom-analytics) |
 {: .docs_table}
 
 ## Push Notifications API
 
 | URL       | HTTP Verb | Functionality                |
 |-----------|-----------|------------------------------|
-| `/parse/push` | POST      | [Push Notifications](#push-notifications)  |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>push</code> | POST      | [Push Notifications](#push-notifications)  |
 {: .docs_table}
 
 ## Installations API
 
 | URL                           | HTTP Verb | Functionality                                            |
 |-------------------------------|-----------|----------------------------------------------------------|
-| `/parse/installations`            | POST      | [Uploading Installation Data](#uploading-installation-data)  |
-| `/parse/installations/<objectId>` | GET       | [Retrieving Installations](#retrieving-installations)        |
-| `/parse/installations/<objectId>` | PUT       | [Updating Installations](#updating-installations)        |
-| `/parse/installations`            | GET       | [Querying Installations](#querying-installations)        |
-| `/parse/installations/<objectId>` | DELETE    | [Deleting Installations](#deleting-installations)        |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>installations</code>            | POST      | [Uploading Installation Data](#uploading-installation-data)  |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>installations/&lt;objectId&gt;</code> | GET       | [Retrieving Installations](#retrieving-installations)        |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>installations/&lt;objectId&gt;</code> | PUT       | [Updating Installations](#updating-installations)        |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>installations</code>            | GET       | [Querying Installations](#querying-installations)        |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>installations/&lt;objectId&gt;</code> | DELETE    | [Deleting Installations](#deleting-installations)        |
 {: .docs_table}
 
 ## Cloud Functions API
 
 | URL                   | HTTP Verb | Functionality                                             |
 |-----------------------|-----------|-----------------------------------------------------------|
-| `/parse/functions/<name>` | POST      | [Calling Cloud Functions](#calling-cloud-functions)    |
-| `/parse/jobs/<name>`      | POST      | [Triggering Background Jobs](#triggering-background-jobs) |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>functions/&lt;name&gt;</code> | POST      | [Calling Cloud Functions](#calling-cloud-functions)    |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>jobs/&lt;name&gt;</code>      | POST      | [Triggering Background Jobs](#triggering-background-jobs) |
 {: .docs_table}
 
 ## Schemas API
 
 | URL                     | HTTP Verb | Functionality                                             |
 |-------------------------|-----------|-----------------------------------------------------------|
-| `/parse/schemas/`           | GET       | [Fetch All Schemas](#fetch-the-schema)             |
-| `/parse/schemas/<className>`| GET       | [Fetch Schema](#fetch-the-schema)                  |
-| `/parse/schemas/<className>`| POST      | [Create Schema](#adding-a-schema)                  |
-| `/parse/schemas/<className>`| PUT       | [Modify Schema](#modifying-the-schema)             |
-| `/parse/schemas/<className>`| DELETE    | [Delete Schema](#removing-a-schema)                |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>schemas/</code>           | GET       | [Fetch All Schemas](#fetch-the-schema)             |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>schemas/&lt;className&gt;</code>| GET       | [Fetch Schema](#fetch-the-schema)                  |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>schemas/&lt;className&gt;</code>| POST      | [Create Schema](#adding-a-schema)                  |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>schemas/&lt;className&gt;</code>| PUT       | [Modify Schema](#modifying-the-schema)             |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>schemas/&lt;className&gt;</code>| DELETE    | [Delete Schema](#removing-a-schema)                |
 {: .docs_table}
 
 ## Function Hooks API
 
 | URL                                 | HTTP Verb | Functionality                                           |
 |-------------------------------------|-----------|---------------------------------------------------------|
-| `/parse/hooks/functions/<functionName>` | GET       | [Fetch Cloud Functions](#fetch-functions) |
-| `/parse/hooks/functions/`               | POST      | [Create Cloud Function](#create-function-webhook) |
-| `/parse/hooks/functions/<functionName>` | PUT       | [Edit Cloud Function](#edit-function-webhook)     |
-| `/parse/hooks/functions/<functionName>` | DELETE    | [Delete Cloud Function](#delete-function-webhook) |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>hooks/functions/&lt;functionName&gt;</code> | GET       | [Fetch Cloud Functions](#fetch-functions) |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>hooks/functions/</code>               | POST      | [Create Cloud Function](#create-function-webhook) |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>hooks/functions/&lt;functionName&gt;</code> | PUT       | [Edit Cloud Function](#edit-function-webhook)     |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>hooks/functions/&lt;functionName&gt;</code> | DELETE    | [Delete Cloud Function](#delete-function-webhook) |
 {: .docs_table}
 
 ## Trigger Hooks API
 
 | URL                                           | HTTP Verb | Functionality                                           |
 |-----------------------------------------------|-----------|---------------------------------------------------------|
-| `/parse/hooks/triggers/<className>/<triggerName>` | GET       | [Fetch Cloud Trigger](#fetch-triggers)      |
-| `/parse/hooks/triggers/`                          | POST      | [Create Cloud Trigger](#create-trigger-webhook)   |
-| `/parse/hooks/triggers/<className>/<triggerName>` | PUT       | [Edit Cloud Trigger](#edit-trigger-webhook)       |
-| `/parse/hooks/triggers/<className>/<triggerName>` | DELETE    | [Delete Cloud Trigger](#delete-trigger-webhook)   |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/&lt;className&gt;/&lt;triggerName&gt;</code> | GET       | [Fetch Cloud Trigger](#fetch-triggers)      |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/</code>                          | POST      | [Create Cloud Trigger](#create-trigger-webhook)   |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/&lt;className&gt;/&lt;triggerName&gt;</code> | PUT       | [Edit Cloud Trigger](#edit-trigger-webhook)       |
+| <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>hooks/triggers/&lt;className&gt;/&lt;triggerName&gt;</code> | DELETE    | [Delete Cloud Trigger](#delete-trigger-webhook)   |
 {: .docs_table}
 
 ## Request Format
@@ -138,7 +140,7 @@ In the examples that follow, the keys for your app are included in the command. 
 You may also authenticate your REST API requests using basic HTTP authentication. For example, to retrieve an object you could set the URL using your Parse credentials in the following format:
 
 <pre><code class="json">
-https://myAppID:javascript-key=myJavaScriptKey@YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
+https://myAppID:javascript-key=myJavaScriptKey@<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 
 For JavaScript usage, the Parse Cloud supports [cross-origin resource sharing](http://en.wikipedia.org/wiki/Cross-Origin_Resource_Sharing), so that you can use these headers in conjunction with XMLHttpRequest.

--- a/_includes/rest/quick-reference.md
+++ b/_includes/rest/quick-reference.md
@@ -1,126 +1,130 @@
 # Quick Reference
 
-All API access is over HTTPS, and accessed via the `https://api.parse.com` domain. The relative path prefix `/1/` indicates that we are currently using version 1 of the API.
+All API access is provided via the domain to your parse server instance. In cases where a domain is used to access the API we will reference `https://YOUR.PARSE-SERVER.HERE`, which should be replaced with your domain for your parse server instance. 
+
+The relative path prefix `/parse/` is the default mount path for most installations. If you are using a different mount path be sure to change this to accommodate for your instance. If you are using a hosted service this may be something other than the expected `/parse/`, be sure to check before you proceed.
+
+API access can be provided over **HTTPS** and **HTTP**. We recommend utilizing **HTTPS** for anything other than local development. If you are using a hosted service you will almost certainly be accessing your API exclusively over **HTTPS**.
 
 ## Objects API
 
 | URL                                 | HTTP Verb | Functionality                                      |
 |-------------------------------------|-----------|----------------------------------------------------|
-| `/1/classes/<className>`            | POST      | [Creating Objects](#creating-objects)      |
-| `/1/classes/<className>/<objectId>` | GET       | [Retrieving Objects](#retrieving-objects)  |
-| `/1/classes/<className>/<objectId>` | PUT       | [Updating Objects](#updating-objects)      |
-| `/1/classes/<className>`            | GET       | [Queries](#queries)                                |
-| `/1/classes/<className>/<objectId>` | DELETE    | [Deleting Objects](#deleting-objects)      |
+| `/parse/classes/<className>`            | POST      | [Creating Objects](#creating-objects)      |
+| `/parse/classes/<className>/<objectId>` | GET       | [Retrieving Objects](#retrieving-objects)  |
+| `/parse/classes/<className>/<objectId>` | PUT       | [Updating Objects](#updating-objects)      |
+| `/parse/classes/<className>`            | GET       | [Queries](#queries)                                |
+| `/parse/classes/<className>/<objectId>` | DELETE    | [Deleting Objects](#deleting-objects)      |
 {: .docs_table}
 
 ## Users API
 
 | URL                       | HTTP Verb | Functionality                                                      |
 |---------------------------|-----------|--------------------------------------------------------------------|
-| `/1/users`                | POST      | [Signing Up](#signing-up) <br/>[Linking Users](#linking-users) |
-| `/1/login`                | GET       | [Logging In](#logging-in)                                    |
-| `/1/logout`               | POST      | [Logging Out](#deleting-sessions)                         |
-| `/1/users/<objectId>`     | GET       | [Retrieving Users](#retrieving-users)                        |
-| `/1/users/me`             | GET       | [Validating Session Tokens](#validating-session-tokens--retrieving-current-user) <br/>[Retrieving Current User](#retrieving-users)                                        |
-| `/1/users/<objectId>`     | PUT       | [Updating Users](#updating-users) <br/>[Linking Users](#linking-users) <br/>[Verifying Emails](#verifying-emails) |
-| `/1/users`                | GET       | [Querying Users](#querying)                                  |
-| `/1/users/<objectId>`     | DELETE    | [Deleting Users](#deleting-users)                            |
-| `/1/requestPasswordReset` | POST      | [Requesting A Password Reset](#requesting-a-password-reset)  |
+| `/parse/users`                | POST      | [Signing Up](#signing-up) <br/>[Linking Users](#linking-users) |
+| `/parse/login`                | GET       | [Logging In](#logging-in)                                    |
+| `/parse/logout`               | POST      | [Logging Out](#deleting-sessions)                         |
+| `/parse/users/<objectId>`     | GET       | [Retrieving Users](#retrieving-users)                        |
+| `/parse/users/me`             | GET       | [Validating Session Tokens](#validating-session-tokens--retrieving-current-user) <br/>[Retrieving Current User](#retrieving-users)                                        |
+| `/parse/users/<objectId>`     | PUT       | [Updating Users](#updating-users) <br/>[Linking Users](#linking-users) <br/>[Verifying Emails](#verifying-emails) |
+| `/parse/users`                | GET       | [Querying Users](#querying)                                  |
+| `/parse/users/<objectId>`     | DELETE    | [Deleting Users](#deleting-users)                            |
+| `/parse/requestPasswordReset` | POST      | [Requesting A Password Reset](#requesting-a-password-reset)  |
 {: .docs_table}
 
 ## Sessions API
 
 | URL                       | HTTP Verb |Functionality                               |
 |---------------------------|-----------|--------------------------------------------|
-| `/1/sessions`             | POST      | [Creating Restricted Sessions](#creating-sessions) |
-| `/1/sessions/<objectId>`  | GET       | [Retrieving Sessions](#retrieving-sessions) |
-| `/1/sessions/me`          | GET       | [Retrieving Current Session](#retrieving-sessions) |
-| `/1/sessions/<objectId>`  | PUT       | [Updating Sessions](#updating-sessions) |
-| `/1/sessions`             | GET       | [Querying Sessions](#querying-sessions) |
-| `/1/sessions/<objectId>`  | DELETE    | [Deleting Sessions](#deleting-sessions) |
-| `/1/sessions/me`          | PUT       | [Pairing with Installation](#pairing-session-with-installation) |
+| `/parse/sessions`             | POST      | [Creating Restricted Sessions](#creating-sessions) |
+| `/parse/sessions/<objectId>`  | GET       | [Retrieving Sessions](#retrieving-sessions) |
+| `/parse/sessions/me`          | GET       | [Retrieving Current Session](#retrieving-sessions) |
+| `/parse/sessions/<objectId>`  | PUT       | [Updating Sessions](#updating-sessions) |
+| `/parse/sessions`             | GET       | [Querying Sessions](#querying-sessions) |
+| `/parse/sessions/<objectId>`  | DELETE    | [Deleting Sessions](#deleting-sessions) |
+| `/parse/sessions/me`          | PUT       | [Pairing with Installation](#pairing-session-with-installation) |
 {: .docs_table}
 
 ## Roles API
 
 | URL                   | HTTP Verb | Functionality                               |
 |-----------------------|-----------|---------------------------------------------|
-| `/1/roles`            | POST      | [Creating Roles](#creating-roles)     |
-| `/1/roles/<objectId>` | GET       | [Retrieving Roles](#retrieving-roles) |
-| `/1/roles/<objectId>` | PUT       | [Updating Roles](#updating-roles)     |
-| `/1/roles/<objectId>` | DELETE    | [Deleting Roles](#deleting-roles)     |
+| `/parse/roles`            | POST      | [Creating Roles](#creating-roles)     |
+| `/parse/roles/<objectId>` | GET       | [Retrieving Roles](#retrieving-roles) |
+| `/parse/roles/<objectId>` | PUT       | [Updating Roles](#updating-roles)     |
+| `/parse/roles/<objectId>` | DELETE    | [Deleting Roles](#deleting-roles)     |
 {: .docs_table}
 
 ## Files API
 
 | URL                   | HTTP Verb | Functionality                             |
 |-----------------------|-----------|-------------------------------------------|
-| `/1/files/<fileName>` | POST      | [Uploading Files](#uploading-files) |
+| `/parse/files/<fileName>` | POST      | [Uploading Files](#uploading-files) |
 {: .docs_table}
 
 ## Analytics API
 
 | URL                     | HTTP Verb | Functionality                                   |
 |-------------------------|-----------|-------------------------------------------------|
-| `/1/events/AppOpened`   | POST      | [Analytics](#app-open-analytics)      |
-| `/1/events/<eventName>` | POST      | [Custom Analytics](#custom-analytics) |
+| `/parse/events/AppOpened`   | POST      | [Analytics](#app-open-analytics)      |
+| `/parse/events/<eventName>` | POST      | [Custom Analytics](#custom-analytics) |
 {: .docs_table}
 
 ## Push Notifications API
 
 | URL       | HTTP Verb | Functionality                |
 |-----------|-----------|------------------------------|
-| `/1/push` | POST      | [Push Notifications](#push-notifications)  |
+| `/parse/push` | POST      | [Push Notifications](#push-notifications)  |
 {: .docs_table}
 
 ## Installations API
 
 | URL                           | HTTP Verb | Functionality                                            |
 |-------------------------------|-----------|----------------------------------------------------------|
-| `/1/installations`            | POST      | [Uploading Installation Data](#uploading-installation-data)  |
-| `/1/installations/<objectId>` | GET       | [Retrieving Installations](#retrieving-installations)        |
-| `/1/installations/<objectId>` | PUT       | [Updating Installations](#updating-installations)        |
-| `/1/installations`            | GET       | [Querying Installations](#querying-installations)        |
-| `/1/installations/<objectId>` | DELETE    | [Deleting Installations](#deleting-installations)        |
+| `/parse/installations`            | POST      | [Uploading Installation Data](#uploading-installation-data)  |
+| `/parse/installations/<objectId>` | GET       | [Retrieving Installations](#retrieving-installations)        |
+| `/parse/installations/<objectId>` | PUT       | [Updating Installations](#updating-installations)        |
+| `/parse/installations`            | GET       | [Querying Installations](#querying-installations)        |
+| `/parse/installations/<objectId>` | DELETE    | [Deleting Installations](#deleting-installations)        |
 {: .docs_table}
 
 ## Cloud Functions API
 
 | URL                   | HTTP Verb | Functionality                                             |
 |-----------------------|-----------|-----------------------------------------------------------|
-| `/1/functions/<name>` | POST      | [Calling Cloud Functions](#calling-cloud-functions)    |
-| `/1/jobs/<name>`      | POST      | [Triggering Background Jobs](#triggering-background-jobs) |
+| `/parse/functions/<name>` | POST      | [Calling Cloud Functions](#calling-cloud-functions)    |
+| `/parse/jobs/<name>`      | POST      | [Triggering Background Jobs](#triggering-background-jobs) |
 {: .docs_table}
 
 ## Schemas API
 
 | URL                     | HTTP Verb | Functionality                                             |
 |-------------------------|-----------|-----------------------------------------------------------|
-| `/1/schemas/`           | GET       | [Fetch All Schemas](#fetch-the-schema)             |
-| `/1/schemas/<className>`| GET       | [Fetch Schema](#fetch-the-schema)                  |
-| `/1/schemas/<className>`| POST      | [Create Schema](#adding-a-schema)                  |
-| `/1/schemas/<className>`| PUT       | [Modify Schema](#modifying-the-schema)             |
-| `/1/schemas/<className>`| DELETE    | [Delete Schema](#removing-a-schema)                |
+| `/parse/schemas/`           | GET       | [Fetch All Schemas](#fetch-the-schema)             |
+| `/parse/schemas/<className>`| GET       | [Fetch Schema](#fetch-the-schema)                  |
+| `/parse/schemas/<className>`| POST      | [Create Schema](#adding-a-schema)                  |
+| `/parse/schemas/<className>`| PUT       | [Modify Schema](#modifying-the-schema)             |
+| `/parse/schemas/<className>`| DELETE    | [Delete Schema](#removing-a-schema)                |
 {: .docs_table}
 
 ## Function Hooks API
 
 | URL                                 | HTTP Verb | Functionality                                           |
 |-------------------------------------|-----------|---------------------------------------------------------|
-| `/1/hooks/functions/<functionName>` | GET       | [Fetch Cloud Functions](#fetch-functions) |
-| `/1/hooks/functions/`               | POST      | [Create Cloud Function](#create-function-webhook) |
-| `/1/hooks/functions/<functionName>` | PUT       | [Edit Cloud Function](#edit-function-webhook)     |
-| `/1/hooks/functions/<functionName>` | DELETE    | [Delete Cloud Function](#delete-function-webhook) |
+| `/parse/hooks/functions/<functionName>` | GET       | [Fetch Cloud Functions](#fetch-functions) |
+| `/parse/hooks/functions/`               | POST      | [Create Cloud Function](#create-function-webhook) |
+| `/parse/hooks/functions/<functionName>` | PUT       | [Edit Cloud Function](#edit-function-webhook)     |
+| `/parse/hooks/functions/<functionName>` | DELETE    | [Delete Cloud Function](#delete-function-webhook) |
 {: .docs_table}
 
 ## Trigger Hooks API
 
 | URL                                           | HTTP Verb | Functionality                                           |
 |-----------------------------------------------|-----------|---------------------------------------------------------|
-| `/1/hooks/triggers/<className>/<triggerName>` | GET       | [Fetch Cloud Trigger](#fetch-triggers)      |
-| `/1/hooks/triggers/`                          | POST      | [Create Cloud Trigger](#create-trigger-webhook)   |
-| `/1/hooks/triggers/<className>/<triggerName>` | PUT       | [Edit Cloud Trigger](#edit-trigger-webhook)       |
-| `/1/hooks/triggers/<className>/<triggerName>` | DELETE    | [Delete Cloud Trigger](#delete-trigger-webhook)   |
+| `/parse/hooks/triggers/<className>/<triggerName>` | GET       | [Fetch Cloud Trigger](#fetch-triggers)      |
+| `/parse/hooks/triggers/`                          | POST      | [Create Cloud Trigger](#create-trigger-webhook)   |
+| `/parse/hooks/triggers/<className>/<triggerName>` | PUT       | [Edit Cloud Trigger](#edit-trigger-webhook)       |
+| `/parse/hooks/triggers/<className>/<triggerName>` | DELETE    | [Delete Cloud Trigger](#delete-trigger-webhook)   |
 {: .docs_table}
 
 ## Request Format
@@ -134,7 +138,7 @@ In the examples that follow, the keys for your app are included in the command. 
 You may also authenticate your REST API requests using basic HTTP authentication. For example, to retrieve an object you could set the URL using your Parse credentials in the following format:
 
 <pre><code class="json">
-https://myAppID:javascript-key=myJavaScriptKey@api.parse.com/1/classes/GameScore/Ed1nuqPvcm
+https://myAppID:javascript-key=myJavaScriptKey@YOUR.PARSE-SERVER.HERE/parse/classes/GameScore/Ed1nuqPvcm
 </code></pre>
 
 For JavaScript usage, the Parse Cloud supports [cross-origin resource sharing](http://en.wikipedia.org/wiki/Cross-Origin_Resource_Sharing), so that you can use these headers in conjunction with XMLHttpRequest.

--- a/_includes/rest/quick-reference.md
+++ b/_includes/rest/quick-reference.md
@@ -1,12 +1,12 @@
 # Quick Reference
 
-All API access is provided via the domain to your parse server instance. In cases where a domain is used to access the API we will reference `YOUR.PARSE-SERVER.HERE`{: .custom-parse-server-url}, which should be replaced with your domain for your parse server instance.
+For your convenience you can customize [your configuration](#your-configuration) to change the default server url, mount path and additional values to match your personal setup.
 
-The relative path prefix `parse`{: .custom-parse-server-mount} is the default mount path for most installations. If you are using a different mount path be sure to change this to accommodate for your instance. If you are using a hosted service this may be something other than the expected `parse`{: .custom-parse-server-mount}, be sure to check before you proceed.
+All API access is provided via the domain to your parse server instance. In cases where a domain is used to access the API we will reference `YOUR.PARSE-SERVER.HERE`{: .custom-parse-server-url}, which should be set to your domain in [your configuration](#your-configuration).
 
-For your convenience you can customize the **Server Settings** values in the left hand navbar to change both the default server url and mount path to match your personal setup.
+The relative path prefix `/parse/` is the default mount path for most installations. If you are using a different mount path be sure to change this to accommodate for your instance. If you are using a hosted service this may be something other than the expected `/parse/`, be sure to check before you proceed. For the following examples we will be using `/parse/`{: .custom-parse-server-mount}, which can be set in [your configuration](#your-configuration).
 
-API access can be provided over **HTTPS** and **HTTP**. We recommend utilizing **HTTPS** for anything other than local development. If you are using a hosted service you will almost certainly be accessing your API exclusively over **HTTPS**. In our examples we will be primarily using **HTTPS**.
+API access can be provided over **HTTPS** and **HTTP**. We recommend utilizing **HTTPS** for anything other than local development. If you are using a hosted service you will almost certainly be accessing your API exclusively over **HTTPS**.
 
 ## Objects API
 
@@ -140,7 +140,7 @@ In the examples that follow, the keys for your app are included in the command. 
 You may also authenticate your REST API requests using basic HTTP authentication. For example, to retrieve an object you could set the URL using your Parse credentials in the following format:
 
 <pre><code class="json">
-https://myAppID:javascript-key=myJavaScriptKey@<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
+<span class="custom-parse-server-protocol">https</span>://myAppID:javascript-key=myJavaScriptKey@<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>classes/GameScore/Ed1nuqPvcm
 </code></pre>
 
 For JavaScript usage, the Parse Cloud supports [cross-origin resource sharing](http://en.wikipedia.org/wiki/Cross-Origin_Resource_Sharing), so that you can use these headers in conjunction with XMLHttpRequest.

--- a/_includes/rest/roles.md
+++ b/_includes/rest/roles.md
@@ -31,13 +31,13 @@ curl -X POST \
           }
         }
       }' \
-  https://api.parse.com/1/roles
+  https://YOUR.PARSE-SERVER.HERE/parse/roles
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/roles', json.dumps({
+connection.request('POST', '/parse/roles', json.dumps({
        "name": "Moderators",
        "ACL": {
          "*": {
@@ -88,13 +88,13 @@ curl -X POST \
           ]
         }
       }' \
-  https://api.parse.com/1/roles
+  https://YOUR.PARSE-SERVER.HERE/parse/roles
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/roles', json.dumps({
+connection.request('POST', '/parse/roles', json.dumps({
        "name": "Moderators",
        "ACL": {
          "*": {
@@ -134,7 +134,7 @@ When the creation is successful, the HTTP response is a `201 Created` and the Lo
 
 <pre><code class="javascript">
 Status: 201 Created
-Location: https://api.parse.com/1/roles/mrmBZvsErB
+Location: https://YOUR.PARSE-SERVER.HERE/parse/roles/mrmBZvsErB
 </code></pre>
 
 The response body is a JSON object containing the `objectId` and `createdAt` timestamp of the newly-created object:
@@ -154,13 +154,13 @@ You can also retrieve the contents of a role object by sending a GET request to 
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://api.parse.com/1/roles/mrmBZvsErB
+  https://YOUR.PARSE-SERVER.HERE/parse/roles/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/roles/mrmBZvsErB', '', {
+connection.request('GET', '/parse/roles/mrmBZvsErB', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -218,13 +218,13 @@ curl -X PUT \
           ]
         }
       }' \
-  https://api.parse.com/1/roles/mrmBZvsErB
+  https://YOUR.PARSE-SERVER.HERE/parse/roles/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/roles/mrmBZvsErB', json.dumps({
+connection.request('PUT', '/parse/roles/mrmBZvsErB', json.dumps({
        "users": {
          "__op": "AddRelation",
          "objects": [
@@ -268,13 +268,13 @@ curl -X PUT \
           ]
         }
       }' \
-  https://api.parse.com/1/roles/mrmBZvsErB
+  https://YOUR.PARSE-SERVER.HERE/parse/roles/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/roles/mrmBZvsErB', json.dumps({
+connection.request('PUT', '/parse/roles/mrmBZvsErB', json.dumps({
        "roles": {
          "__op": "RemoveRelation",
          "objects": [
@@ -305,13 +305,13 @@ To delete a role from the Parse Cloud, send a DELETE request to its URL.  For ex
 curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
-  https://api.parse.com/1/roles/mrmBZvsErB
+  https://YOUR.PARSE-SERVER.HERE/parse/roles/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('DELETE', '/1/roles/mrmBZvsErB', '', {
+connection.request('DELETE', '/parse/roles/mrmBZvsErB', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}"
      })
@@ -326,13 +326,13 @@ curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: pnktnjyb996sj4p156gjtp4im" \
-  https://api.parse.com/1/roles/mrmBZvsErB
+  https://YOUR.PARSE-SERVER.HERE/parse/roles/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('DELETE', '/1/roles/mrmBZvsErB', '', {
+connection.request('DELETE', '/parse/roles/mrmBZvsErB', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "pnktnjyb996sj4p156gjtp4im"
@@ -388,13 +388,13 @@ curl -X PUT \
           ]
         }
       }' \
-  https://api.parse.com/1/roles/<ModeratorsRoleObjectId>
+  https://YOUR.PARSE-SERVER.HERE/parse/roles/<ModeratorsRoleObjectId>
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/roles/<ModeratorsRoleObjectId>', json.dumps({
+connection.request('PUT', '/parse/roles/<ModeratorsRoleObjectId>', json.dumps({
        "roles": {
          "__op": "AddRelation",
          "objects": [

--- a/_includes/rest/roles.md
+++ b/_includes/rest/roles.md
@@ -31,13 +31,13 @@ curl -X POST \
           }
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/roles
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/roles', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>roles', json.dumps({
        "name": "Moderators",
        "ACL": {
          "*": {
@@ -88,13 +88,13 @@ curl -X POST \
           ]
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/roles
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/roles', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>roles', json.dumps({
        "name": "Moderators",
        "ACL": {
          "*": {
@@ -134,7 +134,7 @@ When the creation is successful, the HTTP response is a `201 Created` and the Lo
 
 <pre><code class="javascript">
 Status: 201 Created
-Location: https://YOUR.PARSE-SERVER.HERE/parse/roles/mrmBZvsErB
+Location: https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
 </code></pre>
 
 The response body is a JSON object containing the `objectId` and `createdAt` timestamp of the newly-created object:
@@ -154,13 +154,13 @@ You can also retrieve the contents of a role object by sending a GET request to 
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://YOUR.PARSE-SERVER.HERE/parse/roles/mrmBZvsErB
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/roles/mrmBZvsErB', '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -218,13 +218,13 @@ curl -X PUT \
           ]
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/roles/mrmBZvsErB
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/roles/mrmBZvsErB', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB', json.dumps({
        "users": {
          "__op": "AddRelation",
          "objects": [
@@ -268,13 +268,13 @@ curl -X PUT \
           ]
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/roles/mrmBZvsErB
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/roles/mrmBZvsErB', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB', json.dumps({
        "roles": {
          "__op": "RemoveRelation",
          "objects": [
@@ -305,13 +305,13 @@ To delete a role from the Parse Cloud, send a DELETE request to its URL.  For ex
 curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
-  https://YOUR.PARSE-SERVER.HERE/parse/roles/mrmBZvsErB
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('DELETE', '/parse/roles/mrmBZvsErB', '', {
+connection.request('DELETE', '<span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}"
      })
@@ -326,13 +326,13 @@ curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: pnktnjyb996sj4p156gjtp4im" \
-  https://YOUR.PARSE-SERVER.HERE/parse/roles/mrmBZvsErB
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('DELETE', '/parse/roles/mrmBZvsErB', '', {
+connection.request('DELETE', '<span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "pnktnjyb996sj4p156gjtp4im"
@@ -388,13 +388,13 @@ curl -X PUT \
           ]
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/roles/<ModeratorsRoleObjectId>
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/<ModeratorsRoleObjectId>
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/roles/<ModeratorsRoleObjectId>', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>roles/<ModeratorsRoleObjectId>', json.dumps({
        "roles": {
          "__op": "AddRelation",
          "objects": [

--- a/_includes/rest/roles.md
+++ b/_includes/rest/roles.md
@@ -20,7 +20,7 @@ To create a new role, send a POST request to the roles root:
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -31,7 +31,7 @@ curl -X POST \
           }
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -45,7 +45,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          }
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -57,7 +57,7 @@ You can create a role with child roles or users by adding existing objects to th
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -88,7 +88,7 @@ curl -X POST \
           ]
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -122,7 +122,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          ]
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -134,7 +134,7 @@ When the creation is successful, the HTTP response is a `201 Created` and the Lo
 
 <pre><code class="javascript">
 Status: 201 Created
-Location: https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
+Location: <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
 </code></pre>
 
 The response body is a JSON object containing the `objectId` and `createdAt` timestamp of the newly-created object:
@@ -152,16 +152,16 @@ You can also retrieve the contents of a role object by sending a GET request to 
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -198,7 +198,7 @@ For example, we can add two users to the "Moderators" role created above like so
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -218,7 +218,7 @@ curl -X PUT \
           ]
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -241,7 +241,7 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
          ]
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -253,7 +253,7 @@ Similarly, we can remove a child role from the "Moderators" role created above l
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -268,7 +268,7 @@ curl -X PUT \
           ]
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -286,7 +286,7 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
          ]
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -303,16 +303,16 @@ To delete a role from the Parse Cloud, send a DELETE request to its URL.  For ex
 
 <pre><code class="bash">
 curl -X DELETE \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('DELETE', '<span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -323,17 +323,17 @@ Again, we pass the master key in order to bypass the ACL on the role itself.  Al
 
 <pre><code class="bash">
 curl -X DELETE \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: pnktnjyb996sj4p156gjtp4im" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('DELETE', '<span class="custom-parse-server-mount">/parse/</span>roles/mrmBZvsErB', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "pnktnjyb996sj4p156gjtp4im"
      })
@@ -373,7 +373,7 @@ These types of relationships are commonly found in applications with user-manage
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -383,30 +383,30 @@ curl -X PUT \
             {
               "__type": "Pointer",
               "className": "_Role",
-              "objectId": "<AdministratorsRoleObjectId>"
+              "objectId": "&lt;AdministratorsRoleObjectId&gt;"
             }
           ]
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/<ModeratorsRoleObjectId>
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>roles/&lt;ModeratorsRoleObjectId&gt;
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>roles/<ModeratorsRoleObjectId>', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>roles/&lt;ModeratorsRoleObjectId&gt;', json.dumps({
        "roles": {
          "__op": "AddRelation",
          "objects": [
            {
              "__type": "Pointer",
              "className": "_Role",
-             "objectId": "<AdministratorsRoleObjectId>"
+             "objectId": "&lt;AdministratorsRoleObjectId&gt;"
            }
          ]
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })

--- a/_includes/rest/schemas.md
+++ b/_includes/rest/schemas.md
@@ -17,17 +17,17 @@ as strings in object representation. This is a special case for the Parse API.
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>schemas', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -72,17 +72,17 @@ To fetch schema of a single class, run:
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas/Game
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas/Game
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>schemas/Game', "", {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -97,7 +97,7 @@ fields and some default fields applicable to the class. To add the schema, run:
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d ' 
@@ -109,7 +109,7 @@ curl -X POST \
         }
       }
     }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas/City
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas/City
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -118,7 +118,7 @@ connection.connect()
 connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>schemas/Game', json.dumps({
        "className":"City","fields":{"name":{"type":"String"} }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -132,7 +132,7 @@ You can add or delete columns to a schema. To do so, run:
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '
@@ -144,7 +144,7 @@ curl -X PUT \
         }
       }
     }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas/City
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas/City
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -153,7 +153,7 @@ connection.connect()
 connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>schemas/City', json.dumps(
        "className":"City","fields":{"population":{"type":"Number"} }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -165,7 +165,7 @@ To delete a particular field, you need to use `{"__op" : "Delete" }`
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '
@@ -177,7 +177,7 @@ curl -X PUT \
         }
       }
     }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas/City
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas/City
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -186,7 +186,7 @@ connection.connect()
 connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>schemas/Game', json.dumps(
        "className":"City","fields":{"population":{"__op" : "Delete"} }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })
@@ -201,17 +201,17 @@ To do that, run:
 
 <pre><code class="bash">
 curl -X DELETE\
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas/City
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas/City
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>schemas/City', "", {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
      })

--- a/_includes/rest/schemas.md
+++ b/_includes/rest/schemas.md
@@ -20,13 +20,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://YOUR.PARSE-SERVER.HERE/parse/schemas
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/schemas', '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>schemas', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
@@ -75,13 +75,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://YOUR.PARSE-SERVER.HERE/parse/schemas/Game
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas/Game
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/schemas/Game', "", {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>schemas/Game', "", {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
@@ -109,13 +109,13 @@ curl -X POST \
         }
       }
     }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/schemas/City
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas/City
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/schemas/Game', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>schemas/Game', json.dumps({
        "className":"City","fields":{"name":{"type":"String"} }
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -144,13 +144,13 @@ curl -X PUT \
         }
       }
     }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/schemas/City
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas/City
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/schemas/City', json.dumps(
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>schemas/City', json.dumps(
        "className":"City","fields":{"population":{"type":"Number"} }
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -177,13 +177,13 @@ curl -X PUT \
         }
       }
     }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/schemas/City
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas/City
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/schemas/Game', json.dumps(
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>schemas/Game', json.dumps(
        "className":"City","fields":{"population":{"__op" : "Delete"} }
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -204,13 +204,13 @@ curl -X DELETE\
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://YOUR.PARSE-SERVER.HERE/parse/schemas/City
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>schemas/City
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/schemas/City', "", {
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>schemas/City', "", {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"

--- a/_includes/rest/schemas.md
+++ b/_includes/rest/schemas.md
@@ -20,13 +20,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://api.parse.com/1/schemas
+  https://YOUR.PARSE-SERVER.HERE/parse/schemas
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/schemas', '', {
+connection.request('GET', '/parse/schemas', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
@@ -75,13 +75,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://api.parse.com/1/schemas/Game
+  https://YOUR.PARSE-SERVER.HERE/parse/schemas/Game
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/schemas/Game', "", {
+connection.request('GET', '/parse/schemas/Game', "", {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"
@@ -109,13 +109,13 @@ curl -X POST \
         }
       }
     }' \
-  https://api.parse.com/1/schemas/City
+  https://YOUR.PARSE-SERVER.HERE/parse/schemas/City
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/schemas/Game', json.dumps({
+connection.request('POST', '/parse/schemas/Game', json.dumps({
        "className":"City","fields":{"name":{"type":"String"} }
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -144,13 +144,13 @@ curl -X PUT \
         }
       }
     }' \
-  https://api.parse.com/1/schemas/City
+  https://YOUR.PARSE-SERVER.HERE/parse/schemas/City
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/schemas/City', json.dumps(
+connection.request('PUT', '/parse/schemas/City', json.dumps(
        "className":"City","fields":{"population":{"type":"Number"} }
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -177,13 +177,13 @@ curl -X PUT \
         }
       }
     }' \
-  https://api.parse.com/1/schemas/City
+  https://YOUR.PARSE-SERVER.HERE/parse/schemas/City
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/schemas/Game', json.dumps(
+connection.request('PUT', '/parse/schemas/Game', json.dumps(
        "className":"City","fields":{"population":{"__op" : "Delete"} }
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -204,13 +204,13 @@ curl -X DELETE\
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-Master-Key: ${MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  https://api.parse.com/1/schemas/City
+  https://YOUR.PARSE-SERVER.HERE/parse/schemas/City
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/schemas/City', "", {
+connection.request('PUT', '/parse/schemas/City', "", {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-Master-Key": "${MASTER_KEY}",
        "Content-Type": "application/json"

--- a/_includes/rest/sessions.md
+++ b/_includes/rest/sessions.md
@@ -30,18 +30,18 @@ With revocable sessions, your current session token could become invalid if its 
 
 ## Creating Sessions
 
-For mobile apps and websites, you should not create `Session` objects manually. Instead, you should call `GET <span class="custom-parse-server-mount">/parse/</span>login` and `POST <span class="custom-parse-server-mount">/parse/</span>users` (signup), which will automatically generate a `Session` object in the Parse Cloud. The session token for this automatically-created session will be sent back on the login and signup response. Same for Facebook/Twitter login and signup requests.
+For mobile apps and websites, you should not create `Session` objects manually. Instead, you should call <code class="highlighter-rouge">GET <span class="custom-parse-server-mount">/parse/</span>login</code> and <code class="highlighter-rouge">POST <span class="custom-parse-server-mount">/parse/</span>users</code> (signup), which will automatically generate a `Session` object in the Parse Cloud. The session token for this automatically-created session will be sent back on the login and signup response. Same for Facebook/Twitter login and signup requests.
 
 In "Parse for IoT" apps (e.g. Arduino or Embedded C), you may want to programmatically create a restricted session that can be transferred to an IoT device. In order to do this, you must first log in normally to obtain an unrestricted session token. Then, you can create a restricted session by providing this unrestricted session token:
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
   -H "Content-Type: application/json" \
   -d '{"customField":"value"}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -50,7 +50,7 @@ connection.connect()
 connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>sessions', json.dumps({
        "customField": "value"
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im",
        "Content-Type": "application/json"
@@ -82,17 +82,17 @@ At this point, you can pass the session token `r:aVrtljyb7E8xKo9256gfvp4n2` to a
 If you have the session's objectId, you fetch the `Session` object as long as it belongs to the same user as your current session:
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions/Axy98kq1B09
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions/Axy98kq1B09
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>sessions/Axy98kq1B09', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
      })
@@ -104,17 +104,17 @@ If you only have the session's token (from previous login or session create), yo
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions/me
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions/me
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>sessions/me', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
      })
@@ -128,19 +128,19 @@ Updating a session is analogous to updating a Parse object.
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
   -H "Content-Type: application/json" \
   -d '{"customField":"value"}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions/Axy98kq1B09
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions/Axy98kq1B09
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>logout', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
      })
@@ -154,17 +154,17 @@ Querying for `Session` objects will only return objects belonging to the same us
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>sessions', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
      })
@@ -180,17 +180,17 @@ Deleting the Session object will revoke its session token and cause the user to 
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>logout
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>logout
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>logout', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
      })
@@ -202,17 +202,17 @@ If you want to delete another `Session` object for your user, and you have its `
 
 <pre><code class="bash">
 curl -X DELETE \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions/Axy98kq1B09
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions/Axy98kq1B09
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('DELETE', '<span class="custom-parse-server-mount">/parse/</span>sessions/Axy98kq1B09', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
      })
@@ -224,7 +224,7 @@ print result
 
 ## Pairing Session with Installation
 
-For normal user login with the `<span class="custom-parse-server-mount">/parse/</span>login` endpoint, the Parse Cloud will set the automatically-created `Session` object's `installationId` to the `X-Parse-Installation-Id` header passed on the login or signup request. Therefore, for these scenarios, you don't need to manually associate the `Session` object with an installation.
+For normal user login with the <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>login</code> endpoint, the Parse Cloud will set the automatically-created `Session` object's `installationId` to the `X-Parse-Installation-Id` header passed on the login or signup request. Therefore, for these scenarios, you don't need to manually associate the `Session` object with an installation.
 
 The following API is most useful for "Parse for IoT" apps (e.g. Arduino or Embedded C). During IoT device provisioning, the phone typically does not know the `installationId` of the IoT device. The provisioning process typically goes like this:
 
@@ -235,13 +235,13 @@ The following API is most useful for "Parse for IoT" apps (e.g. Arduino or Embed
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
-  -H "X-Parse-Client-Key: ${CLIENT_KEY}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
+  -H "X-Parse-Client-Key: <span class="custom-parse-server-clientkey">${CLIENT_KEY}</span>" \
   -H "X-Parse-Session-Token: r:aVrtljyb7E8xKo9256gfvp4n2" \
   -H "X-Parse-Installation-Id: 2d3777a5-f5fc-4caf-80be-73c766235afb" \
   -H "Content-Type: application/json" \
   -d '{}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions/me
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions/me
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -249,7 +249,7 @@ connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR
 connection.connect()
 connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>sessions/me', json.dumps({
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:aVrtljyb7E8xKo9256gfvp4n2",
        "Content-Type": "application/json"
@@ -258,13 +258,13 @@ result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
 
-## `Session` Security
+## Session Security
 
 `Session` objects can only be accessed by the user specified in the user field. All `Session` objects have an ACL that is read and write by that user only. You cannot change this ACL. This means querying for sessions will only return objects that match the current logged-in user.
 
-When you log in a user via `<span class="custom-parse-server-mount">/parse/</span>login`, Parse will automatically create a new unrestricted `Session` object in the Parse Cloud. Same for signups and Facebook/Twitter logins.
+When you log in a user via <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>login</code>, Parse will automatically create a new unrestricted `Session` object in the Parse Cloud. Same for signups and Facebook/Twitter logins.
 
-Session objects manually created from `POST <span class="custom-parse-server-mount">/parse/</span>sessions` are always restricted. You cannot manually create an unrestricted sessions using the object creation API.
+Session objects manually created from <code class="highlighter-rouge">POST <span class="custom-parse-server-mount">/parse/</span>sessions</code> are always restricted. You cannot manually create an unrestricted sessions using the object creation API.
 
 Restricted sessions are prohibited from creating, modifying, or deleting any data in the `User`, `Session`, and `Role` classes. Restricted session also cannot read unrestricted sessions. Restricted Sessions are useful for "Parse for IoT" devices (e.g Arduino or Embedded C) that may run in a less-trusted physical environment than mobile apps. However, please keep in mind that restricted sessions can still read data on `User`, `Session`, and `Role` classes, and can read/write data in any other class just like a normal session. So it is still important for IoT devices to be in a safe physical environment and ideally use encrypted storage to store the session token.
 
@@ -280,7 +280,7 @@ Parse.Cloud.beforeSave("MyClass", function(request, response) {
   });
 });
 </code></pre>
-You can configure Class-Level Permissions (CLPs) for the Session class just like other classes on Parse. CLPs restrict reading/writing of sessions via the `<span class="custom-parse-server-mount">/parse/</span>sessions` API, but do not restrict Parse Cloud's automatic session creation/deletion when users log in, sign up, and log out. We recommend that you disable all CLPs not needed by your app. Here are some common use cases for Session CLPs:
+You can configure Class-Level Permissions (CLPs) for the Session class just like other classes on Parse. CLPs restrict reading/writing of sessions via the <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>sessions</code> API, but do not restrict Parse Cloud's automatic session creation/deletion when users log in, sign up, and log out. We recommend that you disable all CLPs not needed by your app. Here are some common use cases for Session CLPs:
 
 * **Find**, **Delete** — Useful for building a UI screen that allows users to see their active session on all devices, and log out of sessions on other devices. If your app does not have this feature, you should disable these permissions.
 * **Create** — Useful for "Parse for IoT" apps (e.g. Arduino or Embedded C) that provision restricted user sessions for other devices from the phone app. You should disable this permission when building apps for mobile and web. For "Parse for IoT" apps, you should check whether your IoT device actually needs to access user-specific data. If not, then your IoT device does not need a user session, and you should disable this permission.

--- a/_includes/rest/sessions.md
+++ b/_includes/rest/sessions.md
@@ -30,7 +30,7 @@ With revocable sessions, your current session token could become invalid if its 
 
 ## Creating Sessions
 
-For mobile apps and websites, you should not create `Session` objects manually. Instead, you should call `GET /parse/login` and `POST /parse/users` (signup), which will automatically generate a `Session` object in the Parse Cloud. The session token for this automatically-created session will be sent back on the login and signup response. Same for Facebook/Twitter login and signup requests.
+For mobile apps and websites, you should not create `Session` objects manually. Instead, you should call `GET <span class="custom-parse-server-mount">/parse/</span>login` and `POST <span class="custom-parse-server-mount">/parse/</span>users` (signup), which will automatically generate a `Session` object in the Parse Cloud. The session token for this automatically-created session will be sent back on the login and signup response. Same for Facebook/Twitter login and signup requests.
 
 In "Parse for IoT" apps (e.g. Arduino or Embedded C), you may want to programmatically create a restricted session that can be transferred to an IoT device. In order to do this, you must first log in normally to obtain an unrestricted session token. Then, you can create a restricted session by providing this unrestricted session token:
 
@@ -41,13 +41,13 @@ curl -X POST \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
   -H "Content-Type: application/json" \
   -d '{"customField":"value"}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/sessions
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/sessions', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>sessions', json.dumps({
        "customField": "value"
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -85,13 +85,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://YOUR.PARSE-SERVER.HERE/parse/sessions/Axy98kq1B09
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions/Axy98kq1B09
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/sessions/Axy98kq1B09', '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>sessions/Axy98kq1B09', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
@@ -107,13 +107,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://YOUR.PARSE-SERVER.HERE/parse/sessions/me
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions/me
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/sessions/me', '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>sessions/me', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
@@ -133,13 +133,13 @@ curl -X PUT \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
   -H "Content-Type: application/json" \
   -d '{"customField":"value"}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/sessions/Axy98kq1B09
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions/Axy98kq1B09
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/logout', '', {
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>logout', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
@@ -157,13 +157,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://YOUR.PARSE-SERVER.HERE/parse/sessions
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/sessions', '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>sessions', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
@@ -183,13 +183,13 @@ curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://YOUR.PARSE-SERVER.HERE/parse/logout
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>logout
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/logout', '', {
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>logout', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
@@ -205,13 +205,13 @@ curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://YOUR.PARSE-SERVER.HERE/parse/sessions/Axy98kq1B09
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions/Axy98kq1B09
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('DELETE', '/parse/sessions/Axy98kq1B09', '', {
+connection.request('DELETE', '<span class="custom-parse-server-mount">/parse/</span>sessions/Axy98kq1B09', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
@@ -224,7 +224,7 @@ print result
 
 ## Pairing Session with Installation
 
-For normal user login with the `/parse/login` endpoint, the Parse Cloud will set the automatically-created `Session` object's `installationId` to the `X-Parse-Installation-Id` header passed on the login or signup request. Therefore, for these scenarios, you don't need to manually associate the `Session` object with an installation.
+For normal user login with the `<span class="custom-parse-server-mount">/parse/</span>login` endpoint, the Parse Cloud will set the automatically-created `Session` object's `installationId` to the `X-Parse-Installation-Id` header passed on the login or signup request. Therefore, for these scenarios, you don't need to manually associate the `Session` object with an installation.
 
 The following API is most useful for "Parse for IoT" apps (e.g. Arduino or Embedded C). During IoT device provisioning, the phone typically does not know the `installationId` of the IoT device. The provisioning process typically goes like this:
 
@@ -241,13 +241,13 @@ curl -X PUT \
   -H "X-Parse-Installation-Id: 2d3777a5-f5fc-4caf-80be-73c766235afb" \
   -H "Content-Type: application/json" \
   -d '{}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/sessions/me
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>sessions/me
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/sessions/me', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>sessions/me', json.dumps({
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
@@ -262,9 +262,9 @@ print result
 
 `Session` objects can only be accessed by the user specified in the user field. All `Session` objects have an ACL that is read and write by that user only. You cannot change this ACL. This means querying for sessions will only return objects that match the current logged-in user.
 
-When you log in a user via `/parse/login`, Parse will automatically create a new unrestricted `Session` object in the Parse Cloud. Same for signups and Facebook/Twitter logins.
+When you log in a user via `<span class="custom-parse-server-mount">/parse/</span>login`, Parse will automatically create a new unrestricted `Session` object in the Parse Cloud. Same for signups and Facebook/Twitter logins.
 
-Session objects manually created from `POST /parse/sessions` are always restricted. You cannot manually create an unrestricted sessions using the object creation API.
+Session objects manually created from `POST <span class="custom-parse-server-mount">/parse/</span>sessions` are always restricted. You cannot manually create an unrestricted sessions using the object creation API.
 
 Restricted sessions are prohibited from creating, modifying, or deleting any data in the `User`, `Session`, and `Role` classes. Restricted session also cannot read unrestricted sessions. Restricted Sessions are useful for "Parse for IoT" devices (e.g Arduino or Embedded C) that may run in a less-trusted physical environment than mobile apps. However, please keep in mind that restricted sessions can still read data on `User`, `Session`, and `Role` classes, and can read/write data in any other class just like a normal session. So it is still important for IoT devices to be in a safe physical environment and ideally use encrypted storage to store the session token.
 
@@ -280,7 +280,7 @@ Parse.Cloud.beforeSave("MyClass", function(request, response) {
   });
 });
 </code></pre>
-You can configure Class-Level Permissions (CLPs) for the Session class just like other classes on Parse. CLPs restrict reading/writing of sessions via the `/parse/sessions` API, but do not restrict Parse Cloud's automatic session creation/deletion when users log in, sign up, and log out. We recommend that you disable all CLPs not needed by your app. Here are some common use cases for Session CLPs:
+You can configure Class-Level Permissions (CLPs) for the Session class just like other classes on Parse. CLPs restrict reading/writing of sessions via the `<span class="custom-parse-server-mount">/parse/</span>sessions` API, but do not restrict Parse Cloud's automatic session creation/deletion when users log in, sign up, and log out. We recommend that you disable all CLPs not needed by your app. Here are some common use cases for Session CLPs:
 
 * **Find**, **Delete** — Useful for building a UI screen that allows users to see their active session on all devices, and log out of sessions on other devices. If your app does not have this feature, you should disable these permissions.
 * **Create** — Useful for "Parse for IoT" apps (e.g. Arduino or Embedded C) that provision restricted user sessions for other devices from the phone app. You should disable this permission when building apps for mobile and web. For "Parse for IoT" apps, you should check whether your IoT device actually needs to access user-specific data. If not, then your IoT device does not need a user session, and you should disable this permission.

--- a/_includes/rest/sessions.md
+++ b/_includes/rest/sessions.md
@@ -30,7 +30,7 @@ With revocable sessions, your current session token could become invalid if its 
 
 ## Creating Sessions
 
-For mobile apps and websites, you should not create `Session` objects manually. Instead, you should call `GET /1/login` and `POST /1/users` (signup), which will automatically generate a `Session` object in the Parse Cloud. The session token for this automatically-created session will be sent back on the login and signup response. Same for Facebook/Twitter login and signup requests.
+For mobile apps and websites, you should not create `Session` objects manually. Instead, you should call `GET /parse/login` and `POST /parse/users` (signup), which will automatically generate a `Session` object in the Parse Cloud. The session token for this automatically-created session will be sent back on the login and signup response. Same for Facebook/Twitter login and signup requests.
 
 In "Parse for IoT" apps (e.g. Arduino or Embedded C), you may want to programmatically create a restricted session that can be transferred to an IoT device. In order to do this, you must first log in normally to obtain an unrestricted session token. Then, you can create a restricted session by providing this unrestricted session token:
 
@@ -41,13 +41,13 @@ curl -X POST \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
   -H "Content-Type: application/json" \
   -d '{"customField":"value"}' \
-  https://api.parse.com/1/sessions
+  https://YOUR.PARSE-SERVER.HERE/parse/sessions
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/sessions', json.dumps({
+connection.request('POST', '/parse/sessions', json.dumps({
        "customField": "value"
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -85,13 +85,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://api.parse.com/1/sessions/Axy98kq1B09
+  https://YOUR.PARSE-SERVER.HERE/parse/sessions/Axy98kq1B09
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/sessions/Axy98kq1B09', '', {
+connection.request('GET', '/parse/sessions/Axy98kq1B09', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
@@ -107,13 +107,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://api.parse.com/1/sessions/me
+  https://YOUR.PARSE-SERVER.HERE/parse/sessions/me
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/sessions/me', '', {
+connection.request('GET', '/parse/sessions/me', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
@@ -133,13 +133,13 @@ curl -X PUT \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
   -H "Content-Type: application/json" \
   -d '{"customField":"value"}' \
-  https://api.parse.com/1/sessions/Axy98kq1B09
+  https://YOUR.PARSE-SERVER.HERE/parse/sessions/Axy98kq1B09
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/logout', '', {
+connection.request('POST', '/parse/logout', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
@@ -157,13 +157,13 @@ curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://api.parse.com/1/sessions
+  https://YOUR.PARSE-SERVER.HERE/parse/sessions
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/sessions', '', {
+connection.request('GET', '/parse/sessions', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
@@ -183,13 +183,13 @@ curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://api.parse.com/1/logout
+  https://YOUR.PARSE-SERVER.HERE/parse/logout
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/logout', '', {
+connection.request('POST', '/parse/logout', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
@@ -205,13 +205,13 @@ curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://api.parse.com/1/sessions/Axy98kq1B09
+  https://YOUR.PARSE-SERVER.HERE/parse/sessions/Axy98kq1B09
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('DELETE', '/1/sessions/Axy98kq1B09', '', {
+connection.request('DELETE', '/parse/sessions/Axy98kq1B09', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
@@ -224,7 +224,7 @@ print result
 
 ## Pairing Session with Installation
 
-For normal user login with the `/1/login` endpoint, the Parse Cloud will set the automatically-created `Session` object's `installationId` to the `X-Parse-Installation-Id` header passed on the login or signup request. Therefore, for these scenarios, you don't need to manually associate the `Session` object with an installation.
+For normal user login with the `/parse/login` endpoint, the Parse Cloud will set the automatically-created `Session` object's `installationId` to the `X-Parse-Installation-Id` header passed on the login or signup request. Therefore, for these scenarios, you don't need to manually associate the `Session` object with an installation.
 
 The following API is most useful for "Parse for IoT" apps (e.g. Arduino or Embedded C). During IoT device provisioning, the phone typically does not know the `installationId` of the IoT device. The provisioning process typically goes like this:
 
@@ -241,13 +241,13 @@ curl -X PUT \
   -H "X-Parse-Installation-Id: 2d3777a5-f5fc-4caf-80be-73c766235afb" \
   -H "Content-Type: application/json" \
   -d '{}' \
-  https://api.parse.com/1/sessions/me
+  https://YOUR.PARSE-SERVER.HERE/parse/sessions/me
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/sessions/me', json.dumps({
+connection.request('PUT', '/parse/sessions/me', json.dumps({
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
@@ -262,9 +262,9 @@ print result
 
 `Session` objects can only be accessed by the user specified in the user field. All `Session` objects have an ACL that is read and write by that user only. You cannot change this ACL. This means querying for sessions will only return objects that match the current logged-in user.
 
-When you log in a user via `/1/login`, Parse will automatically create a new unrestricted `Session` object in the Parse Cloud. Same for signups and Facebook/Twitter logins.
+When you log in a user via `/parse/login`, Parse will automatically create a new unrestricted `Session` object in the Parse Cloud. Same for signups and Facebook/Twitter logins.
 
-Session objects manually created from `POST /1/sessions` are always restricted. You cannot manually create an unrestricted sessions using the object creation API.
+Session objects manually created from `POST /parse/sessions` are always restricted. You cannot manually create an unrestricted sessions using the object creation API.
 
 Restricted sessions are prohibited from creating, modifying, or deleting any data in the `User`, `Session`, and `Role` classes. Restricted session also cannot read unrestricted sessions. Restricted Sessions are useful for "Parse for IoT" devices (e.g Arduino or Embedded C) that may run in a less-trusted physical environment than mobile apps. However, please keep in mind that restricted sessions can still read data on `User`, `Session`, and `Role` classes, and can read/write data in any other class just like a normal session. So it is still important for IoT devices to be in a safe physical environment and ideally use encrypted storage to store the session token.
 
@@ -280,7 +280,7 @@ Parse.Cloud.beforeSave("MyClass", function(request, response) {
   });
 });
 </code></pre>
-You can configure Class-Level Permissions (CLPs) for the Session class just like other classes on Parse. CLPs restrict reading/writing of sessions via the `/1/sessions` API, but do not restrict Parse Cloud's automatic session creation/deletion when users log in, sign up, and log out. We recommend that you disable all CLPs not needed by your app. Here are some common use cases for Session CLPs:
+You can configure Class-Level Permissions (CLPs) for the Session class just like other classes on Parse. CLPs restrict reading/writing of sessions via the `/parse/sessions` API, but do not restrict Parse Cloud's automatic session creation/deletion when users log in, sign up, and log out. We recommend that you disable all CLPs not needed by your app. Here are some common use cases for Session CLPs:
 
 * **Find**, **Delete** — Useful for building a UI screen that allows users to see their active session on all devices, and log out of sessions on other devices. If your app does not have this feature, you should disable these permissions.
 * **Create** — Useful for "Parse for IoT" apps (e.g. Arduino or Embedded C) that provision restricted user sessions for other devices from the phone app. You should disable this permission when building apps for mobile and web. For "Parse for IoT" apps, you should check whether your IoT device actually needs to access user-specific data. If not, then your IoT device does not need a user session, and you should disable this permission.

--- a/_includes/rest/users.md
+++ b/_includes/rest/users.md
@@ -19,13 +19,13 @@ curl -X POST \
   -H "X-Parse-Revocable-Session: 1" \
   -H "Content-Type: application/json" \
   -d '{"username":"cooldude6","password":"p_n7!-e8","phone":"415-392-0202"}' \
-  https://api.parse.com/1/users
+  https://YOUR.PARSE-SERVER.HERE/parse/users
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/users', json.dumps({
+connection.request('POST', '/parse/users', json.dumps({
        "username": "cooldude6",
        "password": "p_n7!-e8",
        "phone": "415-392-0202"
@@ -43,7 +43,7 @@ When the creation is successful, the HTTP response is a `201 Created` and the `L
 
 <pre><code class="javascript">
 Status: 201 Created
-Location: https://api.parse.com/1/users/g7y9tkhB7O
+Location: https://YOUR.PARSE-SERVER.HERE/parse/users/g7y9tkhB7O
 </code></pre>
 
 The response body is a JSON object containing the `objectId`, the `createdAt` timestamp of the newly-created object, and the `sessionToken` which can be used to authenticate subsequent requests as this user:
@@ -58,7 +58,7 @@ The response body is a JSON object containing the `objectId`, the `createdAt` ti
 
 ## Logging In
 
-After you allow users to sign up, you need to let them log in to their account with a username and password in the future. To do this, send a GET request to the `/1/login` endpoint with `username` and `password` as URL-encoded parameters:
+After you allow users to sign up, you need to let them log in to their account with a username and password in the future. To do this, send a GET request to the `/parse/login` endpoint with `username` and `password` as URL-encoded parameters:
 
 <pre><code class="bash">
 curl -X GET \
@@ -68,14 +68,14 @@ curl -X GET \
   -G \
   --data-urlencode 'username=cooldude6' \
   --data-urlencode 'password=p_n7!-e8' \
-  https://api.parse.com/1/login
+  https://YOUR.PARSE-SERVER.HERE/parse/login
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 params = urllib.urlencode({"username":"cooldude6","password":"p_n7!-e8"})
 connection.connect()
-connection.request('GET', '/1/login?%s' % params, '', {
+connection.request('GET', '/parse/login?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Revocable-Session": "1"
@@ -110,7 +110,7 @@ There are three `emailVerified` states to consider:
 
 ## Requesting A Password Reset
 
-You can initiate password resets for users who have emails associated with their account. To do this, send a POST request to `/1/requestPasswordReset` endpoint with `email` in the body of the request:
+You can initiate password resets for users who have emails associated with their account. To do this, send a POST request to `/parse/requestPasswordReset` endpoint with `email` in the body of the request:
 
 <pre><code class="bash">
 curl -X POST \
@@ -118,13 +118,13 @@ curl -X POST \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"email":"coolguy@iloveapps.com"}' \
-  https://api.parse.com/1/requestPasswordReset
+  https://YOUR.PARSE-SERVER.HERE/parse/requestPasswordReset
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/requestPasswordReset', json.dumps({
+connection.request('POST', '/parse/requestPasswordReset', json.dumps({
        "email": "coolguy@iloveapps.com"
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -146,13 +146,13 @@ You can also retrieve the contents of a user object by sending a GET request to 
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://api.parse.com/1/users/g7y9tkhB7O
+  https://YOUR.PARSE-SERVER.HERE/parse/users/g7y9tkhB7O
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/users/g7y9tkhB7O', '', {
+connection.request('GET', '/parse/users/g7y9tkhB7O', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -174,20 +174,20 @@ The response body is a JSON object containing all the user-provided fields excep
 
 ## Validating Session Tokens / Retrieving Current User
 
-With a valid session token, you can send a GET request to the `/1/users/me` endpoint to retrieve the user associated with that session token:
+With a valid session token, you can send a GET request to the `/parse/users/me` endpoint to retrieve the user associated with that session token:
 
 <pre><code class="bash">
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://api.parse.com/1/users/me
+  https://YOUR.PARSE-SERVER.HERE/parse/users/me
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/users/me', '', {
+connection.request('GET', '/parse/users/me', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
@@ -220,13 +220,13 @@ curl -X PUT \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
   -H "Content-Type: application/json" \
   -d '{"phone":"415-369-6201"}' \
-  https://api.parse.com/1/users/g7y9tkhB7O
+  https://YOUR.PARSE-SERVER.HERE/parse/users/g7y9tkhB7O
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/users/g7y9tkhB7O', json.dumps({
+connection.request('PUT', '/parse/users/g7y9tkhB7O', json.dumps({
        "phone": "415-369-6201"
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -254,13 +254,13 @@ You can retrieve multiple users at once by sending a GET request to the root use
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://api.parse.com/1/users
+  https://YOUR.PARSE-SERVER.HERE/parse/users
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('GET', '/1/users', '', {
+connection.request('GET', '/parse/users', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -303,13 +303,13 @@ curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://api.parse.com/1/users/g7y9tkhB7O
+  https://YOUR.PARSE-SERVER.HERE/parse/users/g7y9tkhB7O
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('DELETE', '/1/users/g7y9tkhB7O', '', {
+connection.request('DELETE', '/parse/users/g7y9tkhB7O', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
@@ -386,13 +386,13 @@ curl -X POST \
           }
         }
       }' \
-  https://api.parse.com/1/users
+  https://YOUR.PARSE-SERVER.HERE/parse/users
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('POST', '/1/users', json.dumps({
+connection.request('POST', '/parse/users', json.dumps({
        "authData": {
          "twitter": {
            "id": "12345678",
@@ -417,7 +417,7 @@ Parse then verifies that the provided `authData` is valid and checks to see if a
 
 <pre><code class="javascript">
 Status: 200 OK
-Location: https://api.parse.com/1/users/uMz0YZeAqc
+Location: https://YOUR.PARSE-SERVER.HERE/parse/users/uMz0YZeAqc
 </code></pre>
 
 With a response body like:
@@ -446,7 +446,7 @@ If the user has never been linked with this account, you will instead receive a 
 
 <pre><code class="javascript">
 Status: 201 Created
-Location: https://api.parse.com/1/users/uMz0YZeAqc
+Location: https://YOUR.PARSE-SERVER.HERE/parse/users/uMz0YZeAqc
 </code></pre>
 
 The body of the response will contain the `objectId`, `createdAt`, `sessionToken`, and an automatically-generated unique `username`.  For example:
@@ -479,13 +479,13 @@ curl -X PUT \
           }
         }
       }' \
-  https://api.parse.com/1/users/uMz0YZeAqc
+  https://YOUR.PARSE-SERVER.HERE/parse/users/uMz0YZeAqc
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/users/uMz0YZeAqc', json.dumps({
+connection.request('PUT', '/parse/users/uMz0YZeAqc', json.dumps({
        "authData": {
          "facebook": {
            "id": "123456789",
@@ -520,13 +520,13 @@ curl -X PUT \
           "facebook": null
         }
       }' \
-  https://api.parse.com/1/users/uMz0YZeAqc
+  https://YOUR.PARSE-SERVER.HERE/parse/users/uMz0YZeAqc
 </code></pre>
 <pre><code class="bash">
 import json,httplib
-connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
 connection.connect()
-connection.request('PUT', '/1/users/uMz0YZeAqc', json.dumps({
+connection.request('PUT', '/parse/users/uMz0YZeAqc', json.dumps({
        "authData": {
          "facebook": null
        }

--- a/_includes/rest/users.md
+++ b/_includes/rest/users.md
@@ -19,13 +19,13 @@ curl -X POST \
   -H "X-Parse-Revocable-Session: 1" \
   -H "Content-Type: application/json" \
   -d '{"username":"cooldude6","password":"p_n7!-e8","phone":"415-392-0202"}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/users
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/users', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>users', json.dumps({
        "username": "cooldude6",
        "password": "p_n7!-e8",
        "phone": "415-392-0202"
@@ -43,7 +43,7 @@ When the creation is successful, the HTTP response is a `201 Created` and the `L
 
 <pre><code class="javascript">
 Status: 201 Created
-Location: https://YOUR.PARSE-SERVER.HERE/parse/users/g7y9tkhB7O
+Location: https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O
 </code></pre>
 
 The response body is a JSON object containing the `objectId`, the `createdAt` timestamp of the newly-created object, and the `sessionToken` which can be used to authenticate subsequent requests as this user:
@@ -58,7 +58,7 @@ The response body is a JSON object containing the `objectId`, the `createdAt` ti
 
 ## Logging In
 
-After you allow users to sign up, you need to let them log in to their account with a username and password in the future. To do this, send a GET request to the `/parse/login` endpoint with `username` and `password` as URL-encoded parameters:
+After you allow users to sign up, you need to let them log in to their account with a username and password in the future. To do this, send a GET request to the `<span class="custom-parse-server-mount">/parse/</span>login` endpoint with `username` and `password` as URL-encoded parameters:
 
 <pre><code class="bash">
 curl -X GET \
@@ -68,14 +68,14 @@ curl -X GET \
   -G \
   --data-urlencode 'username=cooldude6' \
   --data-urlencode 'password=p_n7!-e8' \
-  https://YOUR.PARSE-SERVER.HERE/parse/login
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>login
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 params = urllib.urlencode({"username":"cooldude6","password":"p_n7!-e8"})
 connection.connect()
-connection.request('GET', '/parse/login?%s' % params, '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>login?%s' % params, '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Revocable-Session": "1"
@@ -110,7 +110,7 @@ There are three `emailVerified` states to consider:
 
 ## Requesting A Password Reset
 
-You can initiate password resets for users who have emails associated with their account. To do this, send a POST request to `/parse/requestPasswordReset` endpoint with `email` in the body of the request:
+You can initiate password resets for users who have emails associated with their account. To do this, send a POST request to `<span class="custom-parse-server-mount">/parse/</span>requestPasswordReset` endpoint with `email` in the body of the request:
 
 <pre><code class="bash">
 curl -X POST \
@@ -118,13 +118,13 @@ curl -X POST \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"email":"coolguy@iloveapps.com"}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/requestPasswordReset
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>requestPasswordReset
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/requestPasswordReset', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>requestPasswordReset', json.dumps({
        "email": "coolguy@iloveapps.com"
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -146,13 +146,13 @@ You can also retrieve the contents of a user object by sending a GET request to 
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://YOUR.PARSE-SERVER.HERE/parse/users/g7y9tkhB7O
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/users/g7y9tkhB7O', '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -174,20 +174,20 @@ The response body is a JSON object containing all the user-provided fields excep
 
 ## Validating Session Tokens / Retrieving Current User
 
-With a valid session token, you can send a GET request to the `/parse/users/me` endpoint to retrieve the user associated with that session token:
+With a valid session token, you can send a GET request to the `<span class="custom-parse-server-mount">/parse/</span>users/me` endpoint to retrieve the user associated with that session token:
 
 <pre><code class="bash">
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://YOUR.PARSE-SERVER.HERE/parse/users/me
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/me
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/users/me', '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>users/me', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
@@ -220,13 +220,13 @@ curl -X PUT \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
   -H "Content-Type: application/json" \
   -d '{"phone":"415-369-6201"}' \
-  https://YOUR.PARSE-SERVER.HERE/parse/users/g7y9tkhB7O
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/users/g7y9tkhB7O', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O', json.dumps({
        "phone": "415-369-6201"
      }), {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
@@ -254,13 +254,13 @@ You can retrieve multiple users at once by sending a GET request to the root use
 curl -X GET \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://YOUR.PARSE-SERVER.HERE/parse/users
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('GET', '/parse/users', '', {
+connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>users', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
@@ -303,13 +303,13 @@ curl -X DELETE \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://YOUR.PARSE-SERVER.HERE/parse/users/g7y9tkhB7O
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('DELETE', '/parse/users/g7y9tkhB7O', '', {
+connection.request('DELETE', '<span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O', '', {
        "X-Parse-Application-Id": "${APPLICATION_ID}",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
@@ -386,13 +386,13 @@ curl -X POST \
           }
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/users
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('POST', '/parse/users', json.dumps({
+connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>users', json.dumps({
        "authData": {
          "twitter": {
            "id": "12345678",
@@ -417,7 +417,7 @@ Parse then verifies that the provided `authData` is valid and checks to see if a
 
 <pre><code class="javascript">
 Status: 200 OK
-Location: https://YOUR.PARSE-SERVER.HERE/parse/users/uMz0YZeAqc
+Location: https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/uMz0YZeAqc
 </code></pre>
 
 With a response body like:
@@ -446,7 +446,7 @@ If the user has never been linked with this account, you will instead receive a 
 
 <pre><code class="javascript">
 Status: 201 Created
-Location: https://YOUR.PARSE-SERVER.HERE/parse/users/uMz0YZeAqc
+Location: https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/uMz0YZeAqc
 </code></pre>
 
 The body of the response will contain the `objectId`, `createdAt`, `sessionToken`, and an automatically-generated unique `username`.  For example:
@@ -479,13 +479,13 @@ curl -X PUT \
           }
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/users/uMz0YZeAqc
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/uMz0YZeAqc
 </code></pre>
 <pre><code class="python">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/users/uMz0YZeAqc', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>users/uMz0YZeAqc', json.dumps({
        "authData": {
          "facebook": {
            "id": "123456789",
@@ -520,13 +520,13 @@ curl -X PUT \
           "facebook": null
         }
       }' \
-  https://YOUR.PARSE-SERVER.HERE/parse/users/uMz0YZeAqc
+  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/uMz0YZeAqc
 </code></pre>
 <pre><code class="bash">
 import json,httplib
-connection = httplib.HTTPSConnection('YOUR.PARSE-SERVER.HERE', 443)
+connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
-connection.request('PUT', '/parse/users/uMz0YZeAqc', json.dumps({
+connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>users/uMz0YZeAqc', json.dumps({
        "authData": {
          "facebook": null
        }

--- a/_includes/rest/users.md
+++ b/_includes/rest/users.md
@@ -14,12 +14,12 @@ To sign up a new user, send a POST request to the users root. You may add any ad
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Revocable-Session: 1" \
   -H "Content-Type: application/json" \
   -d '{"username":"cooldude6","password":"p_n7!-e8","phone":"415-392-0202"}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -30,7 +30,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
        "password": "p_n7!-e8",
        "phone": "415-392-0202"
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Revocable-Session": "1",
        "Content-Type": "application/json"
@@ -43,7 +43,7 @@ When the creation is successful, the HTTP response is a `201 Created` and the `L
 
 <pre><code class="javascript">
 Status: 201 Created
-Location: https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O
+Location: <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O
 </code></pre>
 
 The response body is a JSON object containing the `objectId`, the `createdAt` timestamp of the newly-created object, and the `sessionToken` which can be used to authenticate subsequent requests as this user:
@@ -58,17 +58,17 @@ The response body is a JSON object containing the `objectId`, the `createdAt` ti
 
 ## Logging In
 
-After you allow users to sign up, you need to let them log in to their account with a username and password in the future. To do this, send a GET request to the `<span class="custom-parse-server-mount">/parse/</span>login` endpoint with `username` and `password` as URL-encoded parameters:
+After you allow users to sign up, you need to let them log in to their account with a username and password in the future. To do this, send a GET request to the <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>login</code> endpoint with `username` and `password` as URL-encoded parameters:
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Revocable-Session: 1" \
   -G \
   --data-urlencode 'username=cooldude6' \
   --data-urlencode 'password=p_n7!-e8' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>login
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>login
 </code></pre>
 <pre><code class="python">
 import json,httplib,urllib
@@ -76,7 +76,7 @@ connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR
 params = urllib.urlencode({"username":"cooldude6","password":"p_n7!-e8"})
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>login?%s' % params, '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Revocable-Session": "1"
      })
@@ -110,15 +110,15 @@ There are three `emailVerified` states to consider:
 
 ## Requesting A Password Reset
 
-You can initiate password resets for users who have emails associated with their account. To do this, send a POST request to `<span class="custom-parse-server-mount">/parse/</span>requestPasswordReset` endpoint with `email` in the body of the request:
+You can initiate password resets for users who have emails associated with their account. To do this, send a POST request to <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>requestPasswordReset</code> endpoint with `email` in the body of the request:
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"email":"coolguy@iloveapps.com"}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>requestPasswordReset
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>requestPasswordReset
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -127,7 +127,7 @@ connection.connect()
 connection.request('POST', '<span class="custom-parse-server-mount">/parse/</span>requestPasswordReset', json.dumps({
        "email": "coolguy@iloveapps.com"
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "Content-Type": "application/json"
      })
@@ -144,16 +144,16 @@ You can also retrieve the contents of a user object by sending a GET request to 
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -174,21 +174,21 @@ The response body is a JSON object containing all the user-provided fields excep
 
 ## Validating Session Tokens / Retrieving Current User
 
-With a valid session token, you can send a GET request to the `<span class="custom-parse-server-mount">/parse/</span>users/me` endpoint to retrieve the user associated with that session token:
+With a valid session token, you can send a GET request to the <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>users/me</code> endpoint to retrieve the user associated with that session token:
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/me
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/me
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>users/me', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
      })
@@ -215,12 +215,12 @@ For example, if we wanted to change the phone number for `cooldude6`:
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
   -H "Content-Type: application/json" \
   -d '{"phone":"415-369-6201"}' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -229,7 +229,7 @@ connection.connect()
 connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O', json.dumps({
        "phone": "415-369-6201"
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im",
        "Content-Type": "application/json"
@@ -252,16 +252,16 @@ You can retrieve multiple users at once by sending a GET request to the root use
 
 <pre><code class="bash">
 curl -X GET \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span>users', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}"
      })
 result = json.loads(connection.getresponse().read())
@@ -300,17 +300,17 @@ To delete a user from the Parse Cloud, send a DELETE request to its URL. You mus
 
 <pre><code class="bash">
 curl -X DELETE \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:pnktnjyb996sj4p156gjtp4im" \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O
 </code></pre>
 <pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
 connection.request('DELETE', '<span class="custom-parse-server-mount">/parse/</span>users/g7y9tkhB7O', '', {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:pnktnjyb996sj4p156gjtp4im"
      })
@@ -370,7 +370,7 @@ Signing a user up with a linked service and logging them in with that service us
 
 <pre><code class="bash">
 curl -X POST \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Revocable-Session: 1" \
   -H "Content-Type: application/json" \
@@ -386,7 +386,7 @@ curl -X POST \
           }
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -404,7 +404,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
          }
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Revocable-Session": "1",
        "Content-Type": "application/json"
@@ -417,7 +417,7 @@ Parse then verifies that the provided `authData` is valid and checks to see if a
 
 <pre><code class="javascript">
 Status: 200 OK
-Location: https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/uMz0YZeAqc
+Location: <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/uMz0YZeAqc
 </code></pre>
 
 With a response body like:
@@ -446,7 +446,7 @@ If the user has never been linked with this account, you will instead receive a 
 
 <pre><code class="javascript">
 Status: 201 Created
-Location: https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/uMz0YZeAqc
+Location: <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/uMz0YZeAqc
 </code></pre>
 
 The body of the response will contain the `objectId`, `createdAt`, `sessionToken`, and an automatically-generated unique `username`.  For example:
@@ -466,7 +466,7 @@ Linking an existing user with a service like Facebook or Twitter uses a PUT requ
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:samplei3l83eerhnln0ecxgy5" \
   -H "Content-Type: application/json" \
@@ -479,7 +479,7 @@ curl -X PUT \
           }
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/uMz0YZeAqc
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/uMz0YZeAqc
 </code></pre>
 <pre><code class="python">
 import json,httplib
@@ -494,7 +494,7 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
          }
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:samplei3l83eerhnln0ecxgy5",
        "Content-Type": "application/json"
@@ -511,7 +511,7 @@ Unlinking an existing user with a service also uses a PUT request to clear `auth
 
 <pre><code class="bash">
 curl -X PUT \
-  -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
+  -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-REST-API-Key: ${REST_API_KEY}" \
   -H "X-Parse-Session-Token: r:samplei3l83eerhnln0ecxgy5" \
   -H "Content-Type: application/json" \
@@ -520,9 +520,9 @@ curl -X PUT \
           "facebook": null
         }
       }' \
-  https://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/uMz0YZeAqc
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>users/uMz0YZeAqc
 </code></pre>
-<pre><code class="bash">
+<pre><code class="python">
 import json,httplib
 connection = httplib.HTTPSConnection('<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span>', 443)
 connection.connect()
@@ -531,7 +531,7 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
          "facebook": null
        }
      }), {
-       "X-Parse-Application-Id": "${APPLICATION_ID}",
+       "X-Parse-Application-Id": "<span class="custom-parse-server-appid">${APPLICATION_ID}</span>",
        "X-Parse-REST-API-Key": "${REST_API_KEY}",
        "X-Parse-Session-Token": "r:samplei3l83eerhnln0ecxgy5",
        "Content-Type": "application/json"

--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -46,7 +46,7 @@
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(_, $) {'use strict';
 
@@ -414,7 +414,6 @@
 									// Build main table of contents list from h1 tags
 									if (el.tagName === 'H1') {
 											latestMajor = UI.tag('ul', { className: 'ui_live_toc_major_list' });
-											latestMajor.name = name;
 											toc.push(UI.tag('li', { 'data-name': name, className: 'ui_live_toc_main' }, [UI.tag('a', { href: '#' + name }, text), latestMajor]));
 											latestMinor = undefined;
 
@@ -422,7 +421,6 @@
 											// that appear before the first H1.
 									} else if (el.tagName === 'H2' && latestMajor !== undefined) {
 											latestMinor = UI.tag('ul', { className: 'ui_live_toc_minor_list' });
-											latestMinor.name = name;
 											latestMajor.appendChild(UI.tag('li', { 'data-name': name, className: 'ui_live_toc_major' }, [UI.tag('a', { href: '#' + name }, text), latestMinor]));
 
 											// Build deeper collapsable sublist with h3 tags. We skip any
@@ -440,27 +438,13 @@
 							var headerHeights = {};
 							var sortedHeights = [];
 							var headers = this.content.querySelectorAll('h1, h2, h3');
-							var latestMajor, latestMinor;
 							for (var i = 0; i < headers.length; i++) {
 									// var anchor = headers[i].getElementsByTagName('a')[0];
 									// var name = anchor.name;
-									var el = headers[i];
-									var name = el.id;
-									var shouldAdd = false;
-									if (el.tagName === 'H1') {
-										latestMajor = el;
-										latestMinor = undefined;
-										shouldAdd = true;
-									} else if (el.tagName === 'H2' && latestMajor !== undefined) {
-										latestMinor = el;
-										shouldAdd = true;
-									} else if (el.tagName === 'H3' && latestMajor !== undefined && latestMinor !== undefined) {
-										shouldAdd = true;
-									}
-									if (shouldAdd) {
-										headerHeights[headers[i].offsetTop] = name;
-										sortedHeights.push(headers[i].offsetTop);
-									}
+									var name = headers[i].id;
+
+									headerHeights[headers[i].offsetTop] = name;
+									sortedHeights.push(headers[i].offsetTop);
 							}
 							this._headerHeights = headerHeights;
 							this._sortedHeights = sortedHeights.sort(function (a, b) {
@@ -692,12 +676,14 @@
 							this.toc = new UI.LiveTOC({
 									parent: document.getElementById('toc'),
 									scrollContent: this.scrollContent,
-									content: document.getElementsByClassName('guide_content')[0],
-									alignment: 'top'
+									content: document.getElementsByClassName('guide_content')[0]
 							});
 
 							// deal with common-lang-blocks
 							this.toggleCommonLangBlocks();
+
+							// setup the server/mount path editor
+							this.setupServerFieldCustomization();
 
 							// add toggles to code blocks if necessary
 							if (this.platform === "ios" || this.platform === "osx" || this.platform === "macos") {
@@ -778,6 +764,66 @@
 							}
 					},
 
+					setupServerFieldCustomization: function setupServerFieldCustomization() {
+
+							if (this.platform !== 'rest') {
+									// only customizes for rest currently
+									return;
+							}
+
+							// constant class name for both
+							var className = "custom-server-option";
+
+							var html = "<span class='custom-server-description'>Your Server Settings</span>";
+
+							// server url
+							var title = "Set your parse server url here.";
+							var value = "YOUR.PARSE-SERVER.HERE";
+							var id = 'parse-server-custom-url';
+							var holder = 'your.parse-server.com';
+							html += "<input id='" + id + "' class='" + className + "' type='text' placeholder='" + holder + "' value='" + value + "' title='" + title + "'>";
+
+							// mount path
+							title = "Set your parse server mount path here.";
+							value = "parse";
+							id = 'parse-server-custom-mount';
+							holder = 'parse';
+							html += "<input id='" + id + "' class='" + className + "' type='text' placeholder='" + holder + "' value='" + value + "' title='" + title + "'>";
+
+							html += "<br/>";
+
+							// add right before the first side bar section
+							document.getElementsByClassName('ui_live_toc')[0].insertAdjacentHTML('beforebegin', html);
+
+							// set url listener
+							$('#parse-server-custom-url').keyup(function () {
+									var url = $('#parse-server-custom-url').val();
+									if (!url.match(/^[-_a-z0-9\.]+$/i)) {
+											// not a valid url
+											return;
+									}
+									$(".custom-parse-server-url").html(url);
+							});
+
+							// set mount listener
+							$('#parse-server-custom-mount').keyup(function () {
+									var mount = $('#parse-server-custom-mount').val();
+									if (!mount.match(/^[-_a-z0-9\/]+$/i) && mount !== '') {
+											// not a valid mount path, and not empty
+											return;
+									}
+									if (!mount.match(/^\//)) {
+											// add leading slash
+											mount = '/' + mount;
+									}
+									if (!mount.match(/\/$/)) {
+											// add trailing slash
+											mount = mount + '/';
+									}
+									$(".custom-parse-server-mount").html(mount);
+							});
+					},
+
 					// we recalculate the header heights for the TOC
 					// highlighting when the height of the content changes
 					handleToggleChange: function handleToggleChange() {
@@ -785,7 +831,7 @@
 					},
 
 					handleSelectChange: function handleSelectChange(e) {
-							location.href = "#" + this.mobileToc.selectedOptions[0].getAttribute('data-anchor');
+							location.href = this.mobileToc.selectedOptions[0].getAttribute('data-anchor');
 					},
 
 					handleWindowResize: function handleWindowResize(e) {
@@ -810,9 +856,9 @@
 	}
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1), __webpack_require__(2)))
 
-/***/ },
+/***/ }),
 /* 1 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;'use strict';
 
@@ -2387,9 +2433,9 @@
 	  }
 	}).call(undefined);
 
-/***/ },
+/***/ }),
 /* 2 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -2398,9 +2444,9 @@
 		return window.jQuery = window.$ = jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 3 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -2848,9 +2894,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 4 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -2879,9 +2925,9 @@
 		};
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 5 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3368,9 +3414,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 6 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3378,9 +3424,9 @@
 		return arr.indexOf;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 7 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3388,9 +3434,9 @@
 		return [];
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 8 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3398,9 +3444,9 @@
 		return arr.slice;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 9 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3408,9 +3454,9 @@
 		return arr.concat;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 10 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3418,9 +3464,9 @@
 		return arr.push;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 11 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3428,9 +3474,9 @@
 		return window.document;
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 12 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3440,9 +3486,9 @@
 		return {};
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 13 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3450,9 +3496,9 @@
 		return class2type.toString;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 14 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3460,9 +3506,9 @@
 		return class2type.hasOwnProperty;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 15 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3472,9 +3518,9 @@
 		return {};
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 16 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3534,9 +3580,9 @@
 		return access;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 17 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3545,9 +3591,9 @@
 		);
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 18 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3556,9 +3602,9 @@
 		return new RegExp("^(?:([+-])=|)(" + pnum + ")([a-z%]*)$", "i");
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 19 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3567,9 +3613,9 @@
 		);
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 20 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3577,9 +3623,9 @@
 		return new RegExp("^(" + pnum + ")(?!px)[a-z%]+$", "i");
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 21 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3587,9 +3633,9 @@
 		return ["Top", "Right", "Bottom", "Left"];
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 22 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3607,17 +3653,17 @@
 		};
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 23 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
 	!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(24)], __WEBPACK_AMD_DEFINE_RESULT__ = function () {}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 24 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -3632,9 +3678,9 @@
 		jQuery.contains = Sizzle.contains;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 25 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -5688,9 +5734,9 @@
 		// EXPOSE
 	})(window);
 
-/***/ },
+/***/ }),
 /* 26 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -5710,9 +5756,9 @@
 		};
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 27 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -5773,9 +5819,9 @@
 		return curCSS;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 28 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -5893,9 +5939,9 @@
 		return support;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 29 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -5903,9 +5949,9 @@
 		return document.documentElement;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 30 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -5970,9 +6016,9 @@
 		return adjustCSS;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 31 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -6044,9 +6090,9 @@
 		return defaultDisplay;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 32 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -6505,9 +6551,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 33 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -6612,9 +6658,9 @@
 		return buildFragment;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 34 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -6623,9 +6669,9 @@
 		);
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 35 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -6634,9 +6680,9 @@
 		);
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 36 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -6668,9 +6714,9 @@
 		return wrapMap;
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 37 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -6688,9 +6734,9 @@
 		return getAll;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 38 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -6709,9 +6755,9 @@
 		return setGlobalEval;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 39 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -6719,9 +6765,9 @@
 		return new Data();
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 40 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -6918,9 +6964,9 @@
 		return Data;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 41 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -6929,9 +6975,9 @@
 		);
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 42 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -6953,9 +6999,9 @@
 		};
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 43 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -6964,9 +7010,9 @@
 		);
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 44 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -7000,9 +7046,9 @@
 		return support;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 45 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -7010,9 +7056,9 @@
 		return new Data();
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 46 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -7137,9 +7183,9 @@
 		return init;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 47 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -7150,9 +7196,9 @@
 		);
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 48 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -7242,9 +7288,9 @@
 		});
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 49 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -7252,9 +7298,9 @@
 		return jQuery.expr.match.needsContext;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 50 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -7415,9 +7461,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 51 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -7439,9 +7485,9 @@
 		};
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 52 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -7460,9 +7506,9 @@
 		};
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 53 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -8165,9 +8211,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 54 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -8195,9 +8241,9 @@
 		return addGetHookIf;
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 55 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -8297,9 +8343,9 @@
 		jQuery.ready.promise();
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 56 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -8449,9 +8495,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 57 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -8688,9 +8734,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 58 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -8877,9 +8923,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 59 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -9020,9 +9066,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 60 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -9046,9 +9092,9 @@
 		return jQuery.fn.delay;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 61 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -9659,9 +9705,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 62 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -9776,9 +9822,9 @@
 		jQuery.fx.step = {};
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 63 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -9788,9 +9834,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 64 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -9927,9 +9973,9 @@
 		});
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 65 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -9966,9 +10012,9 @@
 		return support;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 66 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -10076,9 +10122,9 @@
 		});
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 67 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -10257,9 +10303,9 @@
 		});
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 68 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -10426,9 +10472,9 @@
 		});
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 69 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -10449,9 +10495,9 @@
 		});
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 70 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -10624,9 +10670,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 71 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -10676,9 +10722,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 72 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -10689,9 +10735,9 @@
 		return support;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 73 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -10713,9 +10759,9 @@
 		return jQuery._evalUrl;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 74 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -11571,9 +11617,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 75 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -11581,9 +11627,9 @@
 		return window.location;
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 76 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -11591,9 +11637,9 @@
 		return jQuery.now();
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 77 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -11602,9 +11648,9 @@
 		);
 	}.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 78 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -11619,9 +11665,9 @@
 		return jQuery.parseJSON;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 79 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -11650,9 +11696,9 @@
 		return jQuery.parseXML;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 80 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -11732,9 +11778,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 81 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -11753,9 +11799,9 @@
 		};
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 82 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -11865,9 +11911,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 83 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -12018,9 +12064,9 @@
 		});
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 84 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -12084,9 +12130,9 @@
 		});
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 85 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -12179,9 +12225,9 @@
 		});
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 86 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -12265,9 +12311,9 @@
 		};
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 87 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -12307,9 +12353,9 @@
 		return jQuery.parseHTML;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 88 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -12323,9 +12369,9 @@
 		});
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 89 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -12338,9 +12384,9 @@
 		};
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 90 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -12545,9 +12591,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 91 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -12597,9 +12643,9 @@
 		return jQuery;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 92 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -12630,9 +12676,9 @@
 		jQuery.fn.andSelf = jQuery.fn.addBack;
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ },
+/***/ }),
 /* 93 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;"use strict";
 
@@ -12658,5 +12704,5 @@
 		}
 	}.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
-/***/ }
+/***/ })
 /******/ ]);

--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -766,43 +766,53 @@
 
 					setupServerFieldCustomization: function setupServerFieldCustomization() {
 
-							if (this.platform !== 'rest') {
-									// only customizes for rest currently
+							if (!document.getElementById('parse-server-custom-url')) {
+									// no customization available on this page
 									return;
 							}
 
-							// constant class name for both
-							var className = "custom-server-option";
+							if (typeof Storage !== "undefined") {
+									// apply previous values from local storage
+									var _url = localStorage.getItem('parse-server-custom-url');
+									var _mount = localStorage.getItem('parse-server-custom-mount');
+									var _protocol = localStorage.getItem('parse-server-custom-protocol');
+									var _appId = localStorage.getItem('parse-server-custom-appid');
+									var _clientKey = localStorage.getItem('parse-server-custom-clientkey');
 
-							var html = "<span class='custom-server-description'>Your Server Settings</span>";
-
-							// server url
-							var title = "Set your parse server url here.";
-							var value = "YOUR.PARSE-SERVER.HERE";
-							var id = 'parse-server-custom-url';
-							var holder = 'your.parse-server.com';
-							html += "<input id='" + id + "' class='" + className + "' type='text' placeholder='" + holder + "' value='" + value + "' title='" + title + "'>";
-
-							// mount path
-							title = "Set your parse server mount path here.";
-							value = "parse";
-							id = 'parse-server-custom-mount';
-							holder = 'parse';
-							html += "<input id='" + id + "' class='" + className + "' type='text' placeholder='" + holder + "' value='" + value + "' title='" + title + "'>";
-
-							html += "<br/>";
-
-							// add right before the first side bar section
-							document.getElementsByClassName('ui_live_toc')[0].insertAdjacentHTML('beforebegin', html);
+									// set existing entries
+									if (_url) {
+											$(".custom-parse-server-url").html(_url);
+											$("#parse-server-custom-url").val(_url);
+									}
+									if (_mount) {
+											$(".custom-parse-server-mount").html(_mount);
+											$("#parse-server-custom-mount").val(_mount);
+									}
+									if (_protocol) {
+											$(".custom-parse-server-protocol").html(_protocol);
+											$("#parse-server-custom-protocol").val(_protocol);
+									}
+									if (_appId) {
+											$(".custom-parse-server-appid").html(_appId);
+											$("#parse-server-custom-appid").val(_appId);
+									}
+									if (_clientKey) {
+											$(".custom-parse-server-clientkey").html(_clientKey);
+											$("#parse-server-custom-clientkey").val(_clientKey);
+									}
+							}
 
 							// set url listener
 							$('#parse-server-custom-url').keyup(function () {
 									var url = $('#parse-server-custom-url').val();
-									if (!url.match(/^[-_a-z0-9\.]+$/i)) {
+									if (!url.match(/^[-_a-z0-9\.]+(?::[0-9]+)?$/i)) {
 											// not a valid url
 											return;
 									}
 									$(".custom-parse-server-url").html(url);
+									if (typeof Storage !== "undefined") {
+											localStorage.setItem('parse-server-custom-url', url);
+									}
 							});
 
 							// set mount listener
@@ -821,6 +831,36 @@
 											mount = mount + '/';
 									}
 									$(".custom-parse-server-mount").html(mount);
+									if (typeof Storage !== "undefined") {
+											localStorage.setItem('parse-server-custom-mount', mount);
+									}
+							});
+
+							// set protocol listener
+							$('#parse-server-custom-protocol').change(function () {
+									var protocol = $('#parse-server-custom-protocol').val();
+									$(".custom-parse-server-protocol").html(protocol);
+									if (typeof Storage !== "undefined") {
+											localStorage.setItem('parse-server-custom-protocol', protocol);
+									}
+							});
+
+							// set appId listener
+							$('#parse-server-custom-appid').keyup(function () {
+									var appId = $('#parse-server-custom-appid').val();
+									$(".custom-parse-server-appid").html(appId);
+									if (typeof Storage !== "undefined") {
+											localStorage.setItem('parse-server-custom-appid', appId);
+									}
+							});
+
+							// set clientKey listener
+							$('#parse-server-custom-clientkey').keyup(function () {
+									var clientKey = $('#parse-server-custom-clientkey').val();
+									$(".custom-parse-server-clientkey").html(clientKey);
+									if (typeof Storage !== "undefined") {
+											localStorage.setItem('parse-server-custom-clientkey', clientKey);
+									}
 							});
 					},
 

--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -52,23 +52,23 @@
 
 	// Sticky TOC
 	(function () {
-			window.onscroll = window.onresize = function () {
-					var scrollPos = window.pageYOffset || document.documentElement.scrollTop;
-					var windowWidth = window.innerWidth || document.body.clientWidth;
-					var toc = document.getElementById('toc');
-					if (scrollPos > 250) {
-							if (windowWidth > 1104) {
-									toc.style.position = 'fixed';
-									toc.style.left = document.getElementById('getting-started').getBoundingClientRect().left - 230 + 'px';
-							} else if (windowWidth > 760) {
-									toc.style.position = 'fixed';
-									toc.style.left = document.getElementById('getting-started').getBoundingClientRect().left - 210 + 'px';
-							}
-					} else {
-							toc.style.position = 'absolute';
-							toc.style.left = '0';
-					}
-			};
+	  window.onscroll = window.onresize = function () {
+	    var scrollPos = window.pageYOffset || document.documentElement.scrollTop;
+	    var windowWidth = window.innerWidth || document.body.clientWidth;
+	    var toc = document.getElementById('toc');
+	    if (scrollPos > 250) {
+	      if (windowWidth > 1104) {
+	        toc.style.position = 'fixed';
+	        toc.style.left = document.getElementById('getting-started').getBoundingClientRect().left - 230 + 'px';
+	      } else if (windowWidth > 760) {
+	        toc.style.position = 'fixed';
+	        toc.style.left = document.getElementById('getting-started').getBoundingClientRect().left - 210 + 'px';
+	      }
+	    } else {
+	      toc.style.position = 'absolute';
+	      toc.style.left = '0';
+	    }
+	  };
 	})();
 
 	// application.js
@@ -84,815 +84,831 @@
 	// core.js
 	(function () {
 
-			var svgNamespace = 'http://www.w3.org/2000/svg';
+	  var svgNamespace = 'http://www.w3.org/2000/svg';
 
-			// Wrapped to provide tag vs svgTag methods
-			var createElement = function createElement(name, attr, children, svg) {
-					var tag;
-					if (svg) {
-							tag = document.createElementNS(svgNamespace, name);
-					} else {
-							tag = document.createElement(name);
-					}
-					// We apply attributes after children so that we can set the value of
-					// a select tag at render time
-					if (children) {
-							if (!Array.isArray(children)) {
-									children = [children];
-							}
-							for (var i = 0; i < children.length; i++) {
-									var node = children[i];
-									if (typeof node === 'string' || typeof node === 'number') {
-											node = document.createTextNode(node);
-									}
-									if (node) {
-											// Allow falsy entries to be ignored
-											tag.appendChild(node);
-									}
-							}
-					}
-					if (attr) {
-							for (var a in attr) {
-									if (a === 'style') {
-											for (var s in attr[a]) {
-													tag.style[s] = attr[a][s];
-											}
-									} else if (a.indexOf('data-') === 0 || svg) {
-											tag.setAttribute(a, attr[a]);
-									} else {
-											tag[a] = attr[a];
-									}
-							}
-					}
-					return tag;
-			};
+	  // Wrapped to provide tag vs svgTag methods
+	  var createElement = function createElement(name, attr, children, svg) {
+	    var tag;
+	    if (svg) {
+	      tag = document.createElementNS(svgNamespace, name);
+	    } else {
+	      tag = document.createElement(name);
+	    }
+	    // We apply attributes after children so that we can set the value of
+	    // a select tag at render time
+	    if (children) {
+	      if (!Array.isArray(children)) {
+	        children = [children];
+	      }
+	      for (var i = 0; i < children.length; i++) {
+	        var node = children[i];
+	        if (typeof node === 'string' || typeof node === 'number') {
+	          node = document.createTextNode(node);
+	        }
+	        if (node) {
+	          // Allow falsy entries to be ignored
+	          tag.appendChild(node);
+	        }
+	      }
+	    }
+	    if (attr) {
+	      for (var a in attr) {
+	        if (a === 'style') {
+	          for (var s in attr[a]) {
+	            tag.style[s] = attr[a][s];
+	          }
+	        } else if (a.indexOf('data-') === 0 || svg) {
+	          tag.setAttribute(a, attr[a]);
+	        } else {
+	          tag[a] = attr[a];
+	        }
+	      }
+	    }
+	    return tag;
+	  };
 
-			var UI = window.UI = {
-					// DOM construction methods
-					tag: function tag(name, attr, children) {
-							return createElement(name, attr, children, false);
-					},
+	  var UI = window.UI = {
+	    // DOM construction methods
+	    tag: function tag(name, attr, children) {
+	      return createElement(name, attr, children, false);
+	    },
 
-					svgTag: function svgTag(name, attr, children) {
-							return createElement(name, attr, children, true);
-					},
+	    svgTag: function svgTag(name, attr, children) {
+	      return createElement(name, attr, children, true);
+	    },
 
-					createIcon: function createIcon(icon) {
-							var i = document.createElement('i');
-							i.className = 'icon_' + icon;
-							return i;
-					},
+	    createIcon: function createIcon(icon) {
+	      var i = document.createElement('i');
+	      i.className = 'icon_' + icon;
+	      return i;
+	    },
 
-					createTooltip: function createTooltip(text, options) {
-							var className = 'tooltip_wrap';
-							switch (options.direction) {
-									case 'left':
-											className += ' to_left';
-											break;
-									case 'top-left':
-											className += ' to_top_left';
-											break;
-									case 'top-right':
-											className += ' to_top_right';
-											break;
-							}
-							return UI.tag('span', { className: className }, [UI.tag('span', { className: 'tip' }, text)]);
-					},
+	    createTooltip: function createTooltip(text, options) {
+	      var className = 'tooltip_wrap';
+	      switch (options.direction) {
+	        case 'left':
+	          className += ' to_left';
+	          break;
+	        case 'top-left':
+	          className += ' to_top_left';
+	          break;
+	        case 'top-right':
+	          className += ' to_top_right';
+	          break;
+	      }
+	      return UI.tag('span', { className: className }, [UI.tag('span', { className: 'tip' }, text)]);
+	    },
 
-					// DOM property methods
-					hasAncestor: function hasAncestor(node, ancestor) {
-							var cur = node.parentNode;
-							while (cur) {
-									if (cur === ancestor) {
-											return true;
-									}
-									cur = cur.parentNode;
-							}
-							return false;
-					},
+	    // DOM property methods
+	    hasAncestor: function hasAncestor(node, ancestor) {
+	      var cur = node.parentNode;
+	      while (cur) {
+	        if (cur === ancestor) {
+	          return true;
+	        }
+	        cur = cur.parentNode;
+	      }
+	      return false;
+	    },
 
-					addClass: function addClass(node, className) {
-							var re = new RegExp('\\b' + className + '\\b');
-							if (!node.className.match(re)) {
-									node.className += ' ' + className;
-							}
-					},
+	    addClass: function addClass(node, className) {
+	      var re = new RegExp('\\b' + className + '\\b');
+	      if (!node.className.match(re)) {
+	        node.className += ' ' + className;
+	      }
+	    },
 
-					removeClass: function removeClass(node, className) {
-							var re = new RegExp('\\s*\\b' + className + '\\b', 'g');
-							node.className = node.className.replace(re, '');
-					},
+	    removeClass: function removeClass(node, className) {
+	      var re = new RegExp('\\s*\\b' + className + '\\b', 'g');
+	      node.className = node.className.replace(re, '');
+	    },
 
-					toggleClass: function toggleClass(node, className, add) {
-							if (add === undefined) {
-									add = !UI.hasClass(node, className);
-							}
+	    toggleClass: function toggleClass(node, className, add) {
+	      if (add === undefined) {
+	        add = !UI.hasClass(node, className);
+	      }
 
-							if (add) {
-									UI.addClass(node, className);
-							} else {
-									UI.removeClass(node, className);
-							}
-					},
+	      if (add) {
+	        UI.addClass(node, className);
+	      } else {
+	        UI.removeClass(node, className);
+	      }
+	    },
 
-					hasClass: function hasClass(node, className) {
-							var re = new RegExp('\\b' + className + '\\b');
-							return !!node.className.match(re);
-					},
+	    hasClass: function hasClass(node, className) {
+	      var re = new RegExp('\\b' + className + '\\b');
+	      return !!node.className.match(re);
+	    },
 
-					getStyle: function getStyle(node, prop) {
-							if (node.currentStyle) return node.currentStyle[styleProp];
-							if (window.getComputedStyle) return document.defaultView.getComputedStyle(node, null).getPropertyValue(prop);
-							return '';
-					},
+	    getStyle: function getStyle(node, prop) {
+	      if (node.currentStyle) return node.currentStyle[styleProp];
+	      if (window.getComputedStyle) return document.defaultView.getComputedStyle(node, null).getPropertyValue(prop);
+	      return '';
+	    },
 
-					documentPosition: function documentPosition(node) {
-							var pos = { x: 0, y: 0 };
-							var cur = node;
-							while (cur) {
-									pos.x += cur.offsetLeft;
-									pos.y += cur.offsetTop;
-									cur = cur.offsetParent;
-							}
-							return pos;
-					},
+	    documentPosition: function documentPosition(node) {
+	      var pos = { x: 0, y: 0 };
+	      var cur = node;
+	      while (cur) {
+	        pos.x += cur.offsetLeft;
+	        pos.y += cur.offsetTop;
+	        cur = cur.offsetParent;
+	      }
+	      return pos;
+	    },
 
-					windowPosition: function windowPosition(node) {
-							var pos = UI.documentPosition(node);
-							pos.x -= window.scrollX;
-							pos.y -= window.scrollY;
-							return pos;
-					},
+	    windowPosition: function windowPosition(node) {
+	      var pos = UI.documentPosition(node);
+	      pos.x -= window.scrollX;
+	      pos.y -= window.scrollY;
+	      return pos;
+	    },
 
-					// DOM event methods
-					delegate: function delegate(event, parent, selector, cb) {
-							if (event === 'focus' || event === 'blur') {
-									// Focus and blur don't bubble
-									throw 'Focus and blur delegation are not yet supported';
-							}
-							var matches = function matches() {
-									return false;
-							};
-							if (typeof selector === 'string') {
-									selector = selector.toUpperCase();
-									matches = function matches(el) {
-											return el.tagName === selector;
-									};
-							} else {
-									if (selector.className) {
-											var re = new RegExp('\\b' + selector.className + '\\b');
-											matches = function matches(el) {
-													return el.className.match(re);
-											};
-									} else if (selector.id) {
-											matches = function matches(el) {
-													return el.id === selector.id;
-											};
-									}
-							}
-							parent.addEventListener(event, function (e) {
-									var node = e.target;
-									while (node && node !== document) {
-											if (matches(node)) {
-													cb.call(node, e);
-											}
-											node = node.parentNode;
-									}
-							});
-					},
+	    // DOM event methods
+	    delegate: function delegate(event, parent, selector, cb) {
+	      if (event === 'focus' || event === 'blur') {
+	        // Focus and blur don't bubble
+	        throw 'Focus and blur delegation are not yet supported';
+	      }
+	      var matches = function matches() {
+	        return false;
+	      };
+	      if (typeof selector === 'string') {
+	        selector = selector.toUpperCase();
+	        matches = function matches(el) {
+	          return el.tagName === selector;
+	        };
+	      } else {
+	        if (selector.className) {
+	          var re = new RegExp('\\b' + selector.className + '\\b');
+	          matches = function matches(el) {
+	            return el.className.match(re);
+	          };
+	        } else if (selector.id) {
+	          matches = function matches(el) {
+	            return el.id === selector.id;
+	          };
+	        }
+	      }
+	      parent.addEventListener(event, function (e) {
+	        var node = e.target;
+	        while (node && node !== document) {
+	          if (matches(node)) {
+	            cb.call(node, e);
+	          }
+	          node = node.parentNode;
+	        }
+	      });
+	    },
 
-					// formatting methods
-					prettyNumber: function prettyNumber(num) {
-							var pre;
-							var places = Math.ceil(Math.log(Math.abs(num) + 1) / Math.LN10);
-							if (places > 6 && places < 10) {
-									pre = num / 1e6;
-									if ((pre | 0) === pre || Math.round(num % 1e6 / 1e5) === 0) {
-											return (pre | 0) + 'M';
-									} else {
-											return (pre | 0) + '.' + Math.round(num % 1e6 / 1e5) + 'M';
-									}
-							} else if (places > 5) {
-									pre = num / 1000;
-									if ((pre | 0) === pre || Math.round(num % 1000 / 100) === 0) {
-											return (pre | 0) + 'K';
-									} else {
-											return (pre | 0) + '.' + Math.round(num % 1000 / 100) + 'K';
-									}
-							} else if (places > 3) {
-									var post = num % 1000 | 0;
-									if (post < 10) {
-											post = '00' + post;
-									} else if (post < 100) {
-											post = '0' + post;
-									}
-									return (num / 1000 | 0) + ',' + post;
-							} else {
-									return (num | 0) + '';
-							}
-					},
+	    // formatting methods
+	    prettyNumber: function prettyNumber(num) {
+	      var pre;
+	      var places = Math.ceil(Math.log(Math.abs(num) + 1) / Math.LN10);
+	      if (places > 6 && places < 10) {
+	        pre = num / 1e6;
+	        if ((pre | 0) === pre || Math.round(num % 1e6 / 1e5) === 0) {
+	          return (pre | 0) + 'M';
+	        } else {
+	          return (pre | 0) + '.' + Math.round(num % 1e6 / 1e5) + 'M';
+	        }
+	      } else if (places > 5) {
+	        pre = num / 1000;
+	        if ((pre | 0) === pre || Math.round(num % 1000 / 100) === 0) {
+	          return (pre | 0) + 'K';
+	        } else {
+	          return (pre | 0) + '.' + Math.round(num % 1000 / 100) + 'K';
+	        }
+	      } else if (places > 3) {
+	        var post = num % 1000 | 0;
+	        if (post < 10) {
+	          post = '00' + post;
+	        } else if (post < 100) {
+	          post = '0' + post;
+	        }
+	        return (num / 1000 | 0) + ',' + post;
+	      } else {
+	        return (num | 0) + '';
+	      }
+	    },
 
-					// animation methods
-					Animate: {
-							// The show and hide functions require a "transition: 'opacity' delay"
-							// CSS class to be present on the element
-							show: function show(el, delay) {
-									if (delay === 'undefined') {
-											delay = 0;
-									}
-									el.style.display = 'block';
-									el.style.opacity = 0;
-									setTimeout(function () {
-											el.style.opacity = 1;
-									}, delay);
-							},
+	    // animation methods
+	    Animate: {
+	      // The show and hide functions require a "transition: 'opacity' delay"
+	      // CSS class to be present on the element
+	      show: function show(el, delay) {
+	        if (delay === 'undefined') {
+	          delay = 0;
+	        }
+	        el.style.display = 'block';
+	        el.style.opacity = 0;
+	        setTimeout(function () {
+	          el.style.opacity = 1;
+	        }, delay);
+	      },
 
-							hide: function hide(el, delay) {
-									if (window.getComputedStyle(el).opacity > 0) {
-											if (typeof delay === 'undefined') {
-													delay = 500;
-											}
-											el.style.opacity = 0;
-											setTimeout(function () {
-													el.style.display = 'none';
-											}, delay);
-									}
-							}
-					},
+	      hide: function hide(el, delay) {
+	        if (window.getComputedStyle(el).opacity > 0) {
+	          if (typeof delay === 'undefined') {
+	            delay = 500;
+	          }
+	          el.style.opacity = 0;
+	          setTimeout(function () {
+	            el.style.display = 'none';
+	          }, delay);
+	        }
+	      }
+	    },
 
-					// Methods inherited by components
-					ComponentProto: {
-							attach: function attach(parent) {
-									if (this.node) {
-											parent.appendChild(this.node);
-											return this;
-									}
-									return null;
-							},
+	    // Methods inherited by components
+	    ComponentProto: {
+	      attach: function attach(parent) {
+	        if (this.node) {
+	          parent.appendChild(this.node);
+	          return this;
+	        }
+	        return null;
+	      },
 
-							remove: function remove() {
-									if (this.node && this.node.parentNode) {
-											this.node.parentNode.removeChild(this.node);
-											return this;
-									}
-									return null;
-							}
-					}
-			};
+	      remove: function remove() {
+	        if (this.node && this.node.parentNode) {
+	          this.node.parentNode.removeChild(this.node);
+	          return this;
+	        }
+	        return null;
+	      }
+	    }
+	  };
 	})();
 
 	// live_toc.js
 	(function (UI, _) {
-			if (!UI) {
-					return;
-			}
+	  if (!UI) {
+	    return;
+	  }
 
-			var LiveTOC = UI.LiveTOC = function (options) {
-					this.parent = options.parent;
-					this.content = options.content;
-					this.scrollContent = options.scrollContent || options.content;
+	  var LiveTOC = UI.LiveTOC = function (options) {
+	    this.parent = options.parent;
+	    this.content = options.content;
+	    this.scrollContent = options.scrollContent || options.content;
 
-					this.throttleInterval = options.throttleInterval || 300;
-					this.alignment = options.alignment || 'center';
-					this.onSelect = options.onSelect || null;
+	    this.throttleInterval = options.throttleInterval || 300;
+	    this.alignment = options.alignment || 'center';
+	    this.onSelect = options.onSelect || null;
 
-					this.currentItem = null;
-					this._headerHeights = {};
-					this._sortedHeights = [];
+	    this.currentItem = null;
+	    this._headerHeights = {};
+	    this._sortedHeights = [];
 
-					this.render();
-					if (options.parent) {
-							this.attach(options.parent);
-					}
-					this.initializeEventHandlers();
-			};
+	    this.render();
+	    if (options.parent) {
+	      this.attach(options.parent);
+	    }
+	    this.initializeEventHandlers();
+	  };
 
-			LiveTOC.prototype = {
-					initializeEventHandlers: function initializeEventHandlers() {
-							var throttled = _.throttle(this.handleScroll.bind(this), this.throttleInterval);
+	  LiveTOC.prototype = {
+	    initializeEventHandlers: function initializeEventHandlers() {
+	      var throttled = _.throttle(this.handleScroll.bind(this), this.throttleInterval);
 
-							if (this.scrollContent === document.getElementsByTagName('body')[0]) {
-									document.addEventListener('scroll', throttled);
-							} else {
-									this.scrollContent.addEventListener('scroll', throttled);
-							}
-					},
+	      if (this.scrollContent === document.getElementsByTagName('body')[0]) {
+	        document.addEventListener('scroll', throttled);
+	      } else {
+	        this.scrollContent.addEventListener('scroll', throttled);
+	      }
+	    },
 
-					render: function render() {
-							// we really need this to calculate header heights
-							this.scrollContent.style.position = "relative";
+	    render: function render() {
+	      // we really need this to calculate header heights
+	      this.scrollContent.style.position = "relative";
 
-							// build a mapping of the table of content based on the
-							// h1s and h2s in the content
-							var toc = this.buildTOC();
+	      // build a mapping of the table of content based on the
+	      // h1s and h2s in the content
+	      var toc = this.buildTOC();
 
-							// add toc data
-							this.node = UI.tag('ul', { className: 'ui_live_toc' }, toc);
+	      // add toc data
+	      this.node = UI.tag('ul', { className: 'ui_live_toc' }, toc);
 
-							// calculate the cached heights of each header in the text
-							$(document).ready(function (e) {
-									this.updateHeights();
-							}.bind(this));
-					},
+	      // calculate the cached heights of each header in the text
+	      $(document).ready(function (e) {
+	        this.updateHeights();
+	      }.bind(this));
+	    },
 
-					// find all the h1s and h2s in the content and build the TOC elements
-					buildTOC: function buildTOC() {
-							var headers = this.content.querySelectorAll('h1, h2, h3');
-							var toc = [];
-							var latestMajor, latestMinor;
+	    // find all the h1s and h2s in the content and build the TOC elements
+	    buildTOC: function buildTOC() {
+	      var headers = this.content.querySelectorAll('h1, h2, h3');
+	      var toc = [];
+	      var latestMajor, latestMinor;
 
-							for (var i = 0; i < headers.length; i++) {
-									var el = headers[i];
-									var text = $(el).text();
-									// var anchor = el.getElementsByTagName('a')[0];
-									// if (anchor === undefined) {
-									// 	continue;
-									// }
-									// var name = anchor.name;
-									var name = el.id;
+	      for (var i = 0; i < headers.length; i++) {
+	        var el = headers[i];
+	        var text = $(el).text();
+	        // var anchor = el.getElementsByTagName('a')[0];
+	        // if (anchor === undefined) {
+	        // 	continue;
+	        // }
+	        // var name = anchor.name;
+	        var name = el.id;
 
-									// Build main table of contents list from h1 tags
-									if (el.tagName === 'H1') {
-											latestMajor = UI.tag('ul', { className: 'ui_live_toc_major_list' });
-											toc.push(UI.tag('li', { 'data-name': name, className: 'ui_live_toc_main' }, [UI.tag('a', { href: '#' + name }, text), latestMajor]));
-											latestMinor = undefined;
+	        // Build main table of contents list from h1 tags
+	        if (el.tagName === 'H1') {
+	          latestMajor = UI.tag('ul', { className: 'ui_live_toc_major_list' });
+	          toc.push(UI.tag('li', { 'data-name': name, className: 'ui_live_toc_main' }, [UI.tag('a', { href: '#' + name }, text), latestMajor]));
+	          latestMinor = undefined;
 
-											// Build collapsable sublist with h2 tags. We skip any H2s
-											// that appear before the first H1.
-									} else if (el.tagName === 'H2' && latestMajor !== undefined) {
-											latestMinor = UI.tag('ul', { className: 'ui_live_toc_minor_list' });
-											latestMajor.appendChild(UI.tag('li', { 'data-name': name, className: 'ui_live_toc_major' }, [UI.tag('a', { href: '#' + name }, text), latestMinor]));
+	          // Build collapsable sublist with h2 tags. We skip any H2s
+	          // that appear before the first H1.
+	        } else if (el.tagName === 'H2' && latestMajor !== undefined) {
+	          latestMinor = UI.tag('ul', { className: 'ui_live_toc_minor_list' });
+	          latestMajor.appendChild(UI.tag('li', { 'data-name': name, className: 'ui_live_toc_major' }, [UI.tag('a', { href: '#' + name }, text), latestMinor]));
 
-											// Build deeper collapsable sublist with h3 tags. We skip any
-											// H3s that appear before the first H1 or directly after any H1
-									} else if (el.tagName === 'H3' && latestMajor !== undefined && latestMinor !== undefined) {
-											latestMinor.appendChild(UI.tag('li', { 'data-name': name, className: 'ui_live_toc_minor' }, [UI.tag('a', { href: '#' + name }, text.toLowerCase())]));
-									}
-							}
-							return toc;
-					},
+	          // Build deeper collapsable sublist with h3 tags. We skip any
+	          // H3s that appear before the first H1 or directly after any H1
+	        } else if (el.tagName === 'H3' && latestMajor !== undefined && latestMinor !== undefined) {
+	          latestMinor.appendChild(UI.tag('li', { 'data-name': name, className: 'ui_live_toc_minor' }, [UI.tag('a', { href: '#' + name }, text.toLowerCase())]));
+	        }
+	      }
+	      return toc;
+	    },
 
-					// Update the internal tracking of header heights. Should be called when
-					// the content changes in a way that will affect the height of headers
-					updateHeights: function updateHeights() {
-							var headerHeights = {};
-							var sortedHeights = [];
-							var headers = this.content.querySelectorAll('h1, h2, h3');
-							for (var i = 0; i < headers.length; i++) {
-									// var anchor = headers[i].getElementsByTagName('a')[0];
-									// var name = anchor.name;
-									var name = headers[i].id;
+	    // Update the internal tracking of header heights. Should be called when
+	    // the content changes in a way that will affect the height of headers
+	    updateHeights: function updateHeights() {
+	      var headerHeights = {};
+	      var sortedHeights = [];
+	      var headers = this.content.querySelectorAll('h1, h2, h3');
+	      for (var i = 0; i < headers.length; i++) {
+	        // var anchor = headers[i].getElementsByTagName('a')[0];
+	        // var name = anchor.name;
+	        var name = headers[i].id;
 
-									headerHeights[headers[i].offsetTop] = name;
-									sortedHeights.push(headers[i].offsetTop);
-							}
-							this._headerHeights = headerHeights;
-							this._sortedHeights = sortedHeights.sort(function (a, b) {
-									return a - b;
-							});
-					},
+	        headerHeights[headers[i].offsetTop] = name;
+	        sortedHeights.push(headers[i].offsetTop);
+	      }
+	      this._headerHeights = headerHeights;
+	      this._sortedHeights = sortedHeights.sort(function (a, b) {
+	        return a - b;
+	      });
+	    },
 
-					// find out what item to highlight in the TOC and what section
-					// to collapse/expand
-					handleScroll: function handleScroll() {
-							var fromTop = this.scrollContent.scrollTop;
-							// firefox doesn't like this so we fallback to window
-							if (fromTop === 0) {
-									fromTop = $(window).scrollTop();
-							}
-							var renderedHeight = this.scrollContent.offsetHeight;
+	    // find out what item to highlight in the TOC and what section
+	    // to collapse/expand
+	    handleScroll: function handleScroll() {
+	      var fromTop = this.scrollContent.scrollTop;
+	      // firefox doesn't like this so we fallback to window
+	      if (fromTop === 0) {
+	        fromTop = $(window).scrollTop();
+	      }
+	      var renderedHeight = this.scrollContent.offsetHeight;
 
-							var cur;
-							if (this.alignment === 'top') {
-									cur = fromTop;
-							} else if (this.alignment === 'bottom') {
-									cur = renderedHeight + fromTop;
-							} else {
-									// fallback to center line
-									cur = renderedHeight / 2 + fromTop;
-							}
+	      var cur;
+	      if (this.alignment === 'top') {
+	        cur = fromTop;
+	      } else if (this.alignment === 'bottom') {
+	        cur = renderedHeight + fromTop;
+	      } else {
+	        // fallback to center line
+	        cur = renderedHeight / 2 + fromTop;
+	      }
 
-							// find closest header above the current location
-							var bestHeight = this._sortedHeights[0];
-							for (var i = 0; i < this._sortedHeights.length; i++) {
-									if (this._sortedHeights[i] > cur) {
-											break; // break once we've passed current
-									}
-									bestHeight = this._sortedHeights[i];
-							}
+	      // find closest header above the current location
+	      var bestHeight = this._sortedHeights[0];
+	      for (var i = 0; i < this._sortedHeights.length; i++) {
+	        if (this._sortedHeights[i] > cur) {
+	          break; // break once we've passed current
+	        }
+	        bestHeight = this._sortedHeights[i];
+	      }
 
-							var best = this._headerHeights[bestHeight];
+	      var best = this._headerHeights[bestHeight];
 
-							// only render if nothing is selected or selection has changed
-							if (this.currentItem === null || this.currentItem.getAttribute('data-name') !== best) {
-									// if we have a new item selected, remove current selection
-									var listItems = this.node.getElementsByTagName('li');
-									for (var j = 0; j < listItems.length; j++) {
-											UI.removeClass(listItems[j], 'selected');
-									}
+	      // only render if nothing is selected or selection has changed
+	      if (this.currentItem === null || this.currentItem.getAttribute('data-name') !== best) {
+	        // if we have a new item selected, remove current selection
+	        var listItems = this.node.getElementsByTagName('li');
+	        for (var j = 0; j < listItems.length; j++) {
+	          UI.removeClass(listItems[j], 'selected');
+	        }
 
-									// set newly selected item and add the class
-									this.currentItem = this.node.querySelector('[data-name="' + best + '"]');
-									UI.addClass(this.currentItem, 'selected');
+	        // set newly selected item and add the class
+	        this.currentItem = this.node.querySelector('[data-name="' + best + '"]');
+	        UI.addClass(this.currentItem, 'selected');
 
-									// if the item was a minor header, also select parent (major header)
-									if (UI.hasClass(this.currentItem, 'ui_live_toc_minor')) {
-											UI.addClass(this.currentMajorSection(), 'selected');
-									}
+	        // if the item was a minor header, also select parent (major header)
+	        if (UI.hasClass(this.currentItem, 'ui_live_toc_minor')) {
+	          UI.addClass(this.currentMajorSection(), 'selected');
+	        }
 
-									// if the item was a major header or minor header, also select parent (main header)
-									if (UI.hasClass(this.currentItem, 'ui_live_toc_major') || UI.hasClass(this.currentItem, 'ui_live_toc_minor')) {
-											UI.addClass(this.currentMainSection(), 'selected');
-									}
-							}
-					},
+	        // if the item was a major header or minor header, also select parent (main header)
+	        if (UI.hasClass(this.currentItem, 'ui_live_toc_major') || UI.hasClass(this.currentItem, 'ui_live_toc_minor')) {
+	          UI.addClass(this.currentMainSection(), 'selected');
+	        }
+	      }
+	    },
 
-					/* Utility functions about the state of the content & location */
+	    /* Utility functions about the state of the content & location */
 
-					// find the current main section expanded (this is tied to H1s)
-					currentMainSection: function currentMainSection() {
-							var cur = this.currentItem;
-							while (cur && !UI.hasClass(cur, 'ui_live_toc_main')) {
-									cur = cur.parentElement;
-							}
-							return cur;
-					},
+	    // find the current main section expanded (this is tied to H1s)
+	    currentMainSection: function currentMainSection() {
+	      var cur = this.currentItem;
+	      while (cur && !UI.hasClass(cur, 'ui_live_toc_main')) {
+	        cur = cur.parentElement;
+	      }
+	      return cur;
+	    },
 
-					// find the current major section expanded (this is tied to H2s)
-					currentMajorSection: function currentMajorSection() {
-							if (UI.hasClass(this.currentItem, 'ui_live_toc_main')) {
-									return false;
-							}
+	    // find the current major section expanded (this is tied to H2s)
+	    currentMajorSection: function currentMajorSection() {
+	      if (UI.hasClass(this.currentItem, 'ui_live_toc_main')) {
+	        return false;
+	      }
 
-							var cur = this.currentItem;
-							while (!UI.hasClass(cur, 'ui_live_toc_major')) {
-									cur = cur.parentElement;
-							}
-							return cur;
-					}
-			};
+	      var cur = this.currentItem;
+	      while (!UI.hasClass(cur, 'ui_live_toc_major')) {
+	        cur = cur.parentElement;
+	      }
+	      return cur;
+	    }
+	  };
 
-			_.extend(LiveTOC.prototype, UI.ComponentProto);
+	  _.extend(LiveTOC.prototype, UI.ComponentProto);
 	})(UI, _);
 
 	// docs_toggle.js
 	(function (UI, _) {
-			if (!UI) {
-					return;
-			}
+	  if (!UI) {
+	    return;
+	  }
 
-			if (!App.Views.Docs) {
-					App.Views.Docs = {};
-			}
+	  if (!App.Views.Docs) {
+	    App.Views.Docs = {};
+	  }
 
-			var Toggle = App.Views.Docs.Toggle = function (options) {
-					this.parent = options.parent;
-					this.opt1 = options.opt1;
-					this.opt2 = options.opt2;
-					this.label1 = options.label1;
-					this.label2 = options.label2;
-					this.onChange = options.onChange;
-					this.render();
-			};
+	  var Toggle = App.Views.Docs.Toggle = function (options) {
+	    this.parent = options.parent;
+	    this.opt1 = options.opt1;
+	    this.opt2 = options.opt2;
+	    this.label1 = options.label1;
+	    this.label2 = options.label2;
+	    this.onChange = options.onChange;
+	    this.render();
+	  };
 
-			Toggle.prototype = {
-					render: function render() {
-							var opt1Els = this.parent.getElementsByClassName('hljs ' + this.opt1);
-							for (var i = 0; i < opt1Els.length; i++) {
-									if (opt1Els[i].parentElement.parentElement.getAttribute("class").indexOf("common-lang-block") === -1) {
-											UI.addClass(opt1Els[i], 'has_toggles');
-											opt1Els[i].appendChild(this.renderToggle(true));
-									}
-							}
+	  Toggle.prototype = {
+	    render: function render() {
+	      var opt1Els = this.parent.getElementsByClassName('hljs ' + this.opt1);
+	      for (var i = 0; i < opt1Els.length; i++) {
+	        if (opt1Els[i].parentElement.parentElement.getAttribute("class").indexOf("common-lang-block") === -1) {
+	          UI.addClass(opt1Els[i], 'has_toggles');
+	          opt1Els[i].appendChild(this.renderToggle(true));
+	        }
+	      }
 
-							var opt2Els = this.parent.getElementsByClassName('hljs ' + this.opt2);
-							for (i = 0; i < opt2Els.length; i++) {
-									if (opt2Els[i].parentElement.parentElement.getAttribute("class").indexOf("common-lang-block") === -1) {
-											UI.addClass(opt2Els[i], 'has_toggles');
-											opt2Els[i].appendChild(this.renderToggle(false));
-									}
-							}
+	      var opt2Els = this.parent.getElementsByClassName('hljs ' + this.opt2);
+	      for (i = 0; i < opt2Els.length; i++) {
+	        if (opt2Els[i].parentElement.parentElement.getAttribute("class").indexOf("common-lang-block") === -1) {
+	          UI.addClass(opt2Els[i], 'has_toggles');
+	          opt2Els[i].appendChild(this.renderToggle(false));
+	        }
+	      }
 
-							$('.' + this.opt2 + '-toggle').on('click', this.showOpt2.bind(this));
-							$('.' + this.opt1 + '-toggle').on('click', this.showOpt1.bind(this));
-							this.toggleOpt(true);
-					},
+	      $('.' + this.opt2 + '-toggle').on('click', this.showOpt2.bind(this));
+	      $('.' + this.opt1 + '-toggle').on('click', this.showOpt1.bind(this));
+	      this.toggleOpt(true);
+	    },
 
-					renderToggle: function renderToggle(selectOpt1) {
-							var toggle = UI.tag('div', { className: 'toggles' }, [UI.tag('div', { className: 'toggle-item' }, [UI.tag('a', { className: this.opt1 + '-toggle', href: '#' }, this.label1)]), UI.tag('div', { className: 'toggle-item' }, [UI.tag('a', { className: this.opt2 + '-toggle', href: '#' }, this.label2)])]);
+	    renderToggle: function renderToggle(selectOpt1) {
+	      var toggle = UI.tag('div', { className: 'toggles' }, [UI.tag('div', { className: 'toggle-item' }, [UI.tag('a', { className: this.opt1 + '-toggle', href: '#' }, this.label1)]), UI.tag('div', { className: 'toggle-item' }, [UI.tag('a', { className: this.opt2 + '-toggle', href: '#' }, this.label2)])]);
 
-							if (selectOpt1 === true) {
-									UI.addClass(toggle.childNodes[0], 'selected');
-							} else {
-									UI.addClass(toggle.childNodes[1], 'selected');
-							}
+	      if (selectOpt1 === true) {
+	        UI.addClass(toggle.childNodes[0], 'selected');
+	      } else {
+	        UI.addClass(toggle.childNodes[1], 'selected');
+	      }
 
-							return toggle;
-					},
+	      return toggle;
+	    },
 
-					showOpt1: function showOpt1(e) {
-							e.preventDefault();
+	    showOpt1: function showOpt1(e) {
+	      e.preventDefault();
 
-							// make sure it's the right toggle
-							if ($(e.target).parent().hasClass('selected')) {
-									return false;
-							}
+	      // make sure it's the right toggle
+	      if ($(e.target).parent().hasClass('selected')) {
+	        return false;
+	      }
 
-							var $pre = $(e.target).closest('pre');
-							var distance = $(window).scrollTop() - $pre[0].offsetTop;
+	      var $pre = $(e.target).closest('pre');
+	      var distance = $(window).scrollTop() - $pre[0].offsetTop;
 
-							// flash the border
-							var $code = $pre.prev().children('code');
-							$code.addClass('code_flash');
-							setTimeout(function () {
-									$code.removeClass('code_flash');
-							}, 2000);
+	      // flash the border
+	      var $code = $pre.prev().children('code');
+	      $code.addClass('code_flash');
+	      setTimeout(function () {
+	        $code.removeClass('code_flash');
+	      }, 2000);
 
-							// scroll to the code block
-							var el = $pre.prev()[0];
-							this.toggleOpt(true);
-							$(window).scrollTop(el.offsetTop + distance);
-					},
+	      // scroll to the code block
+	      var el = $pre.prev()[0];
+	      this.toggleOpt(true);
+	      $(window).scrollTop(el.offsetTop + distance);
+	    },
 
-					showOpt2: function showOpt2(e) {
-							e.preventDefault();
+	    showOpt2: function showOpt2(e) {
+	      e.preventDefault();
 
-							// make sure it's the right toggle
-							if ($(e.target).parent().hasClass('selected')) {
-									return false;
-							}
+	      // make sure it's the right toggle
+	      if ($(e.target).parent().hasClass('selected')) {
+	        return false;
+	      }
 
-							var $pre = $(e.target).closest('pre');
-							var distance = $(window).scrollTop() - $pre[0].offsetTop;
+	      var $pre = $(e.target).closest('pre');
+	      var distance = $(window).scrollTop() - $pre[0].offsetTop;
 
-							// flash the border
-							var $code = $pre.next().children('code');
-							$code.addClass('code_flash');
-							setTimeout(function () {
-									$code.removeClass('code_flash');
-							}, 2000);
+	      // flash the border
+	      var $code = $pre.next().children('code');
+	      $code.addClass('code_flash');
+	      setTimeout(function () {
+	        $code.removeClass('code_flash');
+	      }, 2000);
 
-							// scroll to the code block
-							var el = $pre.next()[0];
-							this.toggleOpt(false);
-							$(window).scrollTop(el.offsetTop + distance);
-					},
+	      // scroll to the code block
+	      var el = $pre.next()[0];
+	      this.toggleOpt(false);
+	      $(window).scrollTop(el.offsetTop + distance);
+	    },
 
-					toggleOpt: function toggleOpt(showOpt1) {
-							if (showOpt1 === true) {
-									$('.hljs.' + this.opt2).parent().hide();
-									$('.hljs.' + this.opt1).parent().show();
-							} else {
-									$('.hljs.' + this.opt2).parent().show();
-									$('.hljs.' + this.opt1).parent().hide();
-							}
-							this.onChange();
-					}
-			};
+	    toggleOpt: function toggleOpt(showOpt1) {
+	      if (showOpt1 === true) {
+	        $('.hljs.' + this.opt2).parent().hide();
+	        $('.hljs.' + this.opt1).parent().show();
+	      } else {
+	        $('.hljs.' + this.opt2).parent().show();
+	        $('.hljs.' + this.opt1).parent().hide();
+	      }
+	      this.onChange();
+	    }
+	  };
 
-			_.extend(Toggle.prototype, UI.ComponentProto);
+	  _.extend(Toggle.prototype, UI.ComponentProto);
 	})(UI, _);
 
 	// docs.js
 	(function (UI, _) {
-			if (!UI) {
-					return;
-			}
+	  if (!UI) {
+	    return;
+	  }
 
-			if (!App.Views.Docs) {
-					App.Views.Docs = {};
-			}
+	  if (!App.Views.Docs) {
+	    App.Views.Docs = {};
+	  }
 
-			var Docs = App.Views.Docs.Main = function (options) {
-					this.platform = options.platform;
-					this.language = options.language;
-					this.render();
-			};
+	  var Docs = App.Views.Docs.Main = function (options) {
+	    this.platform = options.platform;
+	    this.language = options.language;
+	    this.render();
+	  };
 
-			Docs.prototype = {
-					render: function render() {
-							// create the TOC
-							this.scrollContent = document.getElementsByTagName('body')[0];
-							this.toc = new UI.LiveTOC({
-									parent: document.getElementById('toc'),
-									scrollContent: this.scrollContent,
-									content: document.getElementsByClassName('guide_content')[0]
-							});
+	  Docs.prototype = {
+	    render: function render() {
+	      // create the TOC
+	      this.scrollContent = document.getElementsByTagName('body')[0];
+	      this.toc = new UI.LiveTOC({
+	        parent: document.getElementById('toc'),
+	        scrollContent: this.scrollContent,
+	        content: document.getElementsByClassName('guide_content')[0]
+	      });
 
-							// deal with common-lang-blocks
-							this.toggleCommonLangBlocks();
+	      // deal with common-lang-blocks
+	      this.toggleCommonLangBlocks();
 
-							// setup the server/mount path editor
-							this.setupServerFieldCustomization();
+	      // setup the server/mount path editor
+	      this.setupServerFieldCustomization();
 
-							// add toggles to code blocks if necessary
-							if (this.platform === "ios" || this.platform === "osx" || this.platform === "macos") {
-									new App.Views.Docs.Toggle({
-											parent: this.scrollContent,
-											opt1: 'objectivec',
-											opt2: 'swift',
-											label1: 'Objective-C',
-											label2: 'Swift',
-											onChange: this.handleToggleChange.bind(this)
-									});
-							} else if (this.platform === "rest") {
-									new App.Views.Docs.Toggle({
-											parent: this.scrollContent,
-											opt1: 'bash',
-											opt2: 'python',
-											label1: 'cURL',
-											label2: 'Python',
-											onChange: this.handleToggleChange.bind(this)
-									});
-							}
+	      // add toggles to code blocks if necessary
+	      if (this.platform === "ios" || this.platform === "osx" || this.platform === "macos") {
+	        new App.Views.Docs.Toggle({
+	          parent: this.scrollContent,
+	          opt1: 'objectivec',
+	          opt2: 'swift',
+	          label1: 'Objective-C',
+	          label2: 'Swift',
+	          onChange: this.handleToggleChange.bind(this)
+	        });
+	      } else if (this.platform === "rest") {
+	        new App.Views.Docs.Toggle({
+	          parent: this.scrollContent,
+	          opt1: 'bash',
+	          opt2: 'python',
+	          label1: 'cURL',
+	          label2: 'Python',
+	          onChange: this.handleToggleChange.bind(this)
+	        });
+	      }
 
-							this.mobileToc = document.getElementById('mobile_toc').getElementsByTagName('select')[0];
-							this.renderMobileTOC();
+	      this.mobileToc = document.getElementById('mobile_toc').getElementsByTagName('select')[0];
+	      this.renderMobileTOC();
 
-							// move the TOC with the content. Since it's fixed, we can't just do it in css :(
-							$(window).on('resize', _.throttle(this.handleWindowResize.bind(this), 300));
-							this.handleWindowResize();
-							// calculate final position of headers for the TOC once
-							// the DOM is loaded (including images)
-							$(window).on('load', function () {
-									this.toc.updateHeights();
-							}.bind(this));
-					},
+	      // move the TOC with the content. Since it's fixed, we can't just do it in css :(
+	      $(window).on('resize', _.throttle(this.handleWindowResize.bind(this), 300));
+	      this.handleWindowResize();
+	      // calculate final position of headers for the TOC once
+	      // the DOM is loaded (including images)
+	      $(window).on('load', function () {
+	        this.toc.updateHeights();
+	      }.bind(this));
+	    },
 
-					renderMobileTOC: function renderMobileTOC() {
-							var h1s = this.scrollContent.getElementsByTagName('h1');
-							for (var i = 0; i < h1s.length; i++) {
-									// var anchor = h1s[i].getElementsByTagName('a')[0];
-									this.mobileToc.appendChild(UI.tag('option', { 'data-anchor': h1s[i].id }, [h1s[i].textContent]));
-							}
-							this.mobileToc.addEventListener('change', this.handleSelectChange.bind(this));
-							this.mobileToc.getElementsByTagName('option')[0].setAttribute('selected', true);
-					},
+	    renderMobileTOC: function renderMobileTOC() {
+	      var h1s = this.scrollContent.getElementsByTagName('h1');
+	      for (var i = 0; i < h1s.length; i++) {
+	        // var anchor = h1s[i].getElementsByTagName('a')[0];
+	        this.mobileToc.appendChild(UI.tag('option', { 'data-anchor': h1s[i].id }, [h1s[i].textContent]));
+	      }
+	      this.mobileToc.addEventListener('change', this.handleSelectChange.bind(this));
+	      this.mobileToc.getElementsByTagName('option')[0].setAttribute('selected', true);
+	    },
 
-					// in "common" sections, there's a code block for every platform,
-					// this hides all but the current one
-					toggleCommonLangBlocks: function toggleCommonLangBlocks() {
-							$('.common-lang-block').hide();
-							switch (this.platform) {
-									case 'ios':
-									case 'osx':
-									case 'macos':
-											$('.common-lang-block.objectivec').show();
-											$('.common-lang-block.swift').show();
-											break;
-									case 'android':
-											$('.common-lang-block.java').show();
-											break;
-									case 'dotnet':
-									case 'unity':
-											$('.common-lang-block.cs').show();
-											break;
-									case 'php':
-											$('.common-lang-block.php').show();
-											break;
-									case 'rest':
-											$('.common-lang-block.bash').show();
-											$('.common-lang-block.python').show();
-											break;
-									case 'arduino':
-											$('.common-lang-block.cpp').show();
-											break;
-									case 'cloudcode':
-									case 'js':
-									default:
-											$('.common-lang-block.js').show();
-							}
-					},
+	    // in "common" sections, there's a code block for every platform,
+	    // this hides all but the current one
+	    toggleCommonLangBlocks: function toggleCommonLangBlocks() {
+	      $('.common-lang-block').hide();
+	      switch (this.platform) {
+	        case 'ios':
+	        case 'osx':
+	        case 'macos':
+	          $('.common-lang-block.objectivec').show();
+	          $('.common-lang-block.swift').show();
+	          break;
+	        case 'android':
+	          $('.common-lang-block.java').show();
+	          break;
+	        case 'dotnet':
+	        case 'unity':
+	          $('.common-lang-block.cs').show();
+	          break;
+	        case 'php':
+	          $('.common-lang-block.php').show();
+	          break;
+	        case 'rest':
+	          $('.common-lang-block.bash').show();
+	          $('.common-lang-block.python').show();
+	          break;
+	        case 'arduino':
+	          $('.common-lang-block.cpp').show();
+	          break;
+	        case 'cloudcode':
+	        case 'js':
+	        default:
+	          $('.common-lang-block.js').show();
+	      }
+	    },
 
-					setupServerFieldCustomization: function setupServerFieldCustomization() {
+	    setupServerFieldCustomization: function setupServerFieldCustomization() {
 
-							if (!document.getElementById('parse-server-custom-url')) {
-									// no customization available on this page
-									return;
-							}
+	      if (!document.getElementById('parse-server-custom-url')) {
+	        // no customization available on this page
+	        return;
+	      }
 
-							if (typeof Storage !== "undefined") {
-									// apply previous values from local storage
-									var _url = localStorage.getItem('parse-server-custom-url');
-									var _mount = localStorage.getItem('parse-server-custom-mount');
-									var _protocol = localStorage.getItem('parse-server-custom-protocol');
-									var _appId = localStorage.getItem('parse-server-custom-appid');
-									var _clientKey = localStorage.getItem('parse-server-custom-clientkey');
+	      if (typeof Storage !== "undefined") {
+	        // apply previous values from local storage
+	        var _url = localStorage.getItem('parse-server-custom-url');
+	        var _mount = localStorage.getItem('parse-server-custom-mount');
+	        var _protocol = localStorage.getItem('parse-server-custom-protocol');
+	        var _appId = localStorage.getItem('parse-server-custom-appid');
+	        var _clientKey = localStorage.getItem('parse-server-custom-clientkey');
 
-									// set existing entries
-									if (_url) {
-											$(".custom-parse-server-url").html(_url);
-											$("#parse-server-custom-url").val(_url);
-									}
-									if (_mount) {
-											$(".custom-parse-server-mount").html(_mount);
-											$("#parse-server-custom-mount").val(_mount);
-									}
-									if (_protocol) {
-											$(".custom-parse-server-protocol").html(_protocol);
-											$("#parse-server-custom-protocol").val(_protocol);
-									}
-									if (_appId) {
-											$(".custom-parse-server-appid").html(_appId);
-											$("#parse-server-custom-appid").val(_appId);
-									}
-									if (_clientKey) {
-											$(".custom-parse-server-clientkey").html(_clientKey);
-											$("#parse-server-custom-clientkey").val(_clientKey);
-									}
-							}
+	        // set existing entries
+	        if (_url) {
+	          $(".custom-parse-server-url").html(_url);
+	          $("#parse-server-custom-url").val(_url);
+	        }
+	        if (_mount) {
+	          $(".custom-parse-server-mount").html(_mount);
+	          $("#parse-server-custom-mount").val(_mount);
+	        }
+	        if (_protocol) {
+	          $(".custom-parse-server-protocol").html(_protocol);
+	          $("#parse-server-custom-protocol").val(_protocol);
+	        }
+	        if (_appId) {
+	          $(".custom-parse-server-appid").html(_appId);
+	          $("#parse-server-custom-appid").val(_appId);
+	        }
+	        if (_clientKey) {
+	          $(".custom-parse-server-clientkey").html(_clientKey);
+	          $("#parse-server-custom-clientkey").val(_clientKey);
+	        }
+	      }
 
-							// set url listener
-							$('#parse-server-custom-url').keyup(function () {
-									var url = $('#parse-server-custom-url').val();
-									if (!url.match(/^[-_a-z0-9\.]+(?::[0-9]+)?$/i)) {
-											// not a valid url
-											return;
-									}
-									$(".custom-parse-server-url").html(url);
-									if (typeof Storage !== "undefined") {
-											localStorage.setItem('parse-server-custom-url', url);
-									}
-							});
+	      // set url listener
+	      $('#parse-server-custom-url').keyup(function () {
+	        var url = $('#parse-server-custom-url').val();
+	        if (!url.match(/^[-_a-z0-9\.]+(?::[0-9]+)?$/i)) {
+	          // not a valid url
+	          return;
+	        }
+	        $(".custom-parse-server-url").html(url);
+	        if (typeof Storage !== "undefined") {
+	          localStorage.setItem('parse-server-custom-url', url);
+	        }
+	      });
 
-							// set mount listener
-							$('#parse-server-custom-mount').keyup(function () {
-									var mount = $('#parse-server-custom-mount').val();
-									if (!mount.match(/^[-_a-z0-9\/]+$/i) && mount !== '') {
-											// not a valid mount path, and not empty
-											return;
-									}
-									if (!mount.match(/^\//)) {
-											// add leading slash
-											mount = '/' + mount;
-									}
-									if (!mount.match(/\/$/)) {
-											// add trailing slash
-											mount = mount + '/';
-									}
-									$(".custom-parse-server-mount").html(mount);
-									if (typeof Storage !== "undefined") {
-											localStorage.setItem('parse-server-custom-mount', mount);
-									}
-							});
+	      // set mount listener
+	      $('#parse-server-custom-mount').keyup(function () {
+	        var mount = $('#parse-server-custom-mount').val();
+	        if (!mount.match(/^[-_a-z0-9\/]+$/i) && mount !== '') {
+	          // not a valid mount path, and not empty
+	          return;
+	        }
+	        if (!mount.match(/^\//)) {
+	          // add leading slash
+	          mount = '/' + mount;
+	        }
+	        if (!mount.match(/\/$/)) {
+	          // add trailing slash
+	          mount = mount + '/';
+	        }
+	        $(".custom-parse-server-mount").html(mount);
+	        if (typeof Storage !== "undefined") {
+	          localStorage.setItem('parse-server-custom-mount', mount);
+	        }
+	      });
 
-							// set protocol listener
-							$('#parse-server-custom-protocol').change(function () {
-									var protocol = $('#parse-server-custom-protocol').val();
-									$(".custom-parse-server-protocol").html(protocol);
-									if (typeof Storage !== "undefined") {
-											localStorage.setItem('parse-server-custom-protocol', protocol);
-									}
-							});
+	      // set protocol listener
+	      $('#parse-server-custom-protocol').change(function () {
+	        var protocol = $('#parse-server-custom-protocol').val();
+	        if (!protocol.match(/^[a-z]+$/)) {
+	          // not a valid protocol
+	          return;
+	        }
+	        $(".custom-parse-server-protocol").html(protocol);
+	        if (typeof Storage !== "undefined") {
+	          localStorage.setItem('parse-server-custom-protocol', protocol);
+	        }
+	      });
 
-							// set appId listener
-							$('#parse-server-custom-appid').keyup(function () {
-									var appId = $('#parse-server-custom-appid').val();
-									$(".custom-parse-server-appid").html(appId);
-									if (typeof Storage !== "undefined") {
-											localStorage.setItem('parse-server-custom-appid', appId);
-									}
-							});
+	      // set appId listener
+	      $('#parse-server-custom-appid').keyup(function () {
+	        var appId = $('#parse-server-custom-appid').val();
+	        if (!appId.match(/^[^\s]+$/i)) {
+	          // not a valid appId
+	          return;
+	        }
+	        // encode any html
+	        appId = appId.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+	        $(".custom-parse-server-appid").html(appId);
+	        if (typeof Storage !== "undefined") {
+	          localStorage.setItem('parse-server-custom-appid', appId);
+	        }
+	      });
 
-							// set clientKey listener
-							$('#parse-server-custom-clientkey').keyup(function () {
-									var clientKey = $('#parse-server-custom-clientkey').val();
-									$(".custom-parse-server-clientkey").html(clientKey);
-									if (typeof Storage !== "undefined") {
-											localStorage.setItem('parse-server-custom-clientkey', clientKey);
-									}
-							});
-					},
+	      // set clientKey listener
+	      $('#parse-server-custom-clientkey').keyup(function () {
+	        var clientKey = $('#parse-server-custom-clientkey').val();
+	        if (!clientKey.match(/^[^\s]+$/i)) {
+	          // not a valid appId
+	          return;
+	        }
+	        // encode any html
+	        clientKey = clientKey.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+	        $(".custom-parse-server-clientkey").html(clientKey);
+	        if (typeof Storage !== "undefined") {
+	          localStorage.setItem('parse-server-custom-clientkey', clientKey);
+	        }
+	      });
+	    },
 
-					// we recalculate the header heights for the TOC
-					// highlighting when the height of the content changes
-					handleToggleChange: function handleToggleChange() {
-							this.toc.updateHeights();
-					},
+	    // we recalculate the header heights for the TOC
+	    // highlighting when the height of the content changes
+	    handleToggleChange: function handleToggleChange() {
+	      this.toc.updateHeights();
+	    },
 
-					handleSelectChange: function handleSelectChange(e) {
-							location.href = this.mobileToc.selectedOptions[0].getAttribute('data-anchor');
-					},
+	    handleSelectChange: function handleSelectChange(e) {
+	      location.href = this.mobileToc.selectedOptions[0].getAttribute('data-anchor');
+	    },
 
-					handleWindowResize: function handleWindowResize(e) {
-							this.toc.parent.style.left = $(".guide").css("margin-left");
-							this.toc.updateHeights();
-					}
-			};
+	    handleWindowResize: function handleWindowResize(e) {
+	      this.toc.parent.style.left = $(".guide").css("margin-left");
+	      this.toc.updateHeights();
+	    }
+	  };
 
-			_.extend(Docs.prototype, UI.ComponentProto);
+	  _.extend(Docs.prototype, UI.ComponentProto);
 	})(UI, _);
 
 	$('pre code').each(function (i, block) {
-			hljs.highlightBlock(block);
+	  hljs.highlightBlock(block);
 	});
 
 	var platform = window.location.pathname.split('/')[1];
 	if (platform) {
-			new App.Views.Docs.Main({
-					language: 'en',
-					platform: platform
-			});
+	  new App.Views.Docs.Main({
+	    language: 'en',
+	    platform: platform
+	  });
 	}
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1), __webpack_require__(2)))
 

--- a/css/docs.scss
+++ b/css/docs.scss
@@ -73,6 +73,7 @@ $svg-plus: "{{ '/assets/svgs/plus.svg' | prepend: site.baseurl }}";
 @import "lib/marketing/components/banner-ctas";
 
 @import "lib/docs/components/live-toc";
+@import "lib/docs/components/custom-server";
 @import "lib/docs/components/docs-platform";
 @import "lib/docs/components/docsearch";
 @import "lib/marketing/components/logo-stacks";

--- a/css/lib/docs/components/_custom-server.scss
+++ b/css/lib/docs/components/_custom-server.scss
@@ -1,0 +1,13 @@
+.custom-server-option {
+  margin: 4px 0 !important;
+  padding: 8px !important;
+  background: #f3f3f3 !important;
+  border-radius: 4px !important;
+  font-size: 12px !important;
+}
+
+.custom-server-description {
+  margin: 2px;
+  font-size: 16px;
+  font-weight: 100;
+}

--- a/css/lib/docs/components/_custom-server.scss
+++ b/css/lib/docs/components/_custom-server.scss
@@ -6,6 +6,10 @@
   font-size: 12px !important;
 }
 
+.custom-server-option:focus {
+  outline: 0;
+}
+
 .custom-server-description {
   margin: 2px;
   font-size: 16px;

--- a/css/lib/multisite/_wysiwyg.scss
+++ b/css/lib/multisite/_wysiwyg.scss
@@ -112,6 +112,7 @@
 
             &:before{
                 display:inline-block;
+                float: left;
                 content: "";
                 left: 0; top:3px;
                 width: 15px; height: 11px;

--- a/rest.md
+++ b/rest.md
@@ -9,6 +9,7 @@ redirect_from:
   - /rest/
 
 sections:
+- "common/server-customize.md"
 - "rest/getting-started.md"
 - "rest/quick-reference.md"
 - "rest/objects.md"


### PR DESCRIPTION
The current [REST Guide](http://docs.parseplatform.org/rest/guide/#quick-reference) and parts of the other guides contain numerous references to the now inactive `api.parse.com`, and the old `/1/` version 1 mount path. As it stands this is misdirecting some individuals, as seen in [#694](https://github.com/parse-community/Parse-SDK-Android/issues/694) over in the Android sdk. 

This proposes to change those old links into `YOUR.PARSE-SERVER.HERE` and `/parse/` respectively. This also adjusts the initial wording for the [REST Quick Reference](https://github.com/montymxb/docs/blob/506928730bdb98949115705bdeb3bb4c64fd1c84/_includes/rest/quick-reference.md) section to remind the user that in the examples provided they should add their own domain, their own mount path and to consider whether they should be accessing over HTTP/HTTPS.