### PR TITLE
afterLiveQueryEvent Triggers

### DIFF
--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -636,6 +636,51 @@ Parse.Cloud.beforeSubscribe('MyObject', request => {
 });
 ```
 
+##afterLiveQueryEvent
+
+*Available only on parse-server cloud code starting 4.-.-*
+
+In some cases you may want to manipulate the results of a Live Query before they are sent to the client. You can do so with the `afterLiveQueryEvent` trigger.
+
+### Examples
+
+```javascript
+// Changing values on object and original
+Parse.Cloud.afterLiveQueryEvent('MyObject', request => {
+  const object = request.object;
+  object.set('name', '***');
+
+  const original = request.original;
+  original.set('name', 'yolo');
+});
+
+// Including an object on LiveQuery event, on update only.
+Parse.Cloud.afterLiveQueryEvent('MyObject', async request => {
+  if (request.event != 'update) {
+    request.sendEvent = false;
+    return;
+  }
+  const object = request.object;
+  const pointer = object.get('child');
+  await pointer.fetch();
+});
+
+// Prevent LiveQuery trigger unless  'foo' is modified
+Parse.Cloud.afterLiveQueryEvent('MyObject', request => {
+  const object = request.object;
+  const original = request.original;
+  if (!original) {
+    return;
+  }
+  if (object.get('foo') != original.get('foo')) {
+    req.sendEvent = false;
+  }
+});
+```
+
+### Some considerations to be aware of
+- Live Query events won't trigger until the `afterLiveQueryEvent` trigger has completed. Make sure any functions inside the trigger are efficient and restrictive to prevent bottlenecks.
+
 ## onLiveQueryEvent
 
 *Available only on parse-server cloud code starting 2.6.2*

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -662,7 +662,7 @@ Parse.Cloud.afterLiveQueryEvent('MyObject', (request) => {
     return;
   }
   if (object.get('foo') != original.get('foo')) {
-    req.sendEvent = false;
+    request.sendEvent = false;
   }
 });
 
@@ -679,7 +679,7 @@ Parse.Cloud.afterLiveQueryEvent('MyObject', async (request) => {
 
 //Extend matchesQuery functionality to LiveQuery
 Parse.Cloud.afterLiveQueryEvent('MyObject', async (request) => {
-  if (req.event != "Create") {
+  if (request.event != "Create") {
     return;
   }
   const query = request.object.relation('children').query();

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -636,7 +636,7 @@ Parse.Cloud.beforeSubscribe('MyObject', request => {
 });
 ```
 
-##afterLiveQueryEvent
+## afterLiveQueryEvent
 
 *Available only on parse-server cloud code starting 4.-.-*
 

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -654,19 +654,8 @@ Parse.Cloud.afterLiveQueryEvent('MyObject', request => {
   original.set('name', 'yolo');
 });
 
-// Including an object on LiveQuery event, on update only.
-Parse.Cloud.afterLiveQueryEvent('MyObject', async request => {
-  if (request.event != 'update) {
-    request.sendEvent = false;
-    return;
-  }
-  const object = request.object;
-  const pointer = object.get('child');
-  await pointer.fetch();
-});
-
 // Prevent LiveQuery trigger unless  'foo' is modified
-Parse.Cloud.afterLiveQueryEvent('MyObject', request => {
+Parse.Cloud.afterLiveQueryEvent('MyObject', (request) => {
   const object = request.object;
   const original = request.original;
   if (!original) {
@@ -674,6 +663,30 @@ Parse.Cloud.afterLiveQueryEvent('MyObject', request => {
   }
   if (object.get('foo') != original.get('foo')) {
     req.sendEvent = false;
+  }
+});
+
+// Including an object on LiveQuery event, on update only.
+Parse.Cloud.afterLiveQueryEvent('MyObject', async (request) => {
+  if (request.event != "update") {
+    request.sendEvent = false;
+    return;
+  }
+  const object = request.object;
+  const pointer = object.get("child");
+  await pointer.fetch();
+});
+
+//Extend matchesQuery functionality to LiveQuery
+Parse.Cloud.afterLiveQueryEvent('MyObject', async (request) => {
+  if (req.event != "Create") {
+    return;
+  }
+  const query = request.object.relation('children').query();
+  query.equalTo('foo','bart');
+  const first = await query.first();
+  if (!first)  {
+    request.sendEvent = false;
   }
 });
 ```

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -638,7 +638,7 @@ Parse.Cloud.beforeSubscribe('MyObject', request => {
 
 ## afterLiveQueryEvent
 
-*Available only on parse-server cloud code starting 4.-.-*
+*Available only on parse-server cloud code starting 4.4.0*
 
 In some cases you may want to manipulate the results of a Live Query before they are sent to the client. You can do so with the `afterLiveQueryEvent` trigger.
 

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -665,7 +665,11 @@ Parse.Cloud.afterLiveQueryEvent('MyObject', (request) => {
     request.sendEvent = false;
   }
 });
+```
 
+By default, ParseLiveQuery does not perform queries that require additional database operations. This is to keep your Parse Server as fast and effient as possible. If you require this functionality, you can perform these in `afterLiveQueryEvent`.  
+
+```javascript
 // Including an object on LiveQuery event, on update only.
 Parse.Cloud.afterLiveQueryEvent('MyObject', async (request) => {
   if (request.event != "update") {

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -654,7 +654,7 @@ Parse.Cloud.afterLiveQueryEvent('MyObject', request => {
   original.set('name', 'yolo');
 });
 
-// Prevent LiveQuery trigger unless  'foo' is modified
+// Prevent LiveQuery trigger unless 'foo' is modified
 Parse.Cloud.afterLiveQueryEvent('MyObject', (request) => {
   const object = request.object;
   const original = request.original;
@@ -677,7 +677,7 @@ Parse.Cloud.afterLiveQueryEvent('MyObject', async (request) => {
   await pointer.fetch();
 });
 
-//Extend matchesQuery functionality to LiveQuery
+// Extend matchesQuery functionality to LiveQuery
 Parse.Cloud.afterLiveQueryEvent('MyObject', async (request) => {
   if (request.event != "Create") {
     return;


### PR DESCRIPTION
Docs for [afterLiveQueryEvent](https://github.com/parse-community/parse-server/pull/6859). Awaiting the release of newest Parse Server version and possible merging of [this PR](https://github.com/parse-community/parse-server/pull/6951).

@TomWFox would you see any benefit in adding a bit of text / examples around the LQ Triggers (beforeConnect / beforeSubscribe) in the [LiveQuery security section](https://docs.parseplatform.org/parse-server/guide/#security-with-livequery)?

Also, the [Parse Server Guide](https://docs.parseplatform.org/parse-server/guide/#getting-started) has very little on enforcing security / validation in cloud code compared to the [platform guides](https://docs.parseplatform.org/js/guide/#security). Do you think it would be worth reiterating here as this is where I think most users would get started with Parse?