### PR TITLE
Update link in deleting the files

### DIFF
--- a/_includes/rest/files.md
+++ b/_includes/rest/files.md
@@ -121,7 +121,7 @@ Users holding the master key are allowed to delete files using the REST API. To 
 curl -X DELETE \
   -H "X-Parse-Application-Id: <span class="custom-parse-server-appid">${APPLICATION_ID}</span>" \
   -H "X-Parse-Master-Key: <span class="custom-parse-server-masterkey">${MASTER_KEY}</span>" \
-  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>files/...profile.png
+  <span class="custom-parse-server-protocol">https</span>://<span class="custom-parse-server-url">YOUR.PARSE-SERVER.HERE</span><span class="custom-parse-server-mount">/parse/</span>files/profile.png
 </code></pre>
 <pre><code class="python">
 import json,httplib


### PR DESCRIPTION
Closing #838 

#### What thing being changed:

The documentation for "[Deleting the files](https://docs.parseplatform.org/rest/guide/#deleting-files)" contains invalid URL. This can be fixed by changing the URL from https://YOUR.PARSE-SERVER.HERE/parse/files/...profile.png to https://YOUR.PARSE-SERVER.HERE/parse/files/profile.png