### PR TITLE
Register Application in Manifest for Android Getting Started

### DIFF
--- a/_includes/android/getting-started.md
+++ b/_includes/android/getting-started.md
@@ -64,3 +64,13 @@ public class App extends Application {
   }
 }
 ```
+
+ For either option, the custom `Application` class must be registered in `AndroidManifest.xml`:
+ ```
+ <application
+   android:name=".App"
+   ...>
+   ...
+ </application>
+ ```
+ 

--- a/_includes/android/queries.md
+++ b/_includes/android/queries.md
@@ -39,7 +39,7 @@ query.whereNotEqualTo("playerName", "Michael Yabuti");
 query.whereGreaterThan("playerAge", 18);
 ```
 
-You can limit the number of results with `setLimit`. By default, results are limited to 100, but anything from 1 to 1000 is a valid limit:
+You can limit the number of results with `setLimit`. By default, results are limited to 100. In the old Parse hosted backend, the maximum limit was 1,000, but Parse Server removed that constraint:
 
 ```java
 query.setLimit(10); // limit to at most 10 results
@@ -61,7 +61,7 @@ query.getFirstInBackground(new GetCallback<ParseObject>() {
 });
 ```
 
-You can skip the first results with `setSkip`. This can be useful for pagination:
+You can skip the first results with `setSkip`. In the old Parse hosted backend, the maximum skip value was 10,000, but Parse Server removed that constraint. This can be useful for pagination:
 
 ```java
 query.setSkip(10); // skip the first 10 results
@@ -227,7 +227,7 @@ query.findInBackground(new FindCallback<ParseObject>() {
 });
 ```
 
-If you want to retrieve objects where a field contains a `ParseObject` that matches a different query, you can use `whereMatchesQuery`. Note that the default limit of 100 and maximum limit of 1000 apply to the inner query as well, so with large data sets you may need to construct queries carefully to get the desired behavior. In order to find comments for posts containing images, you can do:
+If you want to retrieve objects where a field contains a `ParseObject` that matches a different query, you can use `whereMatchesQuery`. In order to find comments for posts containing images, you can do:
 
 ```java
 ParseQuery<ParseObject> innerQuery = ParseQuery.getQuery("Post");
@@ -387,7 +387,7 @@ Query caching also works with ParseQuery helpers including `getFirst()` and `get
 
 ## Counting Objects
 
-Caveat: Count queries are rate limited to a maximum of 160 requests per minute.  They can also return inaccurate results for classes with more than 1,000 objects.  Thus, it is preferable to architect your application to avoid this sort of count operation (by using counters, for example.)
+Note: In the old Parse hosted backend, count queries were rate limited to a maximum of 160 requests per minute. They also returned inaccurate results for classes with more than 1,000 objects. But, Parse Server has removed both constraints and can count objects well above 1,000.
 
 If you just need to count how many objects match a query, but you do not need to retrieve all the objects that match, you can use `count` instead of `find`. For example, to count how many games have been played by a particular player:
 


### PR DESCRIPTION
Include documentation that the developer needs to register the custom Application class in AndroidManifest.xml to correctly initialize Parse.

Pull request #446 achieves something similar but this has different language.