### PR TITLE
Update getting-started.md

### DIFF
--- a/_includes/android/getting-started.md
+++ b/_includes/android/getting-started.md
@@ -50,8 +50,8 @@ public class App extends Application {
  ```xml
  <application
    android:name=".App"
-   android:usesCleartextTraffic="true"
    ...>
    ...
  </application>
  ```
+ Note that if you are testing with a server using http, you will need to add android:usesCleartextTraffic="true" to your above <application> definition, but you should only do this while testing and should use https for your final product.

--- a/_includes/android/getting-started.md
+++ b/_includes/android/getting-started.md
@@ -50,6 +50,7 @@ public class App extends Application {
  ```xml
  <application
    android:name=".App"
+   android:usesCleartextTraffic="true"
    ...>
    ...
  </application>

--- a/_includes/android/getting-started.md
+++ b/_includes/android/getting-started.md
@@ -46,12 +46,13 @@ public class App extends Application {
 }
 ```
 
- The custom `Application` class must be registered in `AndroidManifest.xml`:
- ```xml
+The custom `Application` class must be registered in `AndroidManifest.xml`:
+```xml
  <application
    android:name=".App"
    ...>
    ...
  </application>
- ```
- Note that if you are testing with a server using http, you will need to add android:usesCleartextTraffic="true" to your above <application> definition, but you should only do this while testing and should use https for your final product.
+```
+
+Note that if you are testing with a server using `http`, you will need to add `android:usesCleartextTraffic="true"` to your above `<application>` definition, but you should only do this while testing and should use `https` for your final product.


### PR DESCRIPTION
Starting with Android 9 (API level 28), cleartext support is disabled by default so we need to set this property to true in order to be able to connect to the server.