### PR TITLE
docs: php hint for using master key for requests

### DIFF
--- a/_includes/php/setup.md
+++ b/_includes/php/setup.md
@@ -22,6 +22,8 @@ Even though you specify the master key for intialization the master key is **NOT
 
 Therefore you can often pass a boolean when calling methods like `get`, `count` and `find`. Find details about method parameters in the [PHP SDK repo](https://github.com/parse-community/parse-php-sdk/blob/master/src/Parse/ParseQuery.php).
 
+**Example**: `public function get($objectId, $useMasterKey = false)`
+
 ## Server URL
 
 Directly after initializing the sdk you should set the server url.

--- a/_includes/php/setup.md
+++ b/_includes/php/setup.md
@@ -16,6 +16,12 @@ If your server does not use or require a REST key you may initialize the ParseCl
 ParseClient::initialize( $app_id, null, $master_key );
 ```
 
+**Note**:
+
+The master key is **NOT** used by default for requests. You have to explicitly specify that a request is allowed to use the master key.
+
+For more information see [Using Master Key](#using-master-key).
+
 ## Server URL
 
 Directly after initializing the sdk you should set the server url.

--- a/_includes/php/setup.md
+++ b/_includes/php/setup.md
@@ -16,11 +16,11 @@ If your server does not use or require a REST key you may initialize the ParseCl
 ParseClient::initialize( $app_id, null, $master_key );
 ```
 
-**Note**:
+### Using Master Key
 
-The master key is **NOT** used by default for requests. You have to explicitly specify that a request is allowed to use the master key.
+Even though you specify the master key for intialization the master key is **NOT** used by default for requests. You have to explicitly specify that a request is allowed to use the master key.
 
-For more information see [Using Master Key](#using-master-key).
+Therefore you can often pass a boolean when calling methods like `get`, `count` and `find`. Find details about method parameters in the [PHP SDK repo](https://github.com/parse-community/parse-php-sdk/blob/master/src/Parse/ParseQuery.php).
 
 ## Server URL
 


### PR DESCRIPTION
While implementing the Parse PHP SDK an error occured that the requests are unauthorized even though we have specified the master key.

After digging into the PHP source code we found the optional parameter `useMasterKey`. But it wasn't documented anywhere so I added a note myself to the docs.

Is this okay or is there something to improve?