### PR TITLE
Document Async Current User (JS)

### DIFF
--- a/_includes/js/users.md
+++ b/_includes/js/users.md
@@ -90,6 +90,14 @@ if (currentUser) {
 }
 </code></pre>
 
+When using a platform with an async storage system you should call `currentAsync()` instead.
+
+<pre><code class="javascript">
+Parse.User.currentAsync().then(function(user) {
+    // do stuff with your user
+});
+</code></pre>
+
 You can clear the current user by logging them out:
 
 <pre><code class="javascript">


### PR DESCRIPTION
Adds a small note in the documentation regarding usage of `currentAsync()` when storage is asynchronous. This is noted lack of documentation in issue [#500](https://github.com/parse-community/Parse-SDK-JS/issues/500). 

What still stands is whether we should suggest usage of `currentAsync` or `currentUserAsync`. Since it seems the former was used to resolve the issue mentioned above I have chosen that for an addition the docs.