### PR TITLE
added "options" parameter to the signature of validateAppId

### DIFF
--- a/_includes/parse-server/third-party-auth.md
+++ b/_includes/parse-server/third-party-auth.md
@@ -251,7 +251,7 @@ It is possible to leverage the OAuth support with any 3rd party authentication t
 }
 ```
 
-On this module, you need to implement and export those two functions `validateAuthData(authData, options) {} ` and `validateAppId(appIds, authData) {}`.
+On this module, you need to implement and export those two functions `validateAuthData(authData, options) {} ` and `validateAppId(appIds, authData, options) {}`.
 
 For more information about custom auth please see the examples:
 


### PR DESCRIPTION
In the current Parse-Server guide the description of "Custom authentication" contains this:
> On this module, you need to implement and export those two functions validateAuthData(authData, options) {} and validateAppId(appIds, authData) {}.

However the validateAppId() function is handed a third "options" parameter as well (just as validateAuthData()), so the correct sentence sounds like this:
> On this module, you need to implement and export those two functions validateAuthData(authData, options) {} and validateAppId(appIds, authData, options) {}.

This PR contains only this small change.