### PR TITLE
Add installation instructions for embedded SDK

### DIFF
--- a/_includes/embedded_c/getting-started.md
+++ b/_includes/embedded_c/getting-started.md
@@ -34,6 +34,7 @@ Next, navigate to the newly downloaded directory and run a few commands to build
 
 ```bash
 cd parse-embedded-sdks
+touch README
 autoreconf -fi
 ./configure --prefix=/usr
 make

--- a/_includes/embedded_c/getting-started.md
+++ b/_includes/embedded_c/getting-started.md
@@ -11,6 +11,35 @@ Both these SDKs provide a consistent interface to interact with the [Parse REST 
 
 On Parse, you create an App for each of your mobile and embedded applications. Each App has its own application ID and client key that you apply to your SDK install. Your account on Parse can accommodate multiple Apps. This is useful even if you have one application, since you can deploy different versions for test and production.
 
+## Install the SDK on your device
+
+### Install a few tools
+
+Run the following lines in your Linux terminal:
+```bash
+sudo apt-get update
+sudo apt-get install autoconf automake libtool
+sudo apt-get install libcurl4-openssl-dev uuid-dev
+```
+
+### Download the SDK
+
+```bash
+git clone https://github.com/parse-community/parse-embedded-sdks.git
+```
+
+### Build the SDK
+
+Next, navigate to the newly downloaded directory and run a few commands to build the SDK. After this, the C library will be available globally on device.
+
+```bash
+cd parse-embedded-sdks
+autoreconf -fi
+./configure --prefix=/usr
+make
+sudo make install
+```
+
 ## Initialization
 
 In order for Parse to know which app is associated with the connected device, simply specify the application ID and client key in the device code:


### PR DESCRIPTION
Instructions are taken from the old documentation: https://web.archive.org/web/20161231233515/https://parse.com/apps/quickstart#embedded/raspberrypi