### PR TITLE
Need session activation from Parse

### DIFF
--- a/_includes/php/users.md
+++ b/_includes/php/users.md
@@ -88,10 +88,9 @@ Note that this will only send if the account for the email requested has not alr
 
 It would be bothersome if the user had to log in every time they open your app. You can avoid this by using the cached current `ParseUser` object.
 
-By default, whenever you use any signup or login methods, the user will be saved in PHP Session storage (The `$_SESSION` superglobal.)
+By default, whenever you use any signup or login methods, the user will be saved in PHP Session storage, the `$_SESSION` superglobal. When re-initializing the Parse PHP SDK, you may need to instruct PHP to load the stored session data into the `$_SESSION` superglobal using `session_start()` before initializing the Parse PHP SDK to make Parse use persistent storage and continue the previous user session.
 
 ```php
-//Here we need to call session_start() if we want to rerieve the current user
 $currentUser = ParseUser::getCurrentUser();
 if ($currentUser) {
     // do stuff with the user

--- a/_includes/php/users.md
+++ b/_includes/php/users.md
@@ -91,6 +91,7 @@ It would be bothersome if the user had to log in every time they open your app. 
 By default, whenever you use any signup or login methods, the user will be saved in PHP Session storage (The `$_SESSION` superglobal.)
 
 ```php
+//Here we need to call session_start() if we want to rerieve the current user
 $currentUser = ParseUser::getCurrentUser();
 if ($currentUser) {
     // do stuff with the user


### PR DESCRIPTION
After logging in with parseUser, it can be fine if you start session automatically and developers don't need to call PHP session_start() function, or define into the documentation the full use of the session, thanks.