### PR TITLE
Add ios docs for Swift Package Manager

### DIFF
--- a/_includes/ios/getting-started.md
+++ b/_includes/ios/getting-started.md
@@ -9,6 +9,8 @@ The easiest way to integrate the Parse SDK into your iOS, iPadOS, macOS, watchOS
 https://github.com/parse-community/Parse-SDK-iOS-OSX
 ```
 
+**Note: You may have to add submodules under Link Binary with Libraries**
+
 To initialize the Parse client, add the following to your AppDelegate.swift file (AppDelegate.m for Objective-C), in the `application:didFinishLaunchingWithOptions:` method.
 
 <div class="language-toggle" markdown="1">

--- a/_includes/ios/getting-started.md
+++ b/_includes/ios/getting-started.md
@@ -41,7 +41,7 @@ Make sure to import the Parse module at the top of any file in which you want to
 
 <div class="language-toggle" markdown="1">
 ```objective_c
-@import ParseCore
+@import ParseCore;
 ```
 ```swift
 import ParseCore

--- a/_includes/ios/getting-started.md
+++ b/_includes/ios/getting-started.md
@@ -1,47 +1,13 @@
 # Getting Started
 
-To use parse, head on over to the [releases][releases] page, and download the latest build.
-And you're off! Take a look at the public [documentation][docs] and start building.
+The easiest way to integrate the Parse SDK into your iOS, iPadOS, macOS, watchOS, tvOS app is via Swift Package Manager (SPM).
 
-**Other Installation Options**
+1. Open Xcode > File > Add packages...
+2. Add the following package URL:
 
- - **[CocoaPods](https://cocoapods.org)**
- 
-   Add the following line to your Podfile:
-   ```ruby
-   pod 'Parse'
-   ```
-   Run `pod install`, and you should now have the latest parse release.  CocoaPods will generate a .xcworkspace for you.  You must open the .xcworkspace in Xcode or you will get a linker error.
-    
-    
- - **[Carthage](https://github.com/carthage/carthage)**
- 
-   Add the following line to your Cartfile:
-   ```
-   github "parse-community/Parse-SDK-iOS-OSX"
-   ```
-   Run `carthage update`, and you should now have the latest version of Parse SDK in your Carthage folder.
-
- - **Compiling for yourself**
-
-    If you want to manually compile the SDK, clone it locally, and run the following commands in the root directory of the repository:
-
-        # To pull in extra dependencies (Bolts and OCMock)
-        git submodule update --init --recursive
-
-        # To install all the gems
-        bundle install
-
-        # Build & Package the Frameworks
-        rake package:frameworks
-
-    Compiled frameworks will be in 2 archives: `Parse-iOS.zip` and `Parse-OSX.zip` inside the `build/release` folder, and you can link them as you'd please.
-
- - **Using Parse as a sub-project**
-
-    You can also include parse as a subproject inside of your application if you'd prefer, although we do not recommend this, as it will increase your indexing time significantly. To do so, just drag and drop the Parse.xcodeproj file into your workspace. Note that unit tests will be unavailable if you use Parse like this, as OCMock will be unable to be found.
-
-**Initialise Parse SDK**
+```
+https://github.com/parse-community/Parse-SDK-iOS-OSX
+```
 
 To initialize the Parse client, add the following to your AppDelegate.swift file (AppDelegate.m for Objective-C), in the `application:didFinishLaunchingWithOptions:` method.
 
@@ -73,12 +39,9 @@ Make sure to import the Parse module at the top of any file in which you want to
 
 <div class="language-toggle" markdown="1">
 ```objective_c
-#import <Parse/Parse.h>
+@import ParseCore
 ```
 ```swift
-import Parse
+import ParseCore
 ```
 </div>
-
-[releases]: https://github.com/parse-community/Parse-SDK-iOS-OSX/releases
-[docs]: http://docs.parseplatform.org/ios/guide


### PR DESCRIPTION
Cocoapods and Carthage are no longer supported. Add documentation for installing via SPM.

See https://github.com/parse-community/Parse-SDK-iOS-OSX/issues/1740