### PR TITLE
add s3 adapter examples for Linode and Backblaze

### DIFF
--- a/_includes/parse-server/file-adapters.md
+++ b/_includes/parse-server/file-adapters.md
@@ -175,80 +175,6 @@ var api = new ParseServer({
 
 Don't forget to change **S3_ACCESS_KEY**, **S3_SECRET_KEY** and **S3_BUCKET** to their correct value.
 
-##### S3Adapter constructor options
-
-```js
-new S3Adapter(accessKey, secretKey, bucket, options)
-```
-
-| Parameter | Description | Notes |
-| --------- | ----------- | ----- |
-| accessKey    | The AWS access key for a user that has the required permissions | Required. |
-| secretKey    | The AWS secret key for the user | Required. |
-| bucket       | The name of your S3 bucket. | Required. |
-| options      | JavaScript object (map) that can contain: | |
-| region       | Key in `options`. Set the AWS region to connect to. | Optional. Default: `us-east-1` |
-| bucketPrefix | Key in `options`. Set to create all the files with the specified prefix added to the filename. Can be used to put all the files for an app in a folder with 'folder/'. | Optional. Default: `null` |
-| directAccess | Key in `options`. Controls whether reads are going directly to S3 or proxied through your Parse Server. If set to true, files will be made publicly accessible, and reads will not be proxied. | Optional. Default: `false` |
-| baseUrl | Key in `options`. The base URL the file adapter uses to determine the file location for direct access. | Optional. Default: `null`. To be used when `directAccess=true`. When set the file adapter returns a file URL in format `baseUrl/bucketPrefix` + `filename`. Example for `baseUrl='http://domain.com/folder'` and `bucketPrefix='prefix_'` the returned file location is  `http://domain.com/folder/prefix_file.txt`. |
-| baseUrlDirect | Key in `options`. Is `true` if the file adapter should ignore the bucket prefix when determining the file location for direct access. | Optional. Default: `false`. To be used when `directAccess=true` and `baseUrl` is set. When set to `true`, the file adapter returns a file URL in format `baseUrl/filename`. Example for `baseUrl='http://domain.com/folder'` and `baseUrlDirect=true` the returned file location is `http://domain.com/folder/file.txt`. |
-| globalCacheControl | Key in `options`. The `Cache-Control` http header to set in the file request. | Optional. Default: `null`. Example: `public, max-age=86400` for 24 hrs caching. More info [here](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1). |
-
-
-## Configuring `GCSAdapter`
-
-Unlike the S3 adapter, you must create a new Cloud Storage bucket, as this is not created automatically. See the Google Cloud guide on [Authentication](https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/master/guides/authentication) for more details.
-
-To generate a private key in the Cloud Platform Console follow [these instructions](https://cloud.google.com/storage/docs/authentication#generating-a-private-key).
-
-### Installation
-
-Starting 2.2.6, GCS Adapter is not provided by default by parse-server. To install run:
-
-```
-npm install --save parse-server-gcs-adapter
-```
-
-### Configuration options
-
-Writing to your Google Cloud Storage bucket from Parse Server is as simple as configuring and using the GCS files adapter.
-
-#### Using environment variables
-
-You can use Google Cloud Storage to host your static files by setting the following environment variables:
-
-| Variable Name | Description | Notes |
-| ------------- | ----------- | ----- |
-| PARSE_SERVER_FILES_ADAPTER  | Set this variable to 'parse-server-gcs-adapter'. | Required. |
-| GCP_PROJECT_ID              | The project ID from the Google Developer's Console. | Required. |
-| GCP_KEYFILE_PATH            | Full path to the a .json, .pem, or .p12 key downloaded from the Google Developers Console. | Required. |
-| GCS_BUCKET                  | The name of your GCS bucket. | Required. |
-| GCS_BUCKET_PREFIX           | Create all the files with the specified prefix added to the filename. Can be used to put all the files for an app in a folder with 'folder/'. | Optional. |
-| GCS_DIRECT_ACCESS           | Whether reads are going directly to GCS or proxied through your Parse Server. | Optional. Default: false |
-
-#### Passing as options
-
-If you're using Node.js/Express:
-
-```javascript
-...
-var GCSAdapter = require('parse-server-gcs-adapter');
-
-var api = new ParseServer({
-  databaseURI: databaseUri || 'mongodb://localhost:27017/dev',
-  appId: process.env.APP_ID || 'APPLICATION_ID',
-  masterKey: process.env.MASTER_KEY || 'MASTER_KEY',
-  ...
-  filesAdapter: new GCSAdapter(
-    "GCP_PROJECT_ID",
-    "GCP_KEYFILE_PATH",
-    "GCS_BUCKET",
-    {directAccess: true}
-  ),
-  ...
-});
-```
-
 ##### S3Adapter configuration for Digital Ocean Spaces
 
 Spaces is an S3 equivalent prodivided by Digital Ocean. It's use the same api as S3 so you can use it with the S3 Adapter.
@@ -334,6 +260,80 @@ const s3Adapter = new S3Adapter({
     accessKeyId: process.env.S3_ACCESS_KEY,
     secretAccessKey: process.env.S3_SECRET_KEY
   },
+});
+```
+
+##### S3Adapter constructor options
+
+```js
+new S3Adapter(accessKey, secretKey, bucket, options)
+```
+
+| Parameter | Description | Notes |
+| --------- | ----------- | ----- |
+| accessKey    | The AWS access key for a user that has the required permissions | Required. |
+| secretKey    | The AWS secret key for the user | Required. |
+| bucket       | The name of your S3 bucket. | Required. |
+| options      | JavaScript object (map) that can contain: | |
+| region       | Key in `options`. Set the AWS region to connect to. | Optional. Default: `us-east-1` |
+| bucketPrefix | Key in `options`. Set to create all the files with the specified prefix added to the filename. Can be used to put all the files for an app in a folder with 'folder/'. | Optional. Default: `null` |
+| directAccess | Key in `options`. Controls whether reads are going directly to S3 or proxied through your Parse Server. If set to true, files will be made publicly accessible, and reads will not be proxied. | Optional. Default: `false` |
+| baseUrl | Key in `options`. The base URL the file adapter uses to determine the file location for direct access. | Optional. Default: `null`. To be used when `directAccess=true`. When set the file adapter returns a file URL in format `baseUrl/bucketPrefix` + `filename`. Example for `baseUrl='http://domain.com/folder'` and `bucketPrefix='prefix_'` the returned file location is  `http://domain.com/folder/prefix_file.txt`. |
+| baseUrlDirect | Key in `options`. Is `true` if the file adapter should ignore the bucket prefix when determining the file location for direct access. | Optional. Default: `false`. To be used when `directAccess=true` and `baseUrl` is set. When set to `true`, the file adapter returns a file URL in format `baseUrl/filename`. Example for `baseUrl='http://domain.com/folder'` and `baseUrlDirect=true` the returned file location is `http://domain.com/folder/file.txt`. |
+| globalCacheControl | Key in `options`. The `Cache-Control` http header to set in the file request. | Optional. Default: `null`. Example: `public, max-age=86400` for 24 hrs caching. More info [here](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1). |
+
+
+## Configuring `GCSAdapter`
+
+Unlike the S3 adapter, you must create a new Cloud Storage bucket, as this is not created automatically. See the Google Cloud guide on [Authentication](https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/master/guides/authentication) for more details.
+
+To generate a private key in the Cloud Platform Console follow [these instructions](https://cloud.google.com/storage/docs/authentication#generating-a-private-key).
+
+### Installation
+
+Starting 2.2.6, GCS Adapter is not provided by default by parse-server. To install run:
+
+```
+npm install --save parse-server-gcs-adapter
+```
+
+### Configuration options
+
+Writing to your Google Cloud Storage bucket from Parse Server is as simple as configuring and using the GCS files adapter.
+
+#### Using environment variables
+
+You can use Google Cloud Storage to host your static files by setting the following environment variables:
+
+| Variable Name | Description | Notes |
+| ------------- | ----------- | ----- |
+| PARSE_SERVER_FILES_ADAPTER  | Set this variable to 'parse-server-gcs-adapter'. | Required. |
+| GCP_PROJECT_ID              | The project ID from the Google Developer's Console. | Required. |
+| GCP_KEYFILE_PATH            | Full path to the a .json, .pem, or .p12 key downloaded from the Google Developers Console. | Required. |
+| GCS_BUCKET                  | The name of your GCS bucket. | Required. |
+| GCS_BUCKET_PREFIX           | Create all the files with the specified prefix added to the filename. Can be used to put all the files for an app in a folder with 'folder/'. | Optional. |
+| GCS_DIRECT_ACCESS           | Whether reads are going directly to GCS or proxied through your Parse Server. | Optional. Default: false |
+
+#### Passing as options
+
+If you're using Node.js/Express:
+
+```javascript
+...
+var GCSAdapter = require('parse-server-gcs-adapter');
+
+var api = new ParseServer({
+  databaseURI: databaseUri || 'mongodb://localhost:27017/dev',
+  appId: process.env.APP_ID || 'APPLICATION_ID',
+  masterKey: process.env.MASTER_KEY || 'MASTER_KEY',
+  ...
+  filesAdapter: new GCSAdapter(
+    "GCP_PROJECT_ID",
+    "GCP_KEYFILE_PATH",
+    "GCS_BUCKET",
+    {directAccess: true}
+  ),
+  ...
 });
 ```
 

--- a/_includes/parse-server/file-adapters.md
+++ b/_includes/parse-server/file-adapters.md
@@ -216,7 +216,7 @@ var api = new ParseServer({
 
 ##### S3Adapter configuration for Linode Object Storage
 
-Object Storage is an s3-compoatible storage service from Linode. We can configure our S3Adapter to use Linode's service. Please refer to [this guide](https://www.linode.com/docs/guides/how-to-use-object-storage/) for more details on Linode's API.
+Object Storage is an s3-compatible storage service from Linode. We can configure our S3Adapter to use Linode's service. Please refer to [this guide](https://www.linode.com/docs/guides/how-to-use-object-storage/) for more details on Linode's API.
 
 ```js
 const S3Adapter = require("parse-server").S3Adapter;
@@ -230,7 +230,7 @@ const s3Options = {
   directAccess: false,
   s3overrides: {
     accessKeyId: process.env.PARSE_S3_ACCESS_KEY, // this is generated when you create your bucket
-    secretAccessKey: process.env.PARSE_S3_SECRET_KEY, this is generated when you create your bucket
+    secretAccessKey: process.env.PARSE_S3_SECRET_KEY, // this is generated when you create your bucket
     endpoint: storageEndpoint,
   },
 };

--- a/_includes/parse-server/file-adapters.md
+++ b/_includes/parse-server/file-adapters.md
@@ -175,9 +175,9 @@ var api = new ParseServer({
 
 Don't forget to change **S3_ACCESS_KEY**, **S3_SECRET_KEY** and **S3_BUCKET** to their correct value.
 
-### Options for Digital Ocean Spaces
+### Digital Ocean Spaces
 
-Spaces is an S3-compatible prodivided by Digital Ocean. It's use the same api as S3 so you can use it with the S3 Adapter.
+Spaces is an S3-compatible provided by Digital Ocean. It's use the same api as S3 so you can use it with the S3 Adapter.
 You just need to change the AWS Endpoint to point to your Spaces endpoint.
 
 ```javascript
@@ -196,7 +196,7 @@ const s3Options = {
 };
 ```
 
-### Options for Linode Object Storage
+### Linode Object Storage
 
 Object Storage is an S3-compatible storage service from Linode. We can configure our S3Adapter to use Linode's service. Please refer to [this guide](https://www.linode.com/docs/guides/how-to-use-object-storage/) for more details on Linode's API.
 
@@ -214,7 +214,7 @@ const s3Options = {
 };
 ```
 
-### Options for Backblaze
+### Backblaze
 
 We also can use Backblaze's S3-compatible [B2 Cloud Storage](https://www.backblaze.com/b2/cloud-storage.html) as a storage adapter. Here is a working configuration for B2:
 

--- a/_includes/parse-server/file-adapters.md
+++ b/_includes/parse-server/file-adapters.md
@@ -288,6 +288,54 @@ var api = new ParseServer({
 });
 ```
 
+##### S3Adapter configuration for Linode Object Storage
+
+Object Storage is an s3-compoatible storage service from Linode. We can configure our S3Adapter to use Linode's service. Please refer to [this guide](https://www.linode.com/docs/guides/how-to-use-object-storage/) for more details on Linode's API.
+
+```js
+const S3Adapter = require("parse-server").S3Adapter;
+const AWS = require("aws-sdk");
+
+const storageEndpoint = new AWS.Endpoint(process.env.PARSE_S3_ENDPOINT); // regionName.linodeobjects.com
+const s3Options = {
+  bucket: process.env.PARSE_S3_BUCKET_NAME, // bucket's name
+  baseUrl: process.env.PARSE_S3_BASE_URL, // something like: https://mybucket.regionName.linodeobjects.com
+  region: process.env.PARSE_S3_REGION, // some possible values: eu-central-1 or us-east-1
+  directAccess: false,
+  s3overrides: {
+    accessKeyId: process.env.PARSE_S3_ACCESS_KEY, // this is generated when you create your bucket
+    secretAccessKey: process.env.PARSE_S3_SECRET_KEY, this is generated when you create your bucket
+    endpoint: storageEndpoint,
+  },
+};
+const adapter = new S3Adapter(s3Options);
+const api = new ParseServer({
+  ...otherParseOptions,
+  filesAdapter: adapter,
+});
+```
+
+
+##### S3Adapter configuration for Backblaze
+
+We also can use Backblaze's [B2 Cloud Storage](https://www.backblaze.com/b2/cloud-storage.html) as a storage adapter. Here is a working configuration for B2:
+
+```js
+const s3Adapter = new S3Adapter({
+  bucket: process.env.S3_BUCKET,
+  directAccess: true,
+  baseUrl: process.env.S3_BASE_URL, // taken from BackBlaze, normally https://BUCKET.s3.REGION.backblazeb2.com
+  baseUrlDirect: false,
+  signatureVersion: 'v4',
+  globalCacheControl: 'public, max-age=86400',
+  region: 'us-west-000',
+  s3overrides: {
+    endpoint: process.env.S3_ENDPOINT, // check backblaze bucket endpoint
+    accessKeyId: process.env.S3_ACCESS_KEY,
+    secretAccessKey: process.env.S3_SECRET_KEY
+  },
+});
+```
 
 ##### GCSAdapter constructor options
 

--- a/_includes/parse-server/file-adapters.md
+++ b/_includes/parse-server/file-adapters.md
@@ -204,8 +204,6 @@ const s3Options = {
   bucket: "SPACES_BUCKET_NAME",
   baseUrl: "SPACES_BASE_URL",
   region: "SPACES_REGION",
-  directAccess: true,
-  globalCacheControl: "public, max-age=31536000",
   bucketPrefix: "SPACES_BUCKET_PREFIX",
   s3overrides: {
     accessKeyId: "SPACES_ACCESS_KEY",
@@ -224,7 +222,6 @@ const s3Options = {
   bucket: "S3_BUCKET_NAME",
   baseUrl: "S3_BASE_URL", // https://myBucket.myRegion.linodeobjects.com
   region: "S3_REGION", // possible values: eu-central-1 or us-east-1
-  directAccess: false,
   s3overrides: {
     accessKeyId: "S3_ACCESS_KEY", // bucket access key
     secretAccessKey: "S3_SECRET_KEY", // bucket secret key
@@ -240,11 +237,8 @@ const s3Options = {
 ```js
 const s3Options = {
   bucket: "S3_BUCKET",
-  directAccess: true,
   baseUrl: "S3_BASE_URL", // taken from BackBlaze, normally https://BUCKET.s3.REGION.backblazeb2.com
-  baseUrlDirect: false,
   signatureVersion: 'v4',
-  globalCacheControl: 'public, max-age=86400',
   region: 'us-west-000',
   s3overrides: {
     endpoint: "S3_ENDPOINT", // check backblaze bucket endpoint

--- a/_includes/parse-server/file-adapters.md
+++ b/_includes/parse-server/file-adapters.md
@@ -198,7 +198,7 @@ const s3Options = {
 
 ### Options for Linode Object Storage
 
-Object Storage is an s3-compatible storage service from Linode. We can configure our S3Adapter to use Linode's service. Please refer to [this guide](https://www.linode.com/docs/guides/how-to-use-object-storage/) for more details on Linode's API.
+Object Storage is an S3-compatible storage service from Linode. We can configure our S3Adapter to use Linode's service. Please refer to [this guide](https://www.linode.com/docs/guides/how-to-use-object-storage/) for more details on Linode's API.
 
 ```js
 const s3Options = {
@@ -216,7 +216,7 @@ const s3Options = {
 
 ### Options for Backblaze
 
-We also can use Backblaze's s3-compatible [B2 Cloud Storage](https://www.backblaze.com/b2/cloud-storage.html) as a storage adapter. Here is a working configuration for B2:
+We also can use Backblaze's S3-compatible [B2 Cloud Storage](https://www.backblaze.com/b2/cloud-storage.html) as a storage adapter. Here is a working configuration for B2:
 
 ```js
 const s3Options = {

--- a/_includes/parse-server/file-adapters.md
+++ b/_includes/parse-server/file-adapters.md
@@ -175,67 +175,7 @@ var api = new ParseServer({
 
 Don't forget to change **S3_ACCESS_KEY**, **S3_SECRET_KEY** and **S3_BUCKET** to their correct value.
 
-### Digital Ocean Spaces
-
-Spaces is an S3-compatible provided by Digital Ocean. It's use the same api as S3 so you can use it with the S3 Adapter.
-You just need to change the AWS Endpoint to point to your Spaces endpoint.
-
-```javascript
-const s3Options = {
-  bucket: "SPACES_BUCKET_NAME",
-  baseUrl: "SPACES_BASE_URL",
-  region: "SPACES_REGION",
-  directAccess: true,
-  globalCacheControl: "public, max-age=31536000",
-  bucketPrefix: "SPACES_BUCKET_PREFIX",
-  s3overrides: {
-    accessKeyId: "SPACES_ACCESS_KEY",
-    secretAccessKey: "SPACES_SECRET_KEY",
-    endpoint: 'SPACES_ENDPOINT'
-  }
-};
-```
-
-### Linode Object Storage
-
-Object Storage is an S3-compatible storage service from Linode. We can configure our S3Adapter to use Linode's service. Please refer to [this guide](https://www.linode.com/docs/guides/how-to-use-object-storage/) for more details on Linode's API.
-
-```js
-const s3Options = {
-  bucket: "S3_BUCKET_NAME",
-  baseUrl: "S3_BASE_URL", // https://myBucket.myRegion.linodeobjects.com
-  region: "S3_REGION", // possible values: eu-central-1 or us-east-1
-  directAccess: false,
-  s3overrides: {
-    accessKeyId: "S3_ACCESS_KEY", // bucket access key
-    secretAccessKey: "S3_SECRET_KEY", // bucket secret key
-    endpoint: "S3_ENDPOINT", // regionName.linodeobjects.com
-  },
-};
-```
-
-### Backblaze
-
-We also can use Backblaze's S3-compatible [B2 Cloud Storage](https://www.backblaze.com/b2/cloud-storage.html) as a storage adapter. Here is a working configuration for B2:
-
-```js
-const s3Options = {
-  bucket: "S3_BUCKET",
-  directAccess: true,
-  baseUrl: "S3_BASE_URL", // taken from BackBlaze, normally https://BUCKET.s3.REGION.backblazeb2.com
-  baseUrlDirect: false,
-  signatureVersion: 'v4',
-  globalCacheControl: 'public, max-age=86400',
-  region: 'us-west-000',
-  s3overrides: {
-    endpoint: "S3_ENDPOINT", // check backblaze bucket endpoint
-    accessKeyId: "S3_ACCESS_KEY",
-    secretAccessKey: "S3_SECRET_KEY"
-  },
-};
-```
-
-#### S3Adapter constructor options
+### Adapter Options
 
 ```js
 new S3Adapter(accessKey, secretKey, bucket, options)
@@ -253,6 +193,66 @@ new S3Adapter(accessKey, secretKey, bucket, options)
 | baseUrl | Key in `options`. The base URL the file adapter uses to determine the file location for direct access. | Optional. Default: `null`. To be used when `directAccess=true`. When set the file adapter returns a file URL in format `baseUrl/bucketPrefix` + `filename`. Example for `baseUrl='http://domain.com/folder'` and `bucketPrefix='prefix_'` the returned file location is  `http://domain.com/folder/prefix_file.txt`. |
 | baseUrlDirect | Key in `options`. Is `true` if the file adapter should ignore the bucket prefix when determining the file location for direct access. | Optional. Default: `false`. To be used when `directAccess=true` and `baseUrl` is set. When set to `true`, the file adapter returns a file URL in format `baseUrl/filename`. Example for `baseUrl='http://domain.com/folder'` and `baseUrlDirect=true` the returned file location is `http://domain.com/folder/file.txt`. |
 | globalCacheControl | Key in `options`. The `Cache-Control` http header to set in the file request. | Optional. Default: `null`. Example: `public, max-age=86400` for 24 hrs caching. More info [here](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1). |
+
+### S3-compatible Services
+#### Digital Ocean Spaces
+
+[Digital Ocean Spaces](https://try.digitalocean.com/cloud-storage) is an S3-compatible storage service in the cloud. See their [documentation](https://docs.digitalocean.com/products/spaces/) for more details.
+
+```javascript
+const s3Options = {
+  bucket: "SPACES_BUCKET_NAME",
+  baseUrl: "SPACES_BASE_URL",
+  region: "SPACES_REGION",
+  directAccess: true,
+  globalCacheControl: "public, max-age=31536000",
+  bucketPrefix: "SPACES_BUCKET_PREFIX",
+  s3overrides: {
+    accessKeyId: "SPACES_ACCESS_KEY",
+    secretAccessKey: "SPACES_SECRET_KEY",
+    endpoint: 'SPACES_ENDPOINT'
+  }
+};
+```
+
+#### Linode Object Storage
+
+[Linode Object Storage](https://www.linode.com/products/object-storage/) is an S3-compatible storage service in the cloud. See their [documentation](https://www.linode.com/docs/guides/how-to-use-object-storage/) for more details.
+
+```js
+const s3Options = {
+  bucket: "S3_BUCKET_NAME",
+  baseUrl: "S3_BASE_URL", // https://myBucket.myRegion.linodeobjects.com
+  region: "S3_REGION", // possible values: eu-central-1 or us-east-1
+  directAccess: false,
+  s3overrides: {
+    accessKeyId: "S3_ACCESS_KEY", // bucket access key
+    secretAccessKey: "S3_SECRET_KEY", // bucket secret key
+    endpoint: "S3_ENDPOINT", // regionName.linodeobjects.com
+  },
+};
+```
+
+#### Backblaze B2 Cloud Storage
+
+[Backblaze B2 Cloud Storage](https://www.backblaze.com/b2/cloud-storage.html) is an S3-compatible storage service in the cloud. See their [documentation](https://www.backblaze.com/b2/docs/) for more details.
+
+```js
+const s3Options = {
+  bucket: "S3_BUCKET",
+  directAccess: true,
+  baseUrl: "S3_BASE_URL", // taken from BackBlaze, normally https://BUCKET.s3.REGION.backblazeb2.com
+  baseUrlDirect: false,
+  signatureVersion: 'v4',
+  globalCacheControl: 'public, max-age=86400',
+  region: 'us-west-000',
+  s3overrides: {
+    endpoint: "S3_ENDPOINT", // check backblaze bucket endpoint
+    accessKeyId: "S3_ACCESS_KEY",
+    secretAccessKey: "S3_SECRET_KEY"
+  },
+};
+```
 
 
 ## Configuring `GCSAdapter`

--- a/_includes/parse-server/file-adapters.md
+++ b/_includes/parse-server/file-adapters.md
@@ -214,7 +214,6 @@ const s3Options = {
 };
 ```
 
-
 ### Options for Backblaze
 
 We also can use Backblaze's s3-compatible [B2 Cloud Storage](https://www.backblaze.com/b2/cloud-storage.html) as a storage adapter. Here is a working configuration for B2:

--- a/_includes/parse-server/file-adapters.md
+++ b/_includes/parse-server/file-adapters.md
@@ -175,95 +175,68 @@ var api = new ParseServer({
 
 Don't forget to change **S3_ACCESS_KEY**, **S3_SECRET_KEY** and **S3_BUCKET** to their correct value.
 
-##### S3Adapter configuration for Digital Ocean Spaces
+### Options for Digital Ocean Spaces
 
-Spaces is an S3 equivalent prodivided by Digital Ocean. It's use the same api as S3 so you can use it with the S3 Adapter.
+Spaces is an S3-compatible prodivided by Digital Ocean. It's use the same api as S3 so you can use it with the S3 Adapter.
 You just need to change the AWS Endpoint to point to your Spaces endpoint.
 
 ```javascript
-...
-var S3Adapter = require('parse-server').S3Adapter;
-var AWS = require("aws-sdk");
-
-//Set Digital Ocean Spaces EndPoint
-const spacesEndpoint = new AWS.Endpoint(process.env.SPACES_ENDPOINT);
-//Define S3 options
-var s3Options = {
-  bucket: process.env.SPACES_BUCKET_NAME,
-  baseUrl: process.env.SPACES_BASE_URL,
-  region: process.env.SPACES_REGION,
+const s3Options = {
+  bucket: "SPACES_BUCKET_NAME",
+  baseUrl: "SPACES_BASE_URL",
+  region: "SPACES_REGION",
   directAccess: true,
   globalCacheControl: "public, max-age=31536000",
-  bucketPrefix: process.env.SPACES_BUCKET_PREFIX,
+  bucketPrefix: "SPACES_BUCKET_PREFIX",
   s3overrides: {
-    accessKeyId: process.env.SPACES_ACCESS_KEY,
-    secretAccessKey: process.env.SPACES_SECRET_KEY,
-    endpoint: spacesEndpoint
+    accessKeyId: "SPACES_ACCESS_KEY",
+    secretAccessKey: "SPACES_SECRET_KEY",
+    endpoint: 'SPACES_ENDPOINT'
   }
 };
-
-var s3Adapter = new S3Adapter(s3Options);
-
-var api = new ParseServer({
-  databaseURI: databaseUri || 'mongodb://localhost:27017/dev',
-  appId: process.env.APP_ID || 'APPLICATION_ID',
-  masterKey: process.env.MASTER_KEY || 'MASTER_KEY',
-  ...
-  filesAdapter: s3Adapter
-  ...
-});
 ```
 
-##### S3Adapter configuration for Linode Object Storage
+### Options for Linode Object Storage
 
 Object Storage is an s3-compatible storage service from Linode. We can configure our S3Adapter to use Linode's service. Please refer to [this guide](https://www.linode.com/docs/guides/how-to-use-object-storage/) for more details on Linode's API.
 
 ```js
-const S3Adapter = require("parse-server").S3Adapter;
-const AWS = require("aws-sdk");
-
-const storageEndpoint = new AWS.Endpoint(process.env.PARSE_S3_ENDPOINT); // regionName.linodeobjects.com
 const s3Options = {
-  bucket: process.env.PARSE_S3_BUCKET_NAME, // bucket's name
-  baseUrl: process.env.PARSE_S3_BASE_URL, // something like: https://mybucket.regionName.linodeobjects.com
-  region: process.env.PARSE_S3_REGION, // some possible values: eu-central-1 or us-east-1
+  bucket: "S3_BUCKET_NAME",
+  baseUrl: "S3_BASE_URL", // https://myBucket.myRegion.linodeobjects.com
+  region: "S3_REGION", // possible values: eu-central-1 or us-east-1
   directAccess: false,
   s3overrides: {
-    accessKeyId: process.env.PARSE_S3_ACCESS_KEY, // this is generated when you create your bucket
-    secretAccessKey: process.env.PARSE_S3_SECRET_KEY, // this is generated when you create your bucket
-    endpoint: storageEndpoint,
+    accessKeyId: "S3_ACCESS_KEY", // bucket access key
+    secretAccessKey: "S3_SECRET_KEY", // bucket secret key
+    endpoint: "S3_ENDPOINT", // regionName.linodeobjects.com
   },
 };
-const adapter = new S3Adapter(s3Options);
-const api = new ParseServer({
-  ...otherParseOptions,
-  filesAdapter: adapter,
-});
 ```
 
 
-##### S3Adapter configuration for Backblaze
+### Options for Backblaze
 
-We also can use Backblaze's [B2 Cloud Storage](https://www.backblaze.com/b2/cloud-storage.html) as a storage adapter. Here is a working configuration for B2:
+We also can use Backblaze's s3-compatible [B2 Cloud Storage](https://www.backblaze.com/b2/cloud-storage.html) as a storage adapter. Here is a working configuration for B2:
 
 ```js
-const s3Adapter = new S3Adapter({
-  bucket: process.env.S3_BUCKET,
+const s3Options = {
+  bucket: "S3_BUCKET",
   directAccess: true,
-  baseUrl: process.env.S3_BASE_URL, // taken from BackBlaze, normally https://BUCKET.s3.REGION.backblazeb2.com
+  baseUrl: "S3_BASE_URL", // taken from BackBlaze, normally https://BUCKET.s3.REGION.backblazeb2.com
   baseUrlDirect: false,
   signatureVersion: 'v4',
   globalCacheControl: 'public, max-age=86400',
   region: 'us-west-000',
   s3overrides: {
-    endpoint: process.env.S3_ENDPOINT, // check backblaze bucket endpoint
-    accessKeyId: process.env.S3_ACCESS_KEY,
-    secretAccessKey: process.env.S3_SECRET_KEY
+    endpoint: "S3_ENDPOINT", // check backblaze bucket endpoint
+    accessKeyId: "S3_ACCESS_KEY",
+    secretAccessKey: "S3_SECRET_KEY"
   },
-});
+};
 ```
 
-##### S3Adapter constructor options
+#### S3Adapter constructor options
 
 ```js
 new S3Adapter(accessKey, secretKey, bucket, options)


### PR DESCRIPTION
I upated the docs as discussed [here](https://github.com/parse-community/parse-server-s3-adapter/issues/141) and [here](https://github.com/parse-community/parse-server/pull/7300).