### PR TITLE
Update objects.md

### DIFF
--- a/_includes/js/objects.md
+++ b/_includes/js/objects.md
@@ -249,6 +249,12 @@ var playerName = gameScore.get("playerName");
 var cheatMode = gameScore.get("cheatMode");
 ```
 
+Alternatively, the `attributes` property of the `Parse.Object` can be treated as a Javascript object, and even destructured. 
+
+```javascript
+var { score, playerName, cheatMode } = result.attributes;
+```
+
 The four special reserved values are provided as properties and cannot be retrieved using the 'get' method nor modified with the 'set' method:
 
 ```javascript

--- a/_includes/js/objects.md
+++ b/_includes/js/objects.md
@@ -252,7 +252,7 @@ var cheatMode = gameScore.get("cheatMode");
 Alternatively, the `attributes` property of the `Parse.Object` can be treated as a Javascript object, and even destructured. 
 
 ```javascript
-var { score, playerName, cheatMode } = result.attributes;
+const { score, playerName, cheatMode } = result.attributes;
 ```
 
 The four special reserved values are provided as properties and cannot be retrieved using the 'get' method nor modified with the 'set' method:


### PR DESCRIPTION
According to the docs, when using Parse.Query, we can only access the fields of the returned Object by using `get('fieldName')`, which seems to be very redundant and prone to errors (using strings to get the fields). In Firebase, there is a method to get all the data on a retrieved object : `.data()`. I haven't seen this feature in Parse.

[@burhanyilmaz ](https://github.com/burhanyilmaz/) found out about a property when getting the query result called `attributes`. It seems to be an object that we can destructure and directly get all the fields of the Parse Object. For example :

const query = Parse.Query('Movie');
const result = await query.first();
const { title, price } = result.attributes;

There is only a slight reference to it in the docs : https://parseplatform.org/Parse-SDK-JS/api/master/Parse.Object.html under Members, only with the description Prototype getters/setters.

It also seems that the `get()` method simply returns the `attributes[fieldName]`. I think we can expose the `attributes` property to simplify code, get multiple fields at once, and make it easier to create an interface in Typescript for a `Parse.Object`.

Thanks
