### PR TITLE
Windows installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,14 @@ npm install
 
 Then run webpack and Jekyll:
 
+Start in Linux/OS X:
 ```
 npm start
+```
+
+Start in Windows command prompt:
+```
+npm run dev-win
 ```
 
 Finally, open http://localhost:4000/ in your web browser.

--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
     "dev-webpack": "./node_modules/.bin/webpack --watch",
     "webpack": "webpack -p",
     "dev": "npm run dev-webpack & npm run jekyll",
-    /*Use dev-win when running command on a Windows command prompt. In Bash, the & operator forks and runs processes separately
-     while in Windows MS-DOS, & just runs the command sequentally. Use start command to run commands in parallel*/
     "dev-win": "start npm run dev-webpack & start npm run jekyll",
     "prod": "npm run webpack & npm run jekyll",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "dev-webpack": "./node_modules/.bin/webpack --watch",
     "webpack": "webpack -p",
     "dev": "npm run dev-webpack & npm run jekyll",
+    /*Use dev-win when running command on a Windows command prompt. In Bash, the & operator forks and runs processes separately
+     while in Windows MS-DOS, & just runs the command sequentally. Use start command to run commands in parallel*/
+    "dev-win": "start npm run dev-webpack & start npm run jekyll",
     "prod": "npm run webpack & npm run jekyll",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Add dev-win npm script to run docs from Windows command prompt

Document in README how to run from Windows command prompt

This script should be used in place of dev npm script when user is running npm from a Windows command prompt.

Use dev-win when running command on a Windows command prompt. In Bash, the & operator forks and runs processes separately while in Windows MS-DOS, & just runs the command sequentally. Use start command to run commands in parallel