### PR TITLE
Update getting-started.md

### DIFF
--- a/_includes/android/getting-started.md
+++ b/_includes/android/getting-started.md
@@ -50,6 +50,7 @@ public class App extends Application {
  ```xml
  <application
    android:name=".App"
+   android:usesCleartextTraffic="true"
    ...>
    ...
  </application>


### PR DESCRIPTION
Starting with Android 9 (API level 28), cleartext support is disabled by default so we need to set this property to true in order to be able to connect to the server.