### PR TITLE
Add apiURL to Instagram Auth

### DIFF
--- a/_includes/parse-server/third-party-auth.md
+++ b/_includes/parse-server/third-party-auth.md
@@ -184,7 +184,8 @@ Google oauth supports validation of id_token's and access_token's.
 {
   "instagram": {
     "id": "user's Instagram id (string)",
-    "access_token": "an authorized Instagram access token for the user"
+    "access_token": "an authorized Instagram access token for the user",
+    "apiURL": "an api url to make requests. Default: https://api.instagram.com/v1/"
   }
 }
 ```


### PR DESCRIPTION
https://github.com/parse-community/parse-server/pull/6398

Allows user to specify newer API URLs