### PR TITLE
removed obsolete 128KB limit of Parse Objects

### DIFF
--- a/_includes/android/objects.md
+++ b/_includes/android/objects.md
@@ -352,7 +352,7 @@ bigObject.put("myNull", JSONObject.NULL);
 bigObject.saveInBackground();
 ```
 
-We do not recommend storing large pieces of binary data like images or documents on `ParseObject`. `ParseObject`s should not exceed 128 kilobytes in size. We recommend you use `ParseFile`s to store images, documents, and other types of files. You can do so by instantiating a `ParseFile` object and setting it on a field. See [Files](#files) for more details.
+We do not recommend storing large pieces of binary data like images or documents on `ParseObject`. We recommend you use `ParseFile`s to store images, documents, and other types of files. You can do so by instantiating a `ParseFile` object and setting it on a field. See [Files](#files) for more details.
 
 For more information about how Parse handles data, check out our documentation on [Data](#data).
 

--- a/_includes/arduino/objects.md
+++ b/_includes/arduino/objects.md
@@ -112,6 +112,6 @@ create.addJSONValue("emptyField", "null");
 create.send();
 ```
 
-We do not recommend storing large pieces of binary data like images or documents in a `ParseObject`. `ParseObject`s should not exceed 128 kilobytes in size. We recommend you use `ParseFile`s to store images, documents, and other types of files. You can do so by instantiating a `ParseFile` object and setting it on a field. See the [Files section in the REST documentation]({{ site.baseUrl }}/rest/guide/#files) for more details.
+We do not recommend storing large pieces of binary data like images or documents in a `ParseObject`. We recommend you use `ParseFile`s to store images, documents, and other types of files. You can do so by instantiating a `ParseFile` object and setting it on a field. See the [Files section in the REST documentation]({{ site.baseUrl }}/rest/guide/#files) for more details.
 
 For more information about how Parse handles data, check out our documentation on [Data]({{ site.baseUrl }}/rest/guide/#data).

--- a/_includes/common/errors.md
+++ b/_includes/common/errors.md
@@ -16,7 +16,7 @@ The following is a list of all the error codes that can be returned by the Parse
 | `InvalidJSON`                    |  107 | Badly formed JSON was received upstream. This either indicates you have done something unusual with modifying how things encode to JSON, or the network is failing badly. Can also indicate an invalid utf-8 string or use of multiple form encoded values. Check error message for more details.  |
 | `CommandUnavailable`	           |  108 | The feature you tried to access is only available internally for testing purposes. |
 | `NotInitialized`	               |  109 | You must call Parse.initialize before using the Parse library. Check the Quick Start guide for your platform. |
-| `ObjectTooLarge`	               |  116 | The object is too large. Parse Objects have a max size of 128 kilobytes. |
+| `ObjectTooLarge`	               |  116 | The object is too large. |
 | `ExceededConfigParamsError`      |  116 | You have reached the limit of 100 config parameters. |
 | `InvalidLimitError`	             |  117 | An invalid value was set for the limit. Check error message for more details. |
 | `InvalidSkipError`	             |  118 | An invalid value was set for skip. Check error message for more details. |

--- a/_includes/common/performance.md
+++ b/_includes/common/performance.md
@@ -1417,8 +1417,7 @@ $posts = $query->find();
 There are some limits in place to ensure the API can provide the data you need in a performant manner. We may adjust these in the future. Please take a moment to read through the following list:
 
 **Objects**
-
-* Parse Objects are limited in size to 128 KB.
+* We recommend against storing large pieces of binary data like images or documents in a Parse Object.
 * We recommend against creating more than 64 fields on a single Parse Object to ensure that we can build effective indexes for your queries.
 * We recommend against using field names that are longer than 1,024 characters, otherwise an index for the field will not be created.
 

--- a/_includes/common/relations.md
+++ b/_includes/common/relations.md
@@ -1614,6 +1614,6 @@ const books = await bookQuery.find();
 In Parse, a one-to-one relationship is great for situations where you need to split one object into two objects. These situations should be rare, but two examples include:
 
 * **Limiting visibility of some user data.** In this scenario, you would split the object in two, where one portion of the object contains data that is visible to other users, while the related object contains data that is private to the original user (and protected via ACLs).
-* **Splitting up an object for size.** In this scenario, your original object is greater than the 128K maximum size permitted for an object, so you decide to create a secondary object to house extra data. It is usually better to design your data model to avoid objects this large, rather than splitting them up. If you can't avoid doing so, you can also consider storing large data in a Parse File.
+* **Splitting up an object for size.** In this scenario, your original object size is too large, so you decide to create a secondary object to house extra data. It is usually better to design your data model to avoid objects this large, rather than splitting them up. If you can't avoid doing so, you can also consider storing large data in a Parse File.
 
 Thank you for reading this far. We apologize for the complexity. Modeling relationships in data is a hard subject, in general. But look on the bright side: it's still easier than relationships with people.

--- a/_includes/dotnet/objects.md
+++ b/_includes/dotnet/objects.md
@@ -74,7 +74,7 @@ bigObject["myDictionary"] = dictionary;
 await bigObject.SaveAsync();
 ```
 
-We do not recommend storing large pieces of binary data like images or documents on `ParseObject`. `ParseObject`s should not exceed 128 kilobytes in size. We recommend you use `ParseFile`s to store images, documents, and other types of files. You can do so by instantiating a `ParseFile` object and setting it on a field. See [Files](#files) for more details.
+We do not recommend storing large pieces of binary data like images or documents on `ParseObject`. We recommend you use `ParseFile`s to store images, documents, and other types of files. You can do so by instantiating a `ParseFile` object and setting it on a field. See [Files](#files) for more details.
 
 For more information about how Parse handles data, check out our documentation on [Data](#data).
 

--- a/_includes/js/objects.md
+++ b/_includes/js/objects.md
@@ -479,6 +479,6 @@ bigObject.set("myPointerKey", pointer); // shows up as Pointer &lt;MyClassName&g
 bigObject.save();
 ```
 
-We do not recommend storing large pieces of binary data like images or documents on `Parse.Object`. `Parse.Object`s should not exceed 128 kilobytes in size. We recommend you use `Parse.File`s to store images, documents, and other types of files. You can do so by instantiating a `Parse.File` object and setting it on a field. See [Files](#files) for more details.
+We do not recommend storing large pieces of binary data like images or documents on `Parse.Object`. We recommend you use `Parse.File`s to store images, documents, and other types of files. You can do so by instantiating a `Parse.File` object and setting it on a field. See [Files](#files) for more details.
 
 For more information about how Parse handles data, check out our documentation on [Data](#data).

--- a/_includes/php/objects.md
+++ b/_includes/php/objects.md
@@ -318,7 +318,7 @@ $bigObject->set("anyKey", null); // this value can only be saved to an existing 
 $bigObject->save();
 ```
 
-We do not recommend storing large pieces of binary data like images or documents on `ParseObject`. `ParseObject`s should not exceed 128 kilobytes in size. We recommend you use `ParseFile`s to store images, documents, and other types of files. You can do so by instantiating a `ParseFile` object and setting it on a field. See [Files](#files) for more details.
+We do not recommend storing large pieces of binary data like images or documents on `ParseObject`. We recommend you use `ParseFile`s to store images, documents, and other types of files. You can do so by instantiating a `ParseFile` object and setting it on a field. See [Files](#files) for more details.
 
 For more information about how Parse handles data, check out our documentation on [Data](#data).
 

--- a/_includes/rest/objects.md
+++ b/_includes/rest/objects.md
@@ -684,7 +684,7 @@ The `Relation` type is used for many-to-many relations. It has a `className` tha
 
 When querying, `Relation` objects behave like arrays of Pointers. Any operation that is valid for arrays of pointers (other than `include`) works for `Relation` objects.
 
-We do not recommend storing large pieces of binary data like images or documents on a Parse object. Parse objects should not exceed 128 kilobytes in size. To store more, we recommend you use `File`. You may associate a [previously uploaded file](#files) using the `File` type.
+We do not recommend storing large pieces of binary data like images or documents on a Parse object. To store more, we recommend you use `File`. You may associate a [previously uploaded file](#files) using the `File` type.
 
 ```json
 {

--- a/_includes/unity/objects.md
+++ b/_includes/unity/objects.md
@@ -74,7 +74,7 @@ bigObject["myDictionary"] = dictionary;
 Task saveTask = bigObject.SaveAsync();
 ```
 
-We do not recommend storing large pieces of binary data like images or documents on `ParseObject`. `ParseObject`s should not exceed 128 kilobytes in size. We recommend you use `ParseFile`s to store images, documents, and other types of files. You can do so by instantiating a `ParseFile` object and setting it on a field. See [Files](#files) for more details.
+We do not recommend storing large pieces of binary data like images or documents on `ParseObject`. We recommend you use `ParseFile`s to store images, documents, and other types of files. You can do so by instantiating a `ParseFile` object and setting it on a field. See [Files](#files) for more details.
 
 For more information about how Parse handles data, check out our documentation on [Data](#data).
 


### PR DESCRIPTION
Removed the 128KB Parse Object size limit from the docs, as it does not exist in Open Source Parse Server.