### PR TITLE
Format optional comments to match others

### DIFF
--- a/_includes/graphql/objects.md
+++ b/_includes/graphql/objects.md
@@ -10,7 +10,7 @@ For example, if you have a class named `GameScore` in the schema, Parse Server a
 // Header
 {
   "X-Parse-Application-Id": "APPLICATION_ID",
-  "X-Parse-Master-Key": "MASTER_KEY" // optional
+  "X-Parse-Master-Key": "MASTER_KEY" // (optional)
 }
 ```
 

--- a/_includes/graphql/users.md
+++ b/_includes/graphql/users.md
@@ -68,7 +68,7 @@ After you allow users to sign up, you need to let them log in to their account w
 // Header
 {
   "X-Parse-Application-Id": "APPLICATION_ID",
-  "X-Parse-Master-Key": "MASTER_KEY" // optional
+  "X-Parse-Master-Key": "MASTER_KEY" // (optional)
 }
 ```
 ```graphql
@@ -112,7 +112,7 @@ You can log in a user via a [3rd party authentication](https://docs.parseplatfor
 // Header
 {
   "X-Parse-Application-Id": "APPLICATION_ID",
-  "X-Parse-Master-Key": "MASTER_KEY" // optional
+  "X-Parse-Master-Key": "MASTER_KEY" // (optional)
 }
 ```
 ```graphql


### PR DESCRIPTION
A minor change that matches the formatting of these code sections with the rest of those found in the docs.