### PR TITLE
Fix for scroll nav guide

### DIFF
--- a/css/lib/docs/components/_live-toc.scss
+++ b/css/lib/docs/components/_live-toc.scss
@@ -53,7 +53,7 @@
 
         // position: fixed;
         // left:0; top:0;
-        height: 75vh;
+        height: calc(100vh - (#{$live-toc-distance-top} + 35px) - 20px);
         overflow-y: scroll;
 
         padding: 0;

--- a/css/lib/docs/components/_live-toc.scss
+++ b/css/lib/docs/components/_live-toc.scss
@@ -53,8 +53,8 @@
 
         // position: fixed;
         // left:0; top:0;
-        // height: 100%;
-        // overflow-y: auto;
+        height: 75vh;
+        overflow-y: scroll;
 
         padding: 0;
         margin: 0;


### PR DESCRIPTION
I just used this calc, the values are the top distances, in that way any change to $live-toc-distance-top will calculate a new heigth to ui_live_toc class

`calc(100vh - (#{$live-toc-distance-top} + 35px) - 20px);`

Closes #603