### PR TITLE
Fix doc for creating a subscription in javascript

### DIFF
--- a/_includes/js/live-queries.md
+++ b/_includes/js/live-queries.md
@@ -12,6 +12,8 @@ let query = new Parse.Query('Game');
 let subscription = await query.subscribe();
 ```
 
+* Since release `2.3.0` of Parse JS SDK, the `query.subscribe()` function returns a `Promise` that resolves to the subscription object. Previous releases return the subscription object directly and require you to write `let subscription = query.subscribe();` instead.
+
 The subscription you get is actually an event emitter. For more information on event emitter, check [here](https://nodejs.org/api/events.html). You'll get the LiveQuery events through this `subscription`. The first time you call subscribe, we'll try to open the WebSocket connection to the LiveQuery server for you.
 
 ## Event Handling

--- a/_includes/js/live-queries.md
+++ b/_includes/js/live-queries.md
@@ -9,7 +9,7 @@ Note: Live Queries is supported only in [Parse Server](https://github.com/parse-
 
 ```javascript
 let query = new Parse.Query('Game');
-let subscription = query.subscribe();
+let subscription = await query.subscribe();
 ```
 
 The subscription you get is actually an event emitter. For more information on event emitter, check [here](https://nodejs.org/api/events.html). You'll get the LiveQuery events through this `subscription`. The first time you call subscribe, we'll try to open the WebSocket connection to the LiveQuery server for you.


### PR DESCRIPTION
According to [integration tests](https://github.com/parse-community/Parse-SDK-JS/blob/master/integration/test/ParseLiveQueryTest.js)