### PR TITLE
Remove query skip/limit/count constraints documentation

### DIFF
--- a/_includes/android/queries.md
+++ b/_includes/android/queries.md
@@ -39,7 +39,7 @@ query.whereNotEqualTo("playerName", "Michael Yabuti");
 query.whereGreaterThan("playerAge", 18);
 ```
 
-You can limit the number of results with `setLimit`. By default, results are limited to 100, but anything from 1 to 1000 is a valid limit:
+You can limit the number of results with `setLimit`. By default, results are limited to 100. In the old Parse hosted backend, the maximum limit was 1,000, but Parse Server removed that constraint:
 
 ```java
 query.setLimit(10); // limit to at most 10 results
@@ -61,7 +61,7 @@ query.getFirstInBackground(new GetCallback<ParseObject>() {
 });
 ```
 
-You can skip the first results with `setSkip`. This can be useful for pagination:
+You can skip the first results with `setSkip`. In the old Parse hosted backend, the maximum skip value was 10,000, but Parse Server removed that constraint. This can be useful for pagination:
 
 ```java
 query.setSkip(10); // skip the first 10 results
@@ -227,7 +227,7 @@ query.findInBackground(new FindCallback<ParseObject>() {
 });
 ```
 
-If you want to retrieve objects where a field contains a `ParseObject` that matches a different query, you can use `whereMatchesQuery`. Note that the default limit of 100 and maximum limit of 1000 apply to the inner query as well, so with large data sets you may need to construct queries carefully to get the desired behavior. In order to find comments for posts containing images, you can do:
+If you want to retrieve objects where a field contains a `ParseObject` that matches a different query, you can use `whereMatchesQuery`. In order to find comments for posts containing images, you can do:
 
 ```java
 ParseQuery<ParseObject> innerQuery = ParseQuery.getQuery("Post");
@@ -387,7 +387,7 @@ Query caching also works with ParseQuery helpers including `getFirst()` and `get
 
 ## Counting Objects
 
-Caveat: Count queries are rate limited to a maximum of 160 requests per minute.  They can also return inaccurate results for classes with more than 1,000 objects.  Thus, it is preferable to architect your application to avoid this sort of count operation (by using counters, for example.)
+Note: In the old Parse hosted backend, count queries were rate limited to a maximum of 160 requests per minute. They also returned inaccurate results for classes with more than 1,000 objects. But, Parse Server has removed both constraints and can count objects well above 1,000.
 
 If you just need to count how many objects match a query, but you do not need to retrieve all the objects that match, you can use `count` instead of `find`. For example, to count how many games have been played by a particular player:
 

--- a/_includes/arduino/queries.md
+++ b/_includes/arduino/queries.md
@@ -36,13 +36,13 @@ query.whereEqualTo("leverDown", true);
 query.whereEqualTo("temperature", 100.0);
 ```
 
-You can limit the number of results by setting a limit. By default, results are limited to 100, but anything from 1 to 1000 is a valid limit:
+You can limit the number of results by setting a limit. By default, results are limited to 100. In the old Parse hosted backend, the maximum limit was 1,000, but Parse Server removed that constraint:
 
 ```cpp
 query.setLimit(10);
 ```
 
-You can skip the first results by setting `skip`. This can be useful for pagination:
+You can skip the first results by setting `skip`. In the old Parse hosted backend, the maximum skip value was 10,000, but Parse Server removed that constraint. This can be useful for pagination:
 
 ```cpp
 query.setSkip(10);

--- a/_includes/common/performance.md
+++ b/_includes/common/performance.md
@@ -1289,7 +1289,6 @@ There are some limits in place to ensure the API can provide the data you need i
 **Queries**
 
 * Queries return 100 objects by default. Use the `limit` parameter to change this.
-* Queries can only return up to 1,000 objects in a single result set. This includes any resolved pointers. You can use `skip` and `limit` to page through results.
 * Skips and limits can only be used on the outer query.
 * Constraints that collide with each other will result in only one of the constraint being applied. An example of this would be two `equalTo` constraints over the same key with two different values, which contradicts itself (perhaps you're looking for 'contains').
 * No geo-queries inside compound OR queries.

--- a/_includes/common/performance.md
+++ b/_includes/common/performance.md
@@ -694,7 +694,7 @@ Most of the use cases around using regular expressions involve implementing sear
 
 Writing restrictive queries allows you to return only the data that the client needs. This is critical in a mobile environment were data usage can be limited and network connectivity unreliable. You also want your mobile app to appear responsive and this is directly affected by the objects you send back to the client. The [Querying section](#queries) shows the types of constraints you can add to your existing queries to limit the data returned. When adding constraints, you want to pay attention and design efficient queries.
 
-You can limit the number of query results returned. The limit is 100 by default but anything from 1 to 1000 is a valid limit:
+You can use skip and limit to page through results and load the data as is needed. The query limit is 100 by default:
 
 ```javascript
 query.limit(10); // limit to at most 10 results
@@ -996,7 +996,7 @@ If later on, you need to modify the underlying data model, your client call can 
 
 ## Avoid Count Operations
 
-For classes with over 1,000 objects, count operations are limited by timeouts. Thus, it is preferable to architect your application to avoid this count operation.
+When counting objects frequently, consider storing a count variable in the database that is incremented each time an object is added.
 
 Suppose you are displaying movie information in your app and your data model consists of a Movie class and a Review class that contains a pointer to the corresponding movie. You might want to display the review count for each movie on the top-level navigation screen using a query like this:
 
@@ -1288,17 +1288,13 @@ There are some limits in place to ensure the API can provide the data you need i
 
 **Queries**
 
-* Queries return 100 objects by default. Use the `limit` parameter to change this, up to a value of 1,000.
+* Queries return 100 objects by default. Use the `limit` parameter to change this.
 * Queries can only return up to 1,000 objects in a single result set. This includes any resolved pointers. You can use `skip` and `limit` to page through results.
-* The maximum value accepted by `skip` is 10,000. If you need to get more objects, we recommend sorting the results and then using a constraint on the sort column to filter out the first 10,000 results. You will then be able to continue paging through results starting from a `skip` value of 0. For example, you can sort your results by `createdAt ASC` and then filter out any objects older than the `createdAt` value of the 10,000th object when starting again from 0.
-* Alternatively, you may use the `each()` method in the JavaScript SDK to page through all objects that match the query.
 * Skips and limits can only be used on the outer query.
-* You may increase the limit of a inner query to 1,000, but skip cannot be used to get more results past the first 1,000.
 * Constraints that collide with each other will result in only one of the constraint being applied. An example of this would be two `equalTo` constraints over the same key with two different values, which contradicts itself (perhaps you're looking for 'contains').
 * No geo-queries inside compound OR queries.
 * Using `$exists: false` is not advised.
 * The `each` query method in the JavaScript SDK cannot be used in conjunction with queries using geo-point constraints.
-* A maximum of 500,000 objects will be scanned per query. If your constraints do not successfully limit the scope of the search, this can result in queries with incomplete results.  
 * A `containsAll` query constraint can only take up to 9 items in the comparison array.
 
 **Push Notifications**

--- a/_includes/common/performance.md
+++ b/_includes/common/performance.md
@@ -996,7 +996,7 @@ If later on, you need to modify the underlying data model, your client call can 
 
 ## Avoid Count Operations
 
-When counting objects frequently, consider storing a count variable in the database that is incremented each time an object is added.
+When counting objects frequently, instead consider storing a count variable in the database that is incremented each time an object is added. Then, the count can quickly be retrieved by simply retrieving the variable stored.
 
 Suppose you are displaying movie information in your app and your data model consists of a Movie class and a Review class that contains a pointer to the corresponding movie. You might want to display the review count for each movie on the top-level navigation screen using a query like this:
 

--- a/_includes/dotnet/queries.md
+++ b/_includes/dotnet/queries.md
@@ -56,7 +56,7 @@ var query = ParseObject.GetQuery("GameScore")
     .WhereGreaterThan("playerAge", 18);
 ```
 
-You can limit the number of results by calling `Limit`. By default, results are limited to 100, but anything from 1 to 1000 is a valid limit:
+You can limit the number of results by calling `Limit`. By default, results are limited to 100. In the old Parse hosted backend, the maximum limit was 1,000, but Parse Server removed that constraint:
 
 ```cs
 query = query.Limit(10); // limit to at most 10 results
@@ -76,7 +76,7 @@ var query = ParseObject.GetQuery("GameScore")
 ParseObject obj = await query.FirstAsync();
 ```
 
-You can skip the first results by calling `Skip`. This can be useful for pagination:
+You can skip the first results by calling `Skip`. In the old Parse hosted backend, the maximum skip value was 10,000, but Parse Server removed that constraint. This can be useful for pagination:
 
 ```cs
 query = query.Skip(10); // skip the first 10 results
@@ -285,7 +285,7 @@ var query = ParseObject.GetQuery("Comment")
     .WhereEqualTo("post", ParseObject.CreateWithoutData("Post", "1zEcyElZ80"));
 ```
 
-If you want to retrieve objects where a field contains a `ParseObject` that matches a different query, you can use `WhereMatchesQuery` or a `join` LINQ query. Note that the default limit of 100 and maximum limit of 1000 apply to the inner query as well, so with large data sets you may need to construct queries carefully to get the desired behavior. In order to find comments for posts with images, you can do:
+If you want to retrieve objects where a field contains a `ParseObject` that matches a different query, you can use `WhereMatchesQuery` or a `join` LINQ query. In order to find comments for posts with images, you can do:
 
 ```cs
 var imagePosts = from post in ParseObject.GetQuery("Post")
@@ -388,7 +388,7 @@ You can issue a query with multiple fields included by calling `Include` multipl
 
 ## Counting Objects
 
-Caveat: Count queries are rate limited to a maximum of 160 requests per minute.  They can also return inaccurate results for classes with more than 1,000 objects.  Thus, it is preferable to architect your application to avoid this sort of count operation (by using counters, for example.)
+Note: In the old Parse hosted backend, count queries were rate limited to a maximum of 160 requests per minute. They also returned inaccurate results for classes with more than 1,000 objects. But, Parse Server has removed both constraints and can count objects well above 1,000.
 
 If you just need to count how many objects match a query, but you do not need to retrieve the objects that match, you can use `CountAsync` instead of `FindAsync`. For example, to count how many games have been played by a particular player:
 

--- a/_includes/ios/queries.md
+++ b/_includes/ios/queries.md
@@ -150,7 +150,7 @@ let predicate = NSPredicate(format:"playerName != 'Michael Yabuti' AND playerAge
 let query = PFQuery(className: "GameScore", predicate: predicate)
 </code></pre>
 
-You can limit the number of results by setting `limit`. By default, results are limited to 100. In the old Parse hosted backend, the maximum limit was 1000, but Parse Server removed that constraint:
+You can limit the number of results by setting `limit`. By default, results are limited to 100. In the old Parse hosted backend, the maximum limit was 1,000, but Parse Server removed that constraint:
 
 <pre><code class="objectivec">
 query.limit = 10; // limit to at most 10 results

--- a/_includes/ios/queries.md
+++ b/_includes/ios/queries.md
@@ -150,7 +150,7 @@ let predicate = NSPredicate(format:"playerName != 'Michael Yabuti' AND playerAge
 let query = PFQuery(className: "GameScore", predicate: predicate)
 </code></pre>
 
-You can limit the number of results by setting `limit`. By default, results are limited to 100, but anything from 1 to 1000 is a valid limit:
+You can limit the number of results by setting `limit`. By default, results are limited to 100. In the old Parse hosted backend, the maximum limit was 1000, but Parse Server removed that constraint:
 
 <pre><code class="objectivec">
 query.limit = 10; // limit to at most 10 results
@@ -187,7 +187,7 @@ query.getFirstObjectInBackgroundWithBlock {
 }
 </code></pre>
 
-You can skip the first results by setting `skip`. This can be useful for pagination:
+You can skip the first results by setting `skip`. In the old Parse hosted backend, the maximum skip value was 10,000, but Parse Server removed that constraint. This can be useful for pagination:
 
 <pre><code class="objectivec">
 query.skip = 10; // skip the first 10 results
@@ -570,7 +570,7 @@ query.whereKey("post", equalTo: PFObject(withoutDataWithClassName: "Post", objec
 NSPredicate(format: "post = %@", PFObject(withoutDataWithClassName: "Post", objectId: "1zEcyElZ80"))
 </code></pre>
 
-If you want to retrieve objects where a field contains a `PFObject` that match a different query, you can use `whereKey:matchesQuery`. Note that the default limit of 100 and maximum limit of 1000 apply to the inner query as well, so with large data sets you may need to construct queries carefully to get the desired behavior. In order to find comments for posts with images, you can do:
+If you want to retrieve objects where a field contains a `PFObject` that match a different query, you can use `whereKey:matchesQuery`. In order to find comments for posts with images, you can do:
 
 <pre><code class="objectivec">
 // Using PFQuery
@@ -830,7 +830,7 @@ Query caching also works with PFQuery helpers including `getFirstObject` and `ge
 
 ## Counting Objects
 
-Caveat: Count queries are rate limited to a maximum of 160 requests per minute.  They can also return inaccurate results for classes with more than 1,000 objects.  Thus, it is preferable to architect your application to avoid this sort of count operation (by using counters, for example.)
+Note: In the old Parse hosted backend, count queries were rate limited to a maximum of 160 requests per minute. They also returned inaccurate results for classes with more than 1,000 objects. But, Parse Server has removed both constraints and can count objects well above 1,000.
 
 If you just need to count how many objects match a query, but you do not need to retrieve the objects that match, you can use `countObjects` instead of `findObjects`. For example, to count how many games have been played by a particular player:
 

--- a/_includes/js/queries.md
+++ b/_includes/js/queries.md
@@ -42,7 +42,7 @@ query.notEqualTo("playerName", "Michael Yabuti");
 query.greaterThan("playerAge", 18);
 </code></pre>
 
-You can limit the number of results by setting `limit`. By default, results are limited to 100, but anything from 1 to 1000 is a valid limit:
+You can limit the number of results by setting `limit`. By default, results are limited to 100. In the old Parse hosted backend, the maximum limit was 1,000, but Parse Server removed that constraint:
 
 <pre><code class="javascript">
 query.limit(10); // limit to at most 10 results
@@ -64,7 +64,7 @@ query.first({
 });
 </code></pre>
 
-You can skip the first results by setting `skip`. This can be useful for pagination:
+You can skip the first results by setting `skip`. In the old Parse hosted backend, the maximum skip value was 10,000, but Parse Server removed that constraint. This can be useful for pagination:
 
 <pre><code class="javascript">
 query.skip(10); // skip the first 10 results
@@ -221,7 +221,7 @@ query.find({
 });
 </code></pre>
 
-If you want to retrieve objects where a field contains a `Parse.Object` that matches a different query, you can use `matchesQuery`. Note that the default limit of 100 and maximum limit of 1000 apply to the inner query as well, so with large data sets you may need to construct queries carefully to get the desired behavior. In order to find comments for posts containing images, you can do:
+If you want to retrieve objects where a field contains a `Parse.Object` that matches a different query, you can use `matchesQuery`. In order to find comments for posts containing images, you can do:
 
 <pre><code class="javascript">
 var Post = Parse.Object.extend("Post");
@@ -297,7 +297,7 @@ You can issue a query with multiple fields included by calling `include` multipl
 
 ## Counting Objects
 
-Caveat: Count queries are rate limited to a maximum of 160 requests per minute.  They can also return inaccurate results for classes with more than 1,000 objects.  Thus, it is preferable to architect your application to avoid this sort of count operation (by using counters, for example.)
+Note: In the old Parse hosted backend, count queries were rate limited to a maximum of 160 requests per minute. They also returned inaccurate results for classes with more than 1,000 objects. But, Parse Server has removed both constraints and can count objects well above 1,000.
 
 If you just need to count how many objects match a query, but you do not need to retrieve all the objects that match, you can use `count` instead of `find`. For example, to count how many games have been played by a particular player:
 

--- a/_includes/php/queries.md
+++ b/_includes/php/queries.md
@@ -35,7 +35,7 @@ $query->notEqualTo("playerName", "Michael Yabuti");
 $query->greaterThan("playerAge", 18);
 </code></pre>
 
-You can limit the number of results by setting `limit`. By default, results are limited to 100, but anything from 1 to 1000 is a valid limit:
+You can limit the number of results by setting `limit`. By default, results are limited to 100. In the old Parse hosted backend, the maximum limit was 1,000, but Parse Server removed that constraint:
 
 <pre><code class="php">
 $query->limit(10); // limit to at most 10 results
@@ -49,7 +49,7 @@ $query->equalTo("playerEmail", "dstemkoski@example.com");
 $object = $query->first();
 </code></pre>
 
-You can skip the first results by setting `skip`. This can be useful for pagination, though it is limited to a maximum of ten thousand:
+You can skip the first results by setting `skip`. In the old Parse hosted backend, the maximum skip value was 10,000, but Parse Server removed that constraint. This can be useful for pagination:
 
 <pre><code class="php">
 $query->skip(10); // skip the first 10 results
@@ -214,7 +214,7 @@ $comments = $query->find();
 // comments now contains the comments for myPost
 </code></pre>
 
-If you want to retrieve objects where a field contains a `ParseObject` that matches a different query, you can use `matchesQuery`. Note that the default limit of 100 and maximum limit of 1000 apply to the inner query as well, so with large data sets you may need to construct queries carefully to get the desired behavior. In order to find comments for posts containing images, you can do:
+If you want to retrieve objects where a field contains a `ParseObject` that matches a different query, you can use `matchesQuery`. In order to find comments for posts containing images, you can do:
 
 <pre><code class="php">
 $innerQuery = new ParseQuery("Post");
@@ -276,7 +276,7 @@ You can issue a query with multiple fields included by calling `includeKey` mult
 
 ## Counting Objects
 
-Caveat: Count queries are rate limited to a maximum of 160 requests per minute.  They can also return inaccurate results for classes with more than 1,000 objects.  Thus, it is preferable to architect your application to avoid this sort of count operation (by using counters, for example.)
+Note: In the old Parse hosted backend, count queries were rate limited to a maximum of 160 requests per minute. They also returned inaccurate results for classes with more than 1,000 objects. But, Parse Server has removed both constraints and can count objects well above 1,000.
 
 If you just need to count how many objects match a query, but you do not need to retrieve all the objects that match, you can use `count` instead of `find`. For example, to count how many games have been played by a particular player:
 

--- a/_includes/rest/queries.md
+++ b/_includes/rest/queries.md
@@ -363,7 +363,7 @@ result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
 
-You can use the `limit` and `skip` parameters for pagination. `limit` defaults to 100, but anything from 1 to 1000 is a valid limit. Thus, to retrieve 200 objects after skipping the first 400:
+You can use the `limit` and `skip` parameters for pagination.`limit` defaults to 100. In the old Parse hosted backend, the maximum limit was 1,000, but Parse Server removed that constraint. Thus, to retrieve 200 objects after skipping the first 400:
 
 <pre><code class="bash">
 curl -X GET \
@@ -588,7 +588,7 @@ result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
 
-If you want to retrieve objects where a field contains an object that matches another query, you can use the `$inQuery` operator. Note that the default limit of 100 and maximum limit of 1000 apply to the inner query as well, so with large data sets you may need to construct queries carefully to get the desired behavior. For example, imagine you have Post class and a Comment class, where each Comment has a pointer to its parent Post. You can find comments on posts with images by doing:
+If you want to retrieve objects where a field contains an object that matches another query, you can use the `$inQuery` operator. For example, imagine you have Post class and a Comment class, where each Comment has a pointer to its parent Post. You can find comments on posts with images by doing:
 
 <pre><code class="bash">
 curl -X GET \
@@ -766,7 +766,7 @@ You can issue a query with multiple fields included by passing a comma-separated
 
 ## Counting Objects
 
-Caveat: Count queries are rate limited to a maximum of 160 requests per minute.  They can also return inaccurate results for classes with more than 1,000 objects.  Thus, it is preferable to architect your application to avoid this sort of count operation (by using counters, for example.)
+Note: In the old Parse hosted backend, count queries were rate limited to a maximum of 160 requests per minute. They also returned inaccurate results for classes with more than 1,000 objects. But, Parse Server has removed both constraints and can count objects well above 1,000.
 
 If you are limiting your query, or if there are a very large number of results, and you want to know how many total results there are without returning them all, you can use the `count` parameter. For example, if you only care about the number of games played by a particular player:
 

--- a/_includes/unity/queries.md
+++ b/_includes/unity/queries.md
@@ -36,7 +36,7 @@ var query = ParseObject.GetQuery("GameScore")
     .WhereGreaterThan("playerAge", 18);
 ```
 
-You can limit the number of results by calling `Limit`. By default, results are limited to 100, but anything from 1 to 1000 is a valid limit:
+You can limit the number of results by calling `Limit`. By default, results are limited to 100. In the old Parse hosted backend, the maximum limit was 1,000, but Parse Server removed that constraint:
 
 ```cs
 query = query.Limit(10); // limit to at most 10 results
@@ -53,7 +53,7 @@ query.FirstAsync().ContinueWith(t =>
 });
 ```
 
-You can skip the first results by calling `Skip`. This can be useful for pagination:
+You can skip the first results by calling `Skip`. In the old Parse hosted backend, the maximum skip value was 10,000, but Parse Server removed that constraint. This can be useful for pagination:
 
 ```cs
 query = query.Skip(10); // skip the first 10 results
@@ -180,7 +180,7 @@ var query = ParseObject.GetQuery("Comment")
     .WhereEqualTo("post", ParseObject.CreateWithoutData("Post", "1zEcyElZ80"));
 ```
 
-If you want to retrieve objects where a field contains a `ParseObject` that matches a different query, you can use `WhereMatchesQuery`. Note that the default limit of 100 and maximum limit of 1000 apply to the inner query as well, so with large data sets you may need to construct queries carefully to get the desired behavior. In order to find comments for posts with images, you can do:
+If you want to retrieve objects where a field contains a `ParseObject` that matches a different query, you can use `WhereMatchesQuery`. In order to find comments for posts with images, you can do:
 
 ```cs
 var imagePosts = ParseObject.GetQuery("Post")
@@ -250,7 +250,7 @@ You can issue a query with multiple fields included by calling `Include` multipl
 
 ## Counting Objects
 
-Caveat: Count queries are rate limited to a maximum of 160 requests per minute.  They can also return inaccurate results for classes with more than 1,000 objects.  Thus, it is preferable to architect your application to avoid this sort of count operation (by using counters, for example.)
+Note: In the old Parse hosted backend, count queries were rate limited to a maximum of 160 requests per minute. They also returned inaccurate results for classes with more than 1,000 objects. But, Parse Server has removed both constraints and can count objects well above 1,000.
 
 If you just need to count how many objects match a query, but you do not need to retrieve the objects that match, you can use `CountAsync` instead of `FindAsync`. For example, to count how many games have been played by a particular player:
 


### PR DESCRIPTION
In the old Parse hosted backend, there was a maximum query limit of 1,000 objects, skip limit of 10,000, a maximum rate limit of 160 requests / minute, and a count limit of 1,000 objects.

The Parse Server removed all of those constraints but the documentation was never updated to reflect that. Remove all occurrences of these limits in the documentation

See:
    #461 
    parse-community/parse-server#25
    parse-community/parse-server#917
    parse-community/parse-server#548
    parse-community/parse-server#4088