### PR TITLE
Parse.Cloud.onLiveQueryEvent Documentation

### DIFF
--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -473,7 +473,7 @@ Parse.Cloud.beforeLogin(async request => {
 
 *Available only on parse-server cloud code starting 2.6.2*
 
-Sometimes you may want monitor Live Query Event to be used with a 3rd Party such as datadog. The `onLiveQueryEvent` trigger can be logging events triggered, number of clients connected, number of subscriptions and errors.
+Sometimes you may want to monitor Live Query Events to be used with a 3rd Party such as datadog. The `onLiveQueryEvent` trigger can log events triggered, number of clients connected, number of subscriptions and errors.
 
 ```javascript
 Parse.Cloud.onLiveQueryEvent(({

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -469,6 +469,37 @@ Parse.Cloud.beforeLogin(async request => {
 - On sign up
 - If the login credentials are incorrect
 
+# LiveQuery Triggers
+
+*Available only on parse-server cloud code starting 2.6.2*
+
+Sometimes you may want monitor Live Query Event to be used with a 3rd Party such as datadog. The `onLiveQueryEvent` trigger can be logging events triggered, number of clients connected, number of subscriptions and errors.
+
+```javascript
+Parse.Cloud.onLiveQueryEvent(({
+  event,
+  clients,
+  subscriptions,
+  error
+}) => {
+  if (event !== 'ws_disconnect') {
+    return;
+  }
+  // Do your magic
+});
+```
+
+## Events
+
+* connect
+* subscribe
+* unsubscribe
+* ws_connect
+* ws_disconnect
+* ws_disconnect_error
+
+"connect" differs from "ws_connect", the former means that the client completed the connect procedure as defined by Parse Live Query protocol, where "ws_connect" just means that a new websocket was created.
+
 # Using the Master Key in cloud code
 Set `useMasterKey:true` in the requests that require master key.
 

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -478,6 +478,10 @@ Sometimes you may want to monitor Live Query Events to be used with a 3rd Party 
 ```javascript
 Parse.Cloud.onLiveQueryEvent(({
   event,
+  client,
+  sessionToken,
+  useMasterKey,
+  installationId,
   clients,
   subscriptions,
   error
@@ -488,6 +492,9 @@ Parse.Cloud.onLiveQueryEvent(({
   // Do your magic
 });
 ```
+*client, sessionToken, useMasterKey and installationId are available on parse-server cloud code 2.8.0+*
+
+To learn more, read the [Parse LiveQuery Protocol Specification](https://github.com/parse-community/parse-server/wiki/Parse-LiveQuery-Protocol-Specification)
 
 ## Events
 

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -492,7 +492,7 @@ Parse.Cloud.onLiveQueryEvent(({
   // Do your magic
 });
 ```
-*client, sessionToken, useMasterKey and installationId are available on parse-server cloud code 2.8.0+*
+*client, sessionToken, useMasterKey and installationId are available on parse-server cloud code 3.8.0+*
 
 To learn more, read the [Parse LiveQuery Protocol Specification](https://github.com/parse-community/parse-server/wiki/Parse-LiveQuery-Protocol-Specification)
 


### PR DESCRIPTION
closes: https://github.com/parse-community/docs/issues/628

This is a work in progress. I plan on adding more parameters on the server like sessionToken and connectedAt timestamp.

If you can think of any other parameters / events that would help with monitoring I can open a PR with them