### PR TITLE
docs: updated readme to use includes folder as starting directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 
 These are the markdown sources for all of the [Parse SDK guides](https://parse-community.github.io/#sdks). The content for the guides is stored in this repo, and we use Jekyll to generate a static site that is hosted on GitHub Pages.
-`
+
 ## Repository Structure
 
 The guides are organized by platform inside the _includes directory. Each platform directory contains a set of markdown files, one for each main section in the guide.

--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@
 
 
 These are the markdown sources for all of the [Parse SDK guides](https://parse-community.github.io/#sdks). The content for the guides is stored in this repo, and we use Jekyll to generate a static site that is hosted on GitHub Pages.
-
+`
 ## Repository Structure
 
-The guides are organized by platform. Each platform directory contains a set of markdown files, one for each main section in the guide.
+The guides are organized by platform inside the _includes directory. Each platform directory contains a set of markdown files, one for each main section in the guide.
 
     .
-    ├── {platform}
-    │   └── {section}
-    └── common
-        └── {section}
+    └── _includes
+        ├── {platform}
+        │   └── {section}
+        └── common
+            └── {section}
 
 For example, `/ios/` contains all of sections for the iOS guide. There is also a `common` folder that contains content that is shared amongst all of the guides. It helps us avoid duplicating content unnecessarily.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The guides are organized by platform inside the _includes directory. Each platfo
         └── common
             └── {section}
 
-For example, `/ios/` contains all of sections for the iOS guide. There is also a `common` folder that contains content that is shared amongst all of the guides. It helps us avoid duplicating content unnecessarily.
+For example, `/_includes/ios/` contains all of sections for the iOS guide. There is also a `/_includes/common` folder that contains content that is shared amongst all of the guides. It helps us avoid duplicating content unnecessarily.
 
 ## Can I Access The Docs Offline?
 


### PR DESCRIPTION
The current doesn't mention the starting directory to be _includes.
Have mentioned that the starting directory is _includes