### PR TITLE
Change Markdown comment type from JSON to JSON5 to allow comments

### DIFF
--- a/_includes/cloudcode/cloud-code-advanced.md
+++ b/_includes/cloudcode/cloud-code-advanced.md
@@ -206,7 +206,7 @@ end
 
 Here's an example of the JSON data that would be sent in the request to this webhook:
 
-```json
+```json5
 // Sent to webhook
 {
   "master": false,
@@ -225,14 +225,14 @@ Here's an example of the JSON data that would be sent in the request to this web
 
 This response would indicate a success in the webhook:
 
-```json
+```json5
 // Returned from the webhook on success
 { "success": "Hello World!" }
 ```
 
 This response would indicate an error in the webhook:
 
-```json
+```json5
 // Returned from the webhook on error
 { "error": "Error message >:(" }
 ```
@@ -275,7 +275,7 @@ end
 
 Here's an example of the JSON data that would be sent in the request to this webhook:
 
-```json
+```json5
 // Sent to webhook
 {
   "master": true,
@@ -287,7 +287,7 @@ Here's an example of the JSON data that would be sent in the request to this web
 
 This response would indicate a success in the webhook:
 
-```json
+```json5
 // Returned from the webhook on success
 { "success": "User billed!" }
 ```
@@ -310,7 +310,7 @@ For triggers, the following parameters are sent to your webhook.
 
 To respond to a `beforeSave` request, send a JSON object with the key `error` or `success` set. This is the same as for Cloud functions, but there's an extra capability with `beforeSave` triggers. By returning an error, you will cancel the save request and the object will not be stored on Parse. You can also return a JSON object in this following format to override the values that will be saved for the object:
 
-```json
+```json5
 {
   "className": "AwesomeClass",
   "existingColumn": "sneakyChange",
@@ -348,7 +348,7 @@ end
 
 Here's an example of the JSON data that would be sent in the request to this webhook:
 
-```json
+```json5
 // Sent to webhook
 {
   "master": false,
@@ -419,7 +419,7 @@ end
 
 Here's an example of the JSON data that would be sent in the request to this webhook:
 
-```json
+```json5
 // Sent to webhook
 {
   "master": false,
@@ -485,7 +485,7 @@ end
 
 Here's an example of the JSON data that would be sent in the request to this webhook:
 
-```json
+```json5
 // Sent to webhook
 {
   "master": false,
@@ -509,7 +509,7 @@ Here's an example of the JSON data that would be sent in the request to this web
 
 This response would indicate a success in the webhook:
 
-```json
+```json5
 // Returned from the webhook on success
 { "success": true }
 ```
@@ -554,7 +554,7 @@ end
 
 Here's an example of the JSON data that would be sent in the request to this webhook:
 
-```json
+```json5
 // Sent to webhook
 {
   "master": false,

--- a/_includes/js/objects.md
+++ b/_includes/js/objects.md
@@ -144,9 +144,15 @@ gameScore.save()
 
 After this code runs, you will probably be wondering if anything really happened. To make sure the data was saved, you can look at the Data Browser in your app on Parse. You should see something like this:
 
-```json
-objectId: "xWMyZ4YEGZ", score: 1337, playerName: "Sean Plott", cheatMode: false,
-createdAt:"2011-06-10T18:33:42Z", updatedAt:"2011-06-10T18:33:42Z"
+```json5
+{
+  objectId: "xWMyZ4YEGZ",
+  score: 1337,
+  playerName: "Sean Plott",
+  cheatMode: false,
+  createdAt: "2011-06-10T18:33:42Z",
+  updatedAt: "2011-06-10T18:33:42Z"
+}
 ```
 
 There are two things to note here. You didn't have to configure or set up a new Class called `GameScore` before running this code. Your Parse app lazily creates this Class for you when it first encounters it.

--- a/_includes/php/objects.md
+++ b/_includes/php/objects.md
@@ -35,9 +35,15 @@ try {
 
 After this code runs, you will probably be wondering if anything really happened. To make sure the data was saved, you can look at the Data Browser in your app on Parse. You should see something like this:
 
-```json
-objectId: "xWMyZ4YEGZ", score: 1337, playerName: "Sean Plott", cheatMode: false,
-createdAt:"2011-06-10T18:33:42Z", updatedAt:"2011-06-10T18:33:42Z"
+```json5
+{
+  objectId: "xWMyZ4YEGZ",
+  score: 1337,
+  playerName: "Sean Plott",
+  cheatMode: false,
+  createdAt: "2011-06-10T18:33:42Z",
+  updatedAt: "2011-06-10T18:33:42Z"
+}
 ```
 
 There are two things to note here. You didn't have to configure or set up a new Class called `GameScore` before running this code. Your Parse app lazily creates this Class for you when it first encounters it.

--- a/_includes/php/setup.md
+++ b/_includes/php/setup.md
@@ -62,13 +62,15 @@ Note that it is _not_ guaranteed that 'response' will be a parsable json array. 
 
 A couple examples of bad health responses could include an incorrect mount path, port or domain.
 
-```json
+```json5
 // ParseClient::setServerURL('http://localhost:1337', 'not-good');
 {
     "status": 404,
     "response": "<!DOCTYPE html>...Cannot GET \/not-good\/health..."
 }
+```
 
+```json5
 // ParseClient::setServerURL('http://__uh__oh__.com', 'parse');
 {
     "status": 0,

--- a/_includes/rest/hooks.md
+++ b/_includes/rest/hooks.md
@@ -220,7 +220,7 @@ and perform a `parse deploy` the usual way.
 To create a new function webhook post to <code class="highlighter-rouge"><span class="custom-parse-server-mount">/parse/</span>hooks/functions</code> with payload in the format
 
 ```json
-{"functionName" : x, "url" : y}
+{"functionName" : "baz", "url" : "https://api.example.com/baz"}
 ```
 
 Post example:

--- a/_includes/rest/users.md
+++ b/_includes/rest/users.md
@@ -600,6 +600,7 @@ The ACL is formatted as a JSON object where the keys are either object ids or th
 For example, if you want the user with id `"3KmCvT7Zsb"` to have read and write access to an object, plus the object should be publicly readable, that corresponds to an ACL of:
 
 ```json
+{
 	"ACL": {
 		"3KmCvT7Zsb": {
 			"read": true,

--- a/_includes/unity/objects.md
+++ b/_includes/unity/objects.md
@@ -6,8 +6,8 @@ Storing data on Parse is built around the `ParseObject`. Each `ParseObject` cont
 
 For example, let's say you're tracking high scores for a game. A single `ParseObject` could contain:
 
-```json
-score: 1337, playerName: "Sean Plott", cheatMode: false
+```json5
+{score: 1337, playerName: "Sean Plott", cheatMode: false }
 ```
 
 Keys must start with a letter, and can contain alphanumeric characters and underscores. Values can be strings, numbers, booleans, or even arrays and dictionaries - anything that can be JSON-encoded.


### PR DESCRIPTION
Hi !

Fixed a few more comments.  


JSON5 resemble much more regular JS objects and in most example it's what we are presenting.  I would recommend 
- Using only ` ```json5` to show  actual javascript objects
- Using only ` ```json`  to show actual client/server JSON message




