### PR TITLE
Mention enableLocalDataStore usage with config builder

### DIFF
--- a/_includes/android/local-datastore.md
+++ b/_includes/android/local-datastore.md
@@ -17,6 +17,16 @@ public class App extends Application {
 }
 ```
 
+If you use a `Parse.Configuration.Builder`, enable it there instead:
+
+```java
+Parse.initialize(new Parse.Configuration.Builder(context)
+  .server(...)
+  .applicationId(...)
+  .enableLocalDataStore()
+  .build());
+```
+
 There are a couple of side effects of enabling the local datastore that you should be aware of. When enabled, there will only be one instance of any given `ParseObject`. For example, imagine you have an instance of the `"GameScore"` class with an `objectId` of `"xWMyZ4YEGZ"`, and then you issue a `ParseQuery` for all instances of `"GameScore"` with that `objectId`. The result will be the same instance of the object you already have in memory.
 
 Another side effect is that the current user and current installation will be stored in the local datastore, so you can persist unsaved changes to these objects between runs of your app using the methods below.


### PR DESCRIPTION
I recently ran into an issue where the local data store was not being enabled, because I used the example in the documentation. I found the solution in a Github issue (https://github.com/parse-community/Parse-SDK-Android/issues/398#issuecomment-184776930) and I'm updating the docs to reflect that.