### PR TITLE
Add links to download page for Ruby and npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you have any fixes or suggestions, simply send us a pull request!
 
 ### Running The Site Locally
 
-You will need Ruby, [Bundler](http://bundler.io/), and npm.
+You will need [Ruby](https://www.ruby-lang.org/en/documentation/installation/), [Bundler](http://bundler.io/), and [npm](https://www.npmjs.com/get-npm).
 
 Clone this repository, then install Jekyll and node packages:
 


### PR DESCRIPTION
Add links on the README page to the download page for Ruby and npm. Only Bundle has a link and it is likely worthwhile to link to the other two remaining libraries required for installation.