### PR TITLE
Update Android Parse Gradle Version

### DIFF
--- a/_includes/android/getting-started.md
+++ b/_includes/android/getting-started.md
@@ -9,7 +9,7 @@ Add dependency to the application level `build.gradle` file.
 
 ```groovy
 dependencies {
-  compile 'com.parse:parse-android:1.15.7'
+  compile 'com.parse:parse-android:1.15.8'
 }
 ```
 


### PR DESCRIPTION
Gradle dependency is 1.15.8 instead of 1.15.7 since a new release came out