### PR TITLE
Add afterFind Considerations

### DIFF
--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -673,7 +673,7 @@ Parse.Cloud.afterFind(Parse.User, async (request) => {
 ```
 
 ### Some considerations to be aware of
-- If you use the `masterKey` to fetch a pointer in an `afterFind` trigger, it will be sent in full to the client. Be sure to check that the returned objects and pointers are secured prior to returning to the client.
+- If you use the `masterKey` to fetch a pointer in an `afterFind` trigger, it will be sent in full to the client. Prior to returning to the client, be sure to check that the returned objects and pointers do not contain information that the client should not be able to access
 
 # Session Triggers
 

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -672,6 +672,9 @@ Parse.Cloud.afterFind(Parse.User, async (request) => {
 })
 ```
 
+### Some considerations to be aware of
+- If you use the `masterKey` to fetch a pointer in an `afterFind` trigger, it will be sent in full to the client. Be sure to check that the returned objects and pointers are secured prior to returning to the client.
+
 # Session Triggers
 
 ## beforeLogin


### PR DESCRIPTION
Adds considerations for using `fetch` in an `afterFind` trigger.