### PR TITLE
Add beforeConnect / beforeSubscribe docs

### DIFF
--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -624,7 +624,7 @@ Parse.LiveQuery.on('error', (error) => {
 
 *Available only on parse-server cloud code starting 4.3.0*
 
-In some cases you may want to transform the incoming subcription query, adding an additional limit or increasing the default limit, adding extra includes or restrict the results to a subset of keys. You can do so with the `beforeSubscribe` trigger. 
+In some cases you may want to transform the incoming subscription query. Examples include adding an additional limit, increasing the default limit, adding extra includes or restricting the results to a subset of keys. You can do so with the `beforeSubscribe` trigger. 
 
 ```javascript
 Parse.Cloud.beforeSubscribe('MyObject', request => {

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -598,6 +598,46 @@ Parse.Cloud.afterLogout(async request => {
 
 # LiveQuery Triggers
 
+## beforeConnect
+
+*Available only on parse-server cloud code starting 4.3.0*
+
+You can run custom Cloud Code before a user attempts to connect to your LiveQuery server. You can do this with the `beforeConnect` method. For instance, this can be used to only allow users that have logged in to connect to the LiveQuery server. 
+
+```javascript
+Parse.Cloud.beforeConnect(request => {
+  if (!request.user) {
+    throw "Please login before you attempt to connect."
+  }
+});
+```
+
+In most cases, the `connect` event called the first time the client calls `subscribe`. If this is your use case, you can listen for errors using this event.
+
+```javascript
+Parse.LiveQuery.on('error', (error) => {
+  console.log(error);
+});
+```
+
+## beforeSubscribe
+
+*Available only on parse-server cloud code starting 4.3.0*
+
+In some cases you may want to transform the incoming subcription query, adding an additional limit or increasing the default limit, adding extra includes or restrict the results to a subset of keys. You can do so with the `beforeSubscribe` trigger. 
+
+```javascript
+Parse.Cloud.beforeSubscribe('MyObject', request => {
+    if (!request.user.get('Admin')) {
+        throw new Parse.Error(101, 'You are not authorized to subscribe to MyObject.');
+    }
+    let query = request.query; // the Parse.Query
+    query.select("name","year")
+});
+```
+
+## onLiveQueryEvent
+
 *Available only on parse-server cloud code starting 2.6.2*
 
 Sometimes you may want to monitor Live Query Events to be used with a 3rd Party such as datadog. The `onLiveQueryEvent` trigger can log events triggered, number of clients connected, number of subscriptions and errors.

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -612,7 +612,7 @@ Parse.Cloud.beforeConnect(request => {
 });
 ```
 
-In most cases, the `connect` event called the first time the client calls `subscribe`. If this is your use case, you can listen for errors using this event.
+In most cases, the `connect` event is called the first time the client calls `subscribe`. If this is your use case, you can listen for errors using this event.
 
 ```javascript
 Parse.LiveQuery.on('error', (error) => {

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -602,7 +602,7 @@ Parse.Cloud.afterLogout(async request => {
 
 *Available only on parse-server cloud code starting 4.3.0*
 
-You can run custom Cloud Code before a user attempts to connect to your LiveQuery server. You can do this with the `beforeConnect` method. For instance, this can be used to only allow users that have logged in to connect to the LiveQuery server. 
+You can run custom Cloud Code before a user attempts to connect to your LiveQuery server with the `beforeConnect` method. For instance, this can be used to only allow users that have logged in to connect to the LiveQuery server. 
 
 ```javascript
 Parse.Cloud.beforeConnect(request => {


### PR DESCRIPTION
Closes #751. Adds descriptions for beforeConnect and beforeSubscribe to Cloud Code docs.

How's this @TomWFox? Simple enough, or would you like more examples?