### PR TITLE
📙 Updated apple auth adapter key

### DIFF
--- a/_includes/parse-server/third-party-auth.md
+++ b/_includes/parse-server/third-party-auth.md
@@ -117,7 +117,7 @@ Using Apple Sign In through the Apple JS SDK or through the REST service will on
 {
   auth: {
    apple: {
-     clientId: "", // optional (for extra validation), you can replace it with your Service ID provided by Apple.
+     clientId: 'com.example.app', // optional, for extra validation; replace with the bundle ID provided by Apple.
    },
   }
 }

--- a/_includes/parse-server/third-party-auth.md
+++ b/_includes/parse-server/third-party-auth.md
@@ -117,7 +117,7 @@ Using Apple Sign In through the Apple JS SDK or through the REST service will on
 {
   auth: {
    apple: {
-     client_id: "", // optional (for extra validation), use the Service ID from Apple.
+     clientId: "", // optional (for extra validation), you can replace it with your Service ID provided by Apple.
    },
   }
 }


### PR DESCRIPTION
Closes #761 

#### What things being changed:

Changed `client_id` to `clientId` in https://docs.parseplatform.org/parse-server/guide/#configuring-parse-server-for-sign-in-with-apple
```
{
  auth: {
   apple: {
     client_id: "",
   },
  }
}
```