### PR TITLE
Recommend `axios` instead of `request`

### DIFF
--- a/_includes/cloudcode/cloud-code-advanced.md
+++ b/_includes/cloudcode/cloud-code-advanced.md
@@ -2,7 +2,7 @@
 
 ## httpRequest
 
-You can use your favorite npm module to make HTTP requests, such as [request](https://www.npmjs.com/package/request). Parse Server also supports `Parse.Cloud.httpRequest` for legacy reasons. It allows you to send HTTP requests to any HTTP Server. This function takes an options object to configure the call.
+You can use your favorite npm module to make HTTP requests, such as [axios](https://www.npmjs.com/package/axios). Parse Server also supports `Parse.Cloud.httpRequest` for legacy reasons. It allows you to send HTTP requests to any HTTP Server. This function takes an options object to configure the call.
 
 A simple GET request would look like:
 


### PR DESCRIPTION
Request is depreciated and has been for 2 years. We shouldn't be recommending it as a third party module.