### PR TITLE
Fix typo in cloud-code.md

### DIFF
--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -798,7 +798,7 @@ Parse.Cloud.afterLiveQueryEvent('MyObject', (request) => {
 });
 ```
 
-By default, ParseLiveQuery does not perform queries that require additional database operations. This is to keep your Parse Server as fast and effient as possible. If you require this functionality, you can perform these in `afterLiveQueryEvent`.  
+By default, ParseLiveQuery does not perform queries that require additional database operations. This is to keep your Parse Server as fast and efficient as possible. If you require this functionality, you can perform these in `afterLiveQueryEvent`.  
 
 ```javascript
 // Including an object on LiveQuery event, on update only.


### PR DESCRIPTION
This fixes the typo in the _afterLiveQueryEvent_ section by changing '**effient**' to '**efficient**'.