### PR TITLE
Add language toggles to REST docs

### DIFF
--- a/_includes/rest/config.md
+++ b/_includes/rest/config.md
@@ -39,7 +39,6 @@ The response body is a JSON object containing all the configuration parameters i
 
 You can also update the config by sending a `PUT` request to config URL. Here is a simple example that will update the `Parse.Config`:
 
-<div class="language-toggle">
 <pre><code class="bash">
 curl -X PUT \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -47,6 +46,7 @@ curl -X PUT \
   -d "{\"params\":{\"winningNumber\":43}}"
   <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>config
 </code></pre>
+
 <pre><code class="javascript">
 var request = require('request');
 return request({
@@ -62,7 +62,6 @@ return request({
   }
 })
 </code></pre>
-</div>
 
 The response body is a JSON object containing a simple boolean value in the `result` field.
 

--- a/_includes/rest/hooks.md
+++ b/_includes/rest/hooks.md
@@ -51,6 +51,7 @@ Note that trigger name can only be one of `beforeSave`, `afterSave`, `beforeDele
 ## Fetch functions
 To fetch the list of all cloud functions you deployed or created, use:
 
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X GET \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -70,8 +71,10 @@ connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 The output is a json object with one key: "results" whose value is a list of cloud functions.
+
 <pre><code class="json">
 {
   "results": [
@@ -85,6 +88,7 @@ The output is a json object with one key: "results" whose value is a list of clo
 
 To fetch a single cloud function with a given name, use:
 
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X GET \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -104,6 +108,7 @@ connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 The output is a json object with one key: "results" whose value is a list of cloud functions with the given name.
 
@@ -118,6 +123,8 @@ The output is a json object with one key: "results" whose value is a list of clo
 
 ## Fetch triggers
 To fetch the list of all cloud triggers you deployed or created, use:
+
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X GET \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -137,8 +144,10 @@ connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 The output is a json object with one key: "results" whose value is a list of cloud triggers.
+
 <pre><code class="json">
 {
   "results": [
@@ -159,6 +168,8 @@ The output is a json object with one key: "results" whose value is a list of clo
 </code></pre>
 
 To fetch a single cloud trigger, use:
+
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X GET \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -178,11 +189,13 @@ connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 The path looks like `/hooks/triggers/className/triggerName` where `triggerName`
 can be one of `beforeSave`, `afterSave`, `beforeDelete`, `afterDelete`.
 
 The output may look like this:
+
 <pre><code class="json">
 {
   "results": [
@@ -210,8 +223,9 @@ To create a new function webhook post to <code class="highlighter-rouge"><span c
 {"functionName" : x, "url" : y}
 ```
 
-Post example,
+Post example:
 
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X POST \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -234,6 +248,8 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
+
 
 The output may look like this:
 <pre><code class="json">
@@ -244,7 +260,9 @@ It returns the function name and url of the created webhook.
 
 If you try to create a function webhook and a cloud code function with the same name already exists, upon successful creation the response json has an additional `warning` field informing about the name conflict. Note that, function webhooks takes precedence over cloud code functions.
 
-For example,
+For example:
+
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X POST \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -267,8 +285,10 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 The output may look like this:
+
 <pre><code class="json">
 {
   "functionName": "bar",
@@ -278,15 +298,20 @@ The output may look like this:
 </code></pre>
 
 ## Create trigger webhook
-To create a new function webhook post to <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>hooks/triggers</code> with payload in the format
+To create a new function webhook post to <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>hooks/triggers</code> with payload in the format:
+
+<div class="language-toggle">
 <pre><code class="bash">
 {"className": x, "triggerName": y, "url": z}
 </code></pre>
 <pre><code class="python">
 {"className": x, "triggerName": y, "url": z}
 </code></pre>
+</div>
 
-Post example,
+Post example:
+
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X POST \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -309,8 +334,10 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 The output may look like this:
+
 <pre><code class="json">
 {
   "className": "Game",
@@ -323,7 +350,9 @@ It returns the class name, trigger name and url of the created trigger webhook.
 
 If you try to create a trigger webhook and a cloud code trigger with the same name already exists, upon successful creation the response json has an additional `warning` field informing about the name conflict. Note that, trigger webhooks takes precedence over cloud code triggers.
 
-For example,
+For example:
+
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X POST \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -346,8 +375,10 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 The output may look like this:
+
 <pre><code class="json">
 {
   "className": "Tournament",
@@ -360,7 +391,9 @@ The output may look like this:
 ## Edit function webhook
 To edit the url of a function webhook that was already created use the put method.
 
-Put example,
+Put example:
+
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X PUT \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -383,8 +416,10 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 The output may look like this:
+
 <pre><code class="json">
 {"functionName": "baz", "url": "https://api.example.com/baz"}'
 </code></pre>
@@ -393,7 +428,9 @@ It returns the function name and url of the modified webhook.
 
 If you try to update a function webhook and a cloud code function with the same name already exists, upon successful update the response json has an additional `warning` field informing about the name conflict. Note that, function webhooks takes precedence over cloud code functions.
 
-For example,
+For example:
+
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X PUT \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -416,8 +453,10 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 The output may look like this:
+
 <pre><code class="json">
 {
   "functionName": "bar",
@@ -429,6 +468,7 @@ The output may look like this:
 ## Edit trigger webhook
 To edit the url of a trigger webhook that was already crated use the put method.
 
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X PUT \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -451,8 +491,10 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 The output may look like this:
+
 <pre><code class="json">
 {
   "className": "Game",
@@ -465,7 +507,9 @@ It returns the class name, trigger name and url of the modified trigger webhook.
 
 If you try to update a trigger webhook and a cloud code trigger with the same name already exists, upon successful update the response json has an additional `warning` field informing about the name conflict. Note that, trigger webhooks takes precedence over cloud code triggers.
 
-For example,
+For example:
+
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X PUT \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -488,8 +532,10 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 The output may look like this:
+
 <pre><code class="json">
 {
   "className": "Tournament",
@@ -502,6 +548,7 @@ The output may look like this:
 ## Delete function webhook
 To delete a function webhook use the put method.
 
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X PUT \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -524,8 +571,10 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 The output may look like this:
+
 <pre><code class="json">
 {}
 </code></pre>
@@ -533,6 +582,7 @@ The output may look like this:
 If a cloud code function with the same name already exists then it is returned as the result.
 Since the overriding webhook was just deleted, this cloud code function will be run the next time sendMessage is called.
 
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X PUT \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -555,8 +605,10 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 The output may look like this:
+
 <pre><code class="json">
 { "functionName": "sendMessage" }
 </code></pre>
@@ -564,6 +616,7 @@ The output may look like this:
 ## Delete trigger webhook
 To delete a trigger webhook use the put method.
 
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X PUT \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -586,8 +639,10 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 The output may look like this:
+
 <pre><code class="json">
 {}
 </code></pre>
@@ -595,6 +650,7 @@ The output may look like this:
 If a cloud code trigger with the same name already exists then the it is returned as the result.
 Since the overriding webhook was just deleted, this cloud code trigger will be run the next time a Tournament object is saved.
 
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X PUT \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -617,8 +673,10 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 The output may look like this:
+
 <pre><code class="json">
 {
   "className": "Tournament",

--- a/_includes/rest/push-notifications.md
+++ b/_includes/rest/push-notifications.md
@@ -990,6 +990,7 @@ To schedule a push according to each device's local time, the `push_time` parame
 
 Starting parse-server version 2.6.1, it is possible to localize the push notifications messages according to the _Installation's `localeIdentifier`.
 
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X POST \
   -H "X-Parse-Application-Id: ${APPLICATION_ID}" \
@@ -1020,6 +1021,7 @@ connection.request('POST', '/1/push', json.dumps({
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 When setting the `alert-[lang|locale]` in the data, parse-server will find all installations that have that language or locale set. The language is usually the first part of the locale. This will have no impact on the query planning, as the localizations will be resolved just before the push is sent.
 

--- a/_includes/rest/sessions.md
+++ b/_includes/rest/sessions.md
@@ -34,6 +34,7 @@ For mobile apps and websites, you should not create `Session` objects manually. 
 
 In "Parse for IoT" apps (e.g. Arduino or Embedded C), you may want to programmatically create a restricted session that can be transferred to an IoT device. In order to do this, you must first log in normally to obtain an unrestricted session token. Then, you can create a restricted session by providing this unrestricted session token:
 
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X POST \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -58,6 +59,7 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 In the above code, `r:pnktnjyb996sj4p156gjtp4im` is the unrestricted session token from the original user login.
 
@@ -80,6 +82,8 @@ At this point, you can pass the session token `r:aVrtljyb7E8xKo9256gfvp4n2` to a
 ## Retrieving Sessions
 
 If you have the session's objectId, you fetch the `Session` object as long as it belongs to the same user as your current session:
+
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X GET \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -99,9 +103,11 @@ connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 If you only have the session's token (from previous login or session create), you can validate and fetch the corresponding session by:
 
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X GET \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -121,11 +127,13 @@ connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 ## Updating Sessions
 
 Updating a session is analogous to updating a Parse object.
 
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X PUT \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -147,11 +155,13 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 ## Querying Sessions
 
 Querying for `Session` objects will only return objects belonging to the same user as your current session (due to the Session ACL). You can also add a where clause to your query, just like normal Parse objects.
 
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X GET \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -171,13 +181,13 @@ connection.request('GET', '<span class="custom-parse-server-mount">/parse/</span
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
-
-
+</div>
 
 ## Deleting Sessions
 
 Deleting the Session object will revoke its session token and cause the user to be logged out on the device that's currently using this session token. When you have the session token, then you can delete its `Session` object by calling the logout endpoint:
 
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X POST \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -197,9 +207,11 @@ connection.request('POST', '<span class="custom-parse-server-mount">/parse/</spa
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 If you want to delete another `Session` object for your user, and you have its `objectId`, you can delete it (but not log yourself out) by:
 
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X DELETE \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -219,6 +231,7 @@ connection.request('DELETE', '<span class="custom-parse-server-mount">/parse/</s
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 `X-Parse-Session-Token` authenticates the request as the user that also owns session `Axy98kq1B09`, which may have a different session token. You can only delete other sessions that belong to the same user.
 
@@ -233,6 +246,7 @@ The following API is most useful for "Parse for IoT" apps (e.g. Arduino or Embed
 3. IoT device connects to Internet via Wi-Fi, saves its `Installation` object.
 4. IoT device calls the following endpoint to associate the its `installationId` with its session. This endpoint only works with session tokens from restricted sessions. Please note that REST API calls from an IoT device should use the Client Key, not the REST API Key.
 
+<div class="language-toggle">
 <pre><code class="bash">
 curl -X PUT \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
@@ -257,6 +271,7 @@ connection.request('PUT', '<span class="custom-parse-server-mount">/parse/</span
 result = json.loads(connection.getresponse().read())
 print result
 </code></pre>
+</div>
 
 ## Session Security
 
@@ -280,6 +295,7 @@ Parse.Cloud.beforeSave("MyClass", function(request, response) {
   });
 });
 </code></pre>
+
 You can configure Class-Level Permissions (CLPs) for the Session class just like other classes on Parse. CLPs restrict reading/writing of sessions via the <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>sessions</code> API, but do not restrict Parse Cloud's automatic session creation/deletion when users log in, sign up, and log out. We recommend that you disable all CLPs not needed by your app. Here are some common use cases for Session CLPs:
 
 * **Find**, **Delete** — Useful for building a UI screen that allows users to see their active session on all devices, and log out of sessions on other devices. If your app does not have this feature, you should disable these permissions.


### PR DESCRIPTION
Some sections are missing the `<div class="language-toggle">` and `</div>` so the code displays but not with the toggle and as two separate code blocks instead.

Sections to do / check:
- [x] Getting Started
- [x] Quick Reference
- [x] Objects
- [x] Queries - did discover some other formatting issues #608
- [x] Users
- [x] Sessions (changes made)
- [x] Roles
- [x] Files
- [x] GeoPoints
- [x] Data
- [x] Push Notifications (changes made)
- [x] Config (changes made)
- [x] Analytics
- [x] Cloud Code
- [x] Schema
- [x] Hooks (changes made)
- [x] Security
- [x] Error Codes