### PR TITLE
Allow .current to return CustomUser

### DIFF
--- a/_includes/js/objects.md
+++ b/_includes/js/objects.md
@@ -101,10 +101,10 @@ class CustomUser extends Parse.User {
     return 5;
   }
 }
-Parse.Object.registerSubclass('CustomUser', CustomUser);
+Parse.Object.registerSubclass('_User', CustomUser);
 ```
 
-In addition to queries, `logIn` and `signUp` will return the subclass `CustomUser`.
+In addition to queries, `logIn`, `signUp`, and `current` will return the subclass `CustomUser`.
 
 ```javascript
 const customUser = new CustomUser({ foo: 'bar' });
@@ -117,7 +117,7 @@ customUser.signUp().then((user) => {
 });
 ```
 
-`CustomUser.logIn` and `CustomUser.signUp` will return the subclass `CustomUser` (SDK v2.3.0).
+`CustomUser.logIn`, `CustomUser.signUp`, and `Customer.current` will return the subclass `CustomUser` (SDK v2.3.0).
 
 ## Saving Objects
 


### PR DESCRIPTION
If we do `Parse.Object.registerSubclass('CustomUser', CustomUser);`, parse still serializes the current user in local storage with `className="_User"`. As such, in subsequent loading of the app, the deserialization process will know nothing of the CustomUser class and `CustomUser.current()` will just return a `Parse.User`. Thus we lose access to all the cool custom methods. Changing the registration to `Parse.Object.registerSubclass('_User', CustomUser)` fixes that.