### PR TITLE
Add documentation for beforeLogin trigger

### DIFF
--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -385,14 +385,14 @@ Parse.Cloud.beforeFind('MyObject2', (req) => {
 
 ```
 
-# beforeLogin Triggers
+# beforeLogin Trigger
 
-*Available only on parse-server cloud code starting <version-number>*
+*Available only on parse-server cloud code starting ...*
 
 Sometimes you may want to run custom validation on a login request. The `beforeLogin` trigger can be used for blocking an account from logging in (for example, if they are banned), recording a login event for analytics, notifying user by email if a login occurred at an unusual IP address and more.
 
-```JavaScript
-Parse.Cloud.beforeLogin(async request => { 
+```javascript
+Parse.Cloud.beforeLogin(async request => {
   const { object: user }  = request;
   if(user.get('isBanned')) {
    throw new Error('Access denied, you have been banned.')
@@ -400,16 +400,17 @@ Parse.Cloud.beforeLogin(async request => {
 });
 ```
 
-### Some considerations to be aware of:
-- It does not set the user on the request object - technically, the user has not yet been provided a session until after beforeLogin is successfully completed
-- It waits for any promises to resolve
-- Like `afterSave` on `Parse.User`, it will not save mutations to the user unless explicitly saved.
+## Some considerations to be aware of
 
-#### `beforeLogin` will run...
+- It waits for any promises to resolve
+- The user is not available on the request object - the user has not yet been provided a session until after beforeLogin is successfully completed
+- Like `afterSave` on `Parse.User`, it will not save mutations to the user unless explicitly saved
+
+### The trigger will run...
 - On username & password logins
 - On `authProvider` logins
 
-#### `beforeLogin` will __not__ run...
+### The trigger won't run...
 - On sign up
 - If the login credentials are incorrect
 

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -389,7 +389,7 @@ Parse.Cloud.beforeFind('MyObject2', (req) => {
 
 *Available only on parse-server cloud code starting <version-number>*
 
-The beforeLogin trigger can be used for blocking an account from logging in (for example, if they are banned), recording a login event for analytics, notifying user by email if a login occurred at an unusual IP address and more.
+Sometimes you may want to run custom validation on a login request. The `beforeLogin` trigger can be used for blocking an account from logging in (for example, if they are banned), recording a login event for analytics, notifying user by email if a login occurred at an unusual IP address and more.
 
 ```JavaScript
 Parse.Cloud.beforeLogin(async request => { 
@@ -399,6 +399,12 @@ Parse.Cloud.beforeLogin(async request => {
   }
 });
 ```
+
+### Some considerations to be aware of:
+- It does not set the user on the request object - technically, the user has not yet been provided a session until after beforeLogin is successfully completed
+- It does not run on sign up
+- It does run on username/pass AND authProvider logins
+- It will not run if the login credentials are incorrect
 
 # Using the Master Key in cloud code
 Set `useMasterKey:true` in the requests that require master key.

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -402,9 +402,16 @@ Parse.Cloud.beforeLogin(async request => {
 
 ### Some considerations to be aware of:
 - It does not set the user on the request object - technically, the user has not yet been provided a session until after beforeLogin is successfully completed
-- It does not run on sign up
-- It does run on username/pass AND authProvider logins
-- It will not run if the login credentials are incorrect
+- It waits for any promises to resolve
+- Like `afterSave` on `Parse.User`, it will not save mutations to the user unless explicitly saved.
+
+#### `beforeLogin` will run...
+- On username & password logins
+- On `authProvider` logins
+
+#### `beforeLogin` will __not__ run...
+- On sign up
+- If the login credentials are incorrect
 
 # Using the Master Key in cloud code
 Set `useMasterKey:true` in the requests that require master key.

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -387,9 +387,18 @@ Parse.Cloud.beforeFind('MyObject2', (req) => {
 
 # beforeLogin Triggers
 
-*Available only on parse-server cloud code starting 3.3*
+*Available only on parse-server cloud code starting <version-number>*
 
 The beforeLogin trigger can be used for blocking an account from logging in (for example, if they are banned), recording a login event for analytics, notifying user by email if a login occurred at an unusual IP address and more.
+
+```JavaScript
+Parse.Cloud.beforeLogin(async request => { 
+  const { object: user }  = request;
+  if(user.get('isBanned')) {
+   throw new Error('Access denied, you have been banned.')
+  }
+});
+```
 
 # Using the Master Key in cloud code
 Set `useMasterKey:true` in the requests that require master key.

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -385,6 +385,12 @@ Parse.Cloud.beforeFind('MyObject2', (req) => {
 
 ```
 
+# beforeLogin Triggers
+
+*Available only on parse-server cloud code starting 3.3*
+
+The beforeLogin trigger can be used for blocking an account from logging in (for example, if they are banned), recording a login event for analytics, notifying user by email if a login occurred at an unusual IP address and more.
+
 # Using the Master Key in cloud code
 Set `useMasterKey:true` in the requests that require master key.
 

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -387,7 +387,7 @@ Parse.Cloud.beforeFind('MyObject2', (req) => {
 
 # beforeLogin Trigger
 
-*Available only on parse-server cloud code starting ...*
+*Available only on parse-server cloud code starting 3.3.0*
 
 Sometimes you may want to run custom validation on a login request. The `beforeLogin` trigger can be used for blocking an account from logging in (for example, if they are banned), recording a login event for analytics, notifying user by email if a login occurred at an unusual IP address and more.
 


### PR DESCRIPTION
[#5445](https://github.com/parse-community/parse-server/pull/5445) on the Parse Server repo adds a new `beforeLogin` cloud code trigger. This PR adds documentation for this new trigger in the cloud code guide.

__Note - `beforeLogin` has not yet been released so this is just preemptive.__

- [x] __TO DO__ - Add version number (once parse server released)

Fixes #613.