### PR TITLE
docs: adapt to new login behavior that uses the `POST` HTTP method by default

### DIFF
--- a/_includes/js/users.md
+++ b/_includes/js/users.md
@@ -54,11 +54,11 @@ const user = await Parse.User.logIn("myname", "mypass");
 // Do stuff after successful login.
 ```
 
-By default, the SDK uses the GET HTTP method. If you would like to override this and use a POST HTTP method instead, you may pass an optional Boolean property in the options argument with the key `usePost`.
+By default, the SDK uses the POST HTTP method. If you would like to override this and use a GET HTTP method instead, you may pass an optional Boolean property in the options argument with the key `usePost`.
 
 
 ```javascript
-const user = await Parse.User.logIn("myname", "mypass", { usePost: true });
+const user = await Parse.User.logIn("myname", "mypass", { usePost: false });
 // Do stuff after successful login.
 ```
 > Available with SDK version 2.17.0 and later


### PR DESCRIPTION
Closes #902 

This PR reflects the following changes:

- Removed the references to `{usePost: true}` as discussed in https://github.com/parse-community/Parse-SDK-JS/pull/1284 
- Changed the default login method to POST and added optional boolean property as `{usePost: false}`.