### PR TITLE
Swift example needs update as it errors out as it was.

### DIFF
--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -58,6 +58,7 @@ To call the same Cloud function from an iOS app:
 
 ```swift
 // Swift
+PFCloud.callFunction(inBackground: "averageRatings", withParameters: ["movie":"The Matrix"]) {
 	(response, error) in
 	let ratings = response as? Float
 	// ratings is 4.5

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -58,10 +58,9 @@ To call the same Cloud function from an iOS app:
 
 ```swift
 // Swift
-PFCloud.callFunctionInBackground("averageRatings", withParameters: ["movie":"The Matrix"]) {
-  (response: AnyObject?, error: NSError?) -> Void in
-  let ratings = response as? Float
-  // ratings is 4.5
+	(response, error) in
+	let ratings = response as? Float
+	// ratings is 4.5
 }
 ```
 


### PR DESCRIPTION
Based on closed issue https://github.com/parse-community/Parse-SDK-iOS-OSX/issues/1311

I've updated the Swift usage of CloudCode doc to get it working with the current version of Parse.