### PR TITLE
Update recommended node version to 8 or newer

### DIFF
--- a/_includes/parse-server/getting-started.md
+++ b/_includes/parse-server/getting-started.md
@@ -9,7 +9,7 @@ Parse Server is an open source version of the Parse backend that can be deployed
 
 **Prerequisites**
 
-* Node 4.3
+* Node 9.11
 * MongoDB version 2.6.X, 3.0.X or 3.2.X
 * Python 2.x (For Windows users, 2.7.1 is the required version)
 * For deployment, an infrastructure provider like Heroku or AWS

--- a/_includes/parse-server/getting-started.md
+++ b/_includes/parse-server/getting-started.md
@@ -9,7 +9,7 @@ Parse Server is an open source version of the Parse backend that can be deployed
 
 **Prerequisites**
 
-* Node 9.11
+* Node 8 or newer
 * MongoDB version 2.6.X, 3.0.X or 3.2.X
 * Python 2.x (For Windows users, 2.7.1 is the required version)
 * For deployment, an infrastructure provider like Heroku or AWS


### PR DESCRIPTION
If you use node 4.3, you get a lot of warnings for using a too old node version while installing parse. I found 9.11 to be a good version to use.