### PR TITLE
Copy to Clipboard

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,5 +19,38 @@
     gtag('js', new Date());
 
     gtag('config', 'UA-102564547-3');
+
+    window.onload = function () {
+      function copyToClipboard() {
+        const textId = this.id.replace('btn','code')
+        const copyText = document.getElementById(textId);
+        const text = copyText.textContent || copyText.innerText;
+
+        const input = document.createElement('textarea');
+        input.innerHTML = text;
+        document.body.appendChild(input);
+        input.select();
+        input.setSelectionRange(0, 99999);
+        document.execCommand('copy');
+        document.body.removeChild(input);
+
+        this.innerHTML = '✔️';
+        setTimeout(() => {
+          this.innerHTML = '📋';
+        },2000)
+      }
+    let codes = document.querySelectorAll('.highlight > pre > code');
+    let count = 0;
+    codes.forEach((code) => {
+      code.setAttribute("id", `code-${count}`);
+      const btn = document.createElement('button');
+      btn.innerHTML = "📋";
+      btn.className = "btn-copy";
+      btn.setAttribute("id", `btn-${count}`);
+      btn.addEventListener("click",copyToClipboard);
+      code.before(btn);
+      count++;
+    });
+   }
   </script>
 </html>

--- a/css/lib/docs/views/_detail.scss
+++ b/css/lib/docs/views/_detail.scss
@@ -152,6 +152,16 @@
         }
     }
 
+    .highlight {
+        position: relative;
+    }
+    .btn-copy {
+        position: absolute;
+        right: 10px;
+        background: none;
+        border: none;
+    }
+
     .toggles{
         text-align: right;
         padding-top: 15px;


### PR DESCRIPTION
This PR closes #598, by adding a clipboard button to all code snippets.

Pressing this button will load the snippet into the clipboard, which then can be pasted into prefered IDE.

<img width="620" alt="Screen Shot 2020-11-16 at 10 38 29 pm" src="https://user-images.githubusercontent.com/4974769/99248655-e8a28780-285c-11eb-971c-c4228a027bdd.png">

And then after pressing the clipboard icon:

<img width="698" alt="Screen Shot 2020-11-16 at 10 39 02 pm" src="https://user-images.githubusercontent.com/4974769/99248713-007a0b80-285d-11eb-9081-c3dc9679889d.png">
