### PR TITLE
javaScriptKey is required to connect app

### DIFF
--- a/_includes/js/getting-started.md
+++ b/_includes/js/getting-started.md
@@ -41,6 +41,8 @@ To initialize your own Parse-Server with Javascript, you should replace your cur
 
 ```js
 Parse.initialize("YOUR_APP_ID", "YOUR_JAVASCRIPT_KEY");
+//javascriptKey is required only if you have it on server.
+
 Parse.serverURL = 'http://YOUR_PARSE_SERVER:1337/parse'
 ```
 

--- a/_includes/js/getting-started.md
+++ b/_includes/js/getting-started.md
@@ -40,7 +40,7 @@ To initialize your own Parse-Server with Javascript, you should replace your cur
 
 
 ```js
-Parse.initialize("YOUR_APP_ID");
+Parse.initialize("YOUR_APP_ID", "YOUR_JAVASCRIPT_KEY");
 Parse.serverURL = 'http://YOUR_PARSE_SERVER:1337/parse'
 ```
 


### PR DESCRIPTION
I have to provide javascriptKey to connect my react native app with Parse Server. It took me like an hour to figure it out because it was not mentioned in the docs.