### PR TITLE
Fix casing for afterLiveQueryEvent

### DIFF
--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -815,7 +815,7 @@ Parse.Cloud.afterLiveQueryEvent('MyObject', async (request) => {
 
 // Extend matchesQuery functionality to LiveQuery
 Parse.Cloud.afterLiveQueryEvent('MyObject', async (request) => {
-  if (request.event != "Create") {
+  if (request.event != "create") {
     return;
   }
   const query = request.object.relation('children').query();


### PR DESCRIPTION
Pending next release, `request.event` on `afterLiveQueryEvent` will be lowercase for consistency with the SDKs.

It's also worth noting that the example code in the docs won't work for the current parse server version as `Update` has a capitalised "U"

`if (request.event != "update") {`

Should we mention that this change is upcoming?