### PR TITLE
Finishes renaming PFFile to PFFileObject

### DIFF
--- a/_includes/ios/config.md
+++ b/_includes/ios/config.md
@@ -108,7 +108,7 @@ if date == nil ||
 *   NSString
 *   NSNumber
 *   NSDate
-*   PFFile
+*   PFFileObject
 *   PFGeoPoint
 *   NSArray
 *   NSDictionary

--- a/_includes/ios/files.md
+++ b/_includes/ios/files.md
@@ -9,7 +9,7 @@ Getting started with `PFFileObject` is easy. First, you'll need to have the data
 <div class="language-toggle" markdown="1">
 ```objective_c
 NSData *data = [@"Working at Parse is great!" dataUsingEncoding:NSUTF8StringEncoding];
-PFFile *file = [PFFileObject fileObjectWithName:@"resume.txt" data:data];
+PFFileObject *file = [PFFileObject fileObjectWithName:@"resume.txt" data:data];
 ```
 ```swift
 let str = "Working at Parse is great!"
@@ -55,7 +55,7 @@ Retrieving it back involves calling one of the `getData` variants on the `PFFile
 
 <div class="language-toggle" markdown="1">
 ```objective_c
-PFFile *applicantResume = anotherApplication[@"applicantResumeFile"];
+PFFileObject *applicantResume = anotherApplication[@"applicantResumeFile"];
 NSData *resumeData = [applicantResume getData];
 ```
 ```swift
@@ -73,7 +73,7 @@ You can easily store images by converting them to `NSData` and then using `PFFil
 <div class="language-toggle" markdown="1">
 ```objective_c
 NSData *imageData = UIImagePNGRepresentation(image);
-PFFile *imageFile = [PFFileObject fileObjectWithName:@"image.png" data:imageData];
+PFFileObject *imageFile = [PFFileObject fileObjectWithName:@"image.png" data:imageData];
 
 PFObject *userPhoto = [PFObject objectWithClassName:@"UserPhoto"];
 userPhoto[@"imageName"] = @"My trip to Hawaii!";
@@ -97,7 +97,7 @@ Retrieving the image back involves calling one of the `getData` variants on the 
 
 <div class="language-toggle" markdown="1">
 ```objective_c
-PFFile *userImageFile = anotherPhoto[@"imageFile"];
+PFFileObject *userImageFile = anotherPhoto[@"imageFile"];
 [userImageFile getDataInBackgroundWithBlock:^(NSData *imageData, NSError *error) {
     if (!error) {
         UIImage *image = [UIImage imageWithData:imageData];
@@ -123,7 +123,7 @@ It's easy to get the progress of both uploads and downloads using `PFFileObject`
 <div class="language-toggle" markdown="1">
 ```objective_c
 NSData *data = [@"Working at Parse is great!" dataUsingEncoding:NSUTF8StringEncoding];
-PFFile *file = [PFFile fileWithName:@"resume.txt" data:data];
+PFFileObject *file = [PFFileObject fileObjectWithName:@"resume.txt" data:data];
 [file saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
   // Handle success or failure here ...
 } progressBlock:^(int percentDone) {

--- a/_includes/ios/objects.md
+++ b/_includes/ios/objects.md
@@ -544,7 +544,7 @@ So far we've used values with type `NSString`, `NSNumber`, and `PFObject`. Parse
 * Array => `NSArray`
 * Object => `NSObject`
 * Date => `NSDate`
-* File => `PFFile`
+* File => `PFFileObject`
 * Pointer => other `PFObject`
 * Relation => `PFRelation`
 * Null => `NSNull`
@@ -596,7 +596,7 @@ bigObject.saveInBackground()
 ```
 </div>
 
-We do not recommend storing large pieces of binary data like images or documents on `PFObject`. `PFObject`s should not exceed 128 kilobytes in size. We recommend you use `PFFile`s to store images, documents, and other types of files. You can do so by instantiating a `PFFile` object and setting it on a field. See [Files](#files) for more details.
+We do not recommend storing large pieces of binary data like images or documents on `PFObject`. `PFObject`s should not exceed 128 kilobytes in size. We recommend you use `PFFileObject`s to store images, documents, and other types of files. You can do so by instantiating a `PFFileObject` object and setting it on a field. See [Files](#files) for more details.
 
 For more information about how Parse handles data, check out our documentation on [Data](#data).
 
@@ -692,7 +692,7 @@ If you need more complicated logic than simple property access, you can declare 
 }
 ```
 ```swift
-@NSManaged var iconFile: PFFile
+@NSManaged var iconFile: PFFileObject
 
 func iconView() -> UIImageView {
   let view = PFImageView(imageView: PlaceholderImage)

--- a/_includes/ios/user-interface.md
+++ b/_includes/ios/user-interface.md
@@ -567,7 +567,7 @@ A good starting point to learn more is to look at the [API for the class](http:/
 
 ### Loading Remote Images in Cells
 
-`PFQueryTableViewController` makes it simple to display remote images stored in the Parse Cloud as `PFFile`s. All you need to do is to override `tableView:cellForRowAtIndexPath:object:` and return a `PFTableViewCell` with its `imageView`'s `file` property specified. If you would like to display a placeholder image to be shown before the remote image is loaded, assign the placeholder image to the `image` property of the `imageView`.
+`PFQueryTableViewController` makes it simple to display remote images stored in the Parse Cloud as `PFFileObject`s. All you need to do is to override `tableView:cellForRowAtIndexPath:object:` and return a `PFTableViewCell` with its `imageView`'s `file` property specified. If you would like to display a placeholder image to be shown before the remote image is loaded, assign the placeholder image to the `image` property of the `imageView`.
 
 <div class="language-toggle" markdown="1">
 ```objective_c
@@ -580,7 +580,7 @@ A good starting point to learn more is to look at the [API for the class](http:/
     }
     cell.textLabel.text = object[@"title"];
 
-    PFFile *thumbnail = object[@"thumbnail"];
+    PFFileObject *thumbnail = object[@"thumbnail"];
     cell.imageView.image = [UIImage imageNamed:@"placeholder.jpg"];
     cell.imageView.file = thumbnail;
     return cell;
@@ -599,7 +599,7 @@ override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath:
     if let object = object {
         cell?.textLabel?.text = object["title"] as? String
         cell?.imageView?.image = UIImage(named: "placeholder.jpg")
-        cell?.imageView?.file = object["thumbnail"] as? PFFile
+        cell?.imageView?.file = object["thumbnail"] as? PFFileObject
     }
 
     return cell
@@ -609,7 +609,7 @@ override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath:
 
 <img data-echo="{{ site.baseUrl }}/assets/images/images_table.png" style="max-width:200px"/>
 
-This table shows a list of cute animal photos which are stored in the Parse Cloud, as `PFFile`s. "placeholder.jpg" is an image included in the application bundle which is shown before the animal photos are downloaded.
+This table shows a list of cute animal photos which are stored in the Parse Cloud, as `PFFileObject`s. "placeholder.jpg" is an image included in the application bundle which is shown before the animal photos are downloaded.
 
 The images are downloaded on demand. As you scroll through the table, the images in the currently visible cells are downloaded. This just-in-time behavior is desirable because not only does it conserve bandwidth, it also ensures timely display of visible images. If a more aggressive loading behavior is desired, you can use the `loadInBackground` method on `imageView` to download the image.
 
@@ -657,13 +657,13 @@ When the user is offline or a Parse error was generated from a query, an alert c
 
 ## PFImageView
 
-Many apps need to display images stored in the Parse Cloud as `PFFile`s. However, to load remote images with the built-in `UIImageView` involves writing many lines of boilerplate code. `PFImageView` simplifies this task:
+Many apps need to display images stored in the Parse Cloud as `PFFileObject`s. However, to load remote images with the built-in `UIImageView` involves writing many lines of boilerplate code. `PFImageView` simplifies this task:
 
 <div class="language-toggle" markdown="1">
 ```objective_c
 PFImageView *imageView = [[PFImageView alloc] init];
 imageView.image = [UIImage imageNamed:@"..."]; // placeholder image
-imageView.file = (PFFile *)someObject[@"picture"]; // remote image
+imageView.file = (PFFileObject *)someObject[@"picture"]; // remote image
 
 [imageView loadInBackground];
 ```
@@ -680,7 +680,7 @@ If assigned to, the `image` property is used to display a placeholder before the
 
 ## PFTableViewCell
 
-Many apps need to display table view cells which contain images stored in the Parse Cloud as `PFFile`s. However, to load remote images with the built-in `UITableViewCell` involves writing many lines of boilerplate code. `PFTableViewCell` simplifies this task by exposing an `imageView` property of the type `PFImageView` that supports remote image loading:
+Many apps need to display table view cells which contain images stored in the Parse Cloud as `PFFileObject`s. However, to load remote images with the built-in `UITableViewCell` involves writing many lines of boilerplate code. `PFTableViewCell` simplifies this task by exposing an `imageView` property of the type `PFImageView` that supports remote image loading:
 
 <div class="language-toggle" markdown="1">
 ```objective_c
@@ -693,7 +693,7 @@ Many apps need to display table view cells which contain images stored in the Pa
     }
     cell.textLabel.text = object[@"title"];
 
-    PFFile *thumbnail = object[@"thumbnail"];
+    PFFileObject *thumbnail = object[@"thumbnail"];
     cell.imageView.image = [UIImage imageNamed:@"placeholder.jpg"];
     cell.imageView.file = thumbnail;
     return cell;
@@ -712,7 +712,7 @@ func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexP
     if let title = object["title"] as? String {
         cell!.textLabel.text = title
     }
-    if let thumbnail = object["thumbnail"] as? PFFile {
+    if let thumbnail = object["thumbnail"] as? PFFileObject {
         cell!.imageView.image = UIImage(named: "placeholder.jpg")
         cell!.imageView.file = thumbnail
     }
@@ -722,7 +722,7 @@ func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexP
 ```
 </div>
 
-Like `UITableViewCell`, `PFTableViewCell` supports the default layout styles. Unlike `UITableViewCell`, `PFTableViewCell`'s `imageView` property is of the type `PFImageView`, which supports downloading remote images in `PFFile`.
+Like `UITableViewCell`, `PFTableViewCell` supports the default layout styles. Unlike `UITableViewCell`, `PFTableViewCell`'s `imageView` property is of the type `PFImageView`, which supports downloading remote images in `PFFileObject`.
 
 Although it can be used independently, `PFTableViewCell` really shines when used in `PFQueryTableViewController`. `PFQueryTableViewController` knows about `PFTableViewCell` and loads the images automatically. This behavior is discussed in detail in the documentation for `PFQueryTableViewController`.
 


### PR DESCRIPTION
I missed most of the references to PFFile in the previous PR (https://github.com/parse-community/docs/pull/580).

This PR finishes renaming them all (I hope :) )