### PR TITLE
Removed MongoRocks from the parse-server guide

### DIFF
--- a/_includes/parse-server/database.md
+++ b/_includes/parse-server/database.md
@@ -17,8 +17,6 @@ If this is your first time setting up a MongoDB instance, we recommend a Databas
 
 When using MongoDB with your Parse app, you need to manage your indexes yourself. You will also need to size up your database as your data grows.
 
-If you are planning to run MongoDB on your own infrastructure, we highly recommend using the [RocksDB Storage Engine](#using-mongodb--rocksdb).
-
 In order to allow for better scaling of your data layer, it is possible to direct queries to a mongodb secondary for read operations.  See: [Mongo Read Preference](#using-mongodb-read-preference).
 
 ## Postgres

--- a/parse-server.md
+++ b/parse-server.md
@@ -20,7 +20,6 @@ sections:
 - "parse-server/cache-adapters.md"
 - "parse-server/live-query.md"
 - "parse-server/third-party-auth.md"
-- "parse-server/MongoRocks.md"
 - "parse-server/MongoReadPreference.md"
 - "parse-server/development.md"
 ---


### PR DESCRIPTION
Issue #718 and from [here](https://community.parseplatform.org/t/using-mongodb-with-rocksdb/1543/6)

closes #718 