### PR TITLE
Update user-interface.md

### DIFF
--- a/_includes/ios/user-interface.md
+++ b/_includes/ios/user-interface.md
@@ -2,11 +2,9 @@
 
 At the end of the day, users of your app are going to be interacting with UIKit components.
 
-[ParseUI](https://github.com/parse-community/ParseUI-iOS) is an opensource collection of a handy user interface components aimed to streamline and simplify user authentication, displaying lists of data, and other common app elements.
+ParseUI is an opensource collection of a handy user interface components aimed to streamline and simplify user authentication, displaying lists of data, and other common app elements.
 
-Please note that [ParseUI](https://github.com/parse-community/ParseUI-iOS) is not included inside the main Parse iOS SDK.
-
-To learn more on how to install it - follow the instructions on the official [GitHub page](https://github.com/parse-community/ParseUI-iOS).
+ParseUI can be installed by leveraging Cocoapods 'subspecs', simply add `pod 'Parse/UI'` to your Podfile and run `pod install`. Once installed just use `import Parse` to use ParseUI. More details can be found on the official [GitHub page](https://github.com/parse-community/Parse-SDK-iOS-OSX#other-installation-options)
 
 ## PFLogInViewController
 


### PR DESCRIPTION
ParseUI has moved to Parse-SDK-iOS-OSX - this change is now reflected in the docs

I’ve also added basic install instructions taken from the iOS SDK github page.