### PR TITLE
Remove erroneous docs for Jobs in 3.x

### DIFF
--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -144,8 +144,6 @@ Sometimes you want to execute long running functions, and you don't want to wait
     });
 ```
 
-Note that calling `status.success` or `status.error` won't prevent any further execution of the job.
-
 ## Running a Job
 
 Calling jobs is done via the REST API and is protected by the master key.


### PR DESCRIPTION
Looks like this line got left behind during the process of updating the docs to 3.0. (jobs are no longer called with a `status` argument.