### PR TITLE
docs: correct cloud code function argument number

### DIFF
--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -104,7 +104,7 @@ const ratings = await Parse.Cloud.run("averageStars", params);
 // ratings should be 4.5
 ```
 
-In general, three arguments will be passed into cloud functions:
+In general, these arguments will be passed into Cloud Functions:
 
 1.  **`request`** - The request object contains information about the request. The following fields are set:
   1.  **`params`** - The parameters object sent to the function by the client.

--- a/_includes/cloudcode/cloud-code.md
+++ b/_includes/cloudcode/cloud-code.md
@@ -104,7 +104,7 @@ const ratings = await Parse.Cloud.run("averageStars", params);
 // ratings should be 4.5
 ```
 
-In general, two arguments will be passed into cloud functions:
+In general, three arguments will be passed into cloud functions:
 
 1.  **`request`** - The request object contains information about the request. The following fields are set:
   1.  **`params`** - The parameters object sent to the function by the client.


### PR DESCRIPTION
Tiny tweak to fix the documentation on the number of arguments passed to cloud functions.