### PR TITLE
docs: update Parse Server API links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ apis:
   dotnet: https://parseplatform.org/Parse-SDK-dotNET/api/
   flutter: https://parseplatform.org/Parse-SDK-Flutter/flutter/flutter_parse_sdk_flutter/flutter_parse_sdk_flutter-library.html
   dart: https://parseplatform.org/Parse-SDK-Flutter/dart/flutter_parse_sdk/flutter_parse_sdk-library.html
-  parse-server: https://parseplatform.org/parse-server/api/
+  parse-server: https://website.parseplatform.org/parse-server/api/
 
 # Build settings
 markdown: kramdown

--- a/_includes/dart/getting-started.md
+++ b/_includes/dart/getting-started.md
@@ -41,7 +41,7 @@ await Parse().initialize(
 Due to Cross-Origin Resource Sharing (CORS) restrictions, web support requires adding `X-Parse-Installation-Id` as an allowed header in the Parse Server configuration:
 
 - When running directly via docker, set the env var `PARSE_SERVER_ALLOW_HEADERS=X-Parse-Installation-Id`.
-- When running via express, set the [Parse Server option](https://parseplatform.org/parse-server/api/master/ParseServerOptions.html) `allowHeaders: ['X-Parse-Installation-Id']`.
+- When running via express, set the [Parse Server option](https://website.parseplatform.org/parse-server/api/master/ParseServerOptions.html) `allowHeaders: ['X-Parse-Installation-Id']`.
 
 ## Desktop Support (macOS)
 

--- a/_includes/flutter/getting-started.md
+++ b/_includes/flutter/getting-started.md
@@ -41,7 +41,7 @@ await Parse().initialize(
 Due to Cross-Origin Resource Sharing (CORS) restrictions, web support requires adding `X-Parse-Installation-Id` as an allowed header in the Parse Server configuration:
 
 - When running directly via docker, set the env var `PARSE_SERVER_ALLOW_HEADERS=X-Parse-Installation-Id`.
-- When running via express, set the [Parse Server option](https://parseplatform.org/parse-server/api/master/ParseServerOptions.html) `allowHeaders: ['X-Parse-Installation-Id']`.
+- When running via express, set the [Parse Server option](https://website.parseplatform.org/parse-server/api/master/ParseServerOptions.html) `allowHeaders: ['X-Parse-Installation-Id']`.
 
 ## Desktop Support (macOS)
 

--- a/_includes/graphql/getting-started.md
+++ b/_includes/graphql/getting-started.md
@@ -12,7 +12,7 @@ $ parse-server --appId APPLICATION_ID --masterKey MASTER_KEY --databaseURI mongo
 ```
 
 Notes:
-* Run `parse-server --help` or refer to [Parse Server Options](https://parseplatform.org/parse-server/api/master/ParseServerOptions.html) for a complete list of Parse Server configuration options.
+* Run `parse-server --help` or refer to [Parse Server Options](https://website.parseplatform.org/parse-server/api/master/ParseServerOptions.html) for a complete list of Parse Server configuration options.
 * ⚠️ Please do not use `--mountPlayground` option in production as anyone could access your API Playground and read or change your application's data. [Parse Dashboard](#running-parse-dashboard) has a built-in GraphQL Playground and it is the recommended option for production apps. If you want to secure your API in production take a look at [Class Level Permissions](/js/guide/#class-level-permissions)
 
 After running the CLI command, you should have something like this in your terminal:

--- a/_includes/parse-server/deploying-aws-ubuntu.md
+++ b/_includes/parse-server/deploying-aws-ubuntu.md
@@ -117,7 +117,7 @@ After that, we need to setup the configuration file, use your own `appId`, `mast
 ```bash
 sudo nano -w config.json
 ```
-This are the basic options of the config.json file, for the full list you can type `parse-server --help` or refer to the [full options document](https://website.parseplatform.org/parse-server/api/5.2.0/ParseServerOptions.html) for more details.
+These are the basic options of the config.json file. For the full list, you can run `parse-server --help` or refer to the [full options document](https://website.parseplatform.org/parse-server/api/5.2.0/ParseServerOptions.html) for more details.
 ```jsonc
 {
   "appId": "exampleAppId",

--- a/_includes/parse-server/deploying-aws-ubuntu.md
+++ b/_includes/parse-server/deploying-aws-ubuntu.md
@@ -117,7 +117,7 @@ After that, we need to setup the configuration file, use your own `appId`, `mast
 ```bash
 sudo nano -w config.json
 ```
-This are the basic options of the config.json file, for the full list you can type `parse-server --help` or refer to the [full options document](https://parseplatform.org/parse-server/api/5.2.0/ParseServerOptions.html) for more details.
+This are the basic options of the config.json file, for the full list you can type `parse-server --help` or refer to the [full options document](https://website.parseplatform.org/parse-server/api/5.2.0/ParseServerOptions.html) for more details.
 ```jsonc
 {
   "appId": "exampleAppId",

--- a/_includes/parse-server/usage.md
+++ b/_includes/parse-server/usage.md
@@ -16,7 +16,7 @@ const api = new ParseServer({
 });
 ```
 
-A few of the [Parse Server Options](https://parseplatform.org/parse-server/api/master/ParseServerOptions.html) are as follows:
+A few of the [Parse Server Options](https://website.parseplatform.org/parse-server/api/master/ParseServerOptions.html) are as follows:
 
 * `databaseURI`: Connection string for your database.
 * `cloud`: Path to your app’s Cloud Code.

--- a/parse-server-api.md
+++ b/parse-server-api.md
@@ -3,5 +3,5 @@ layout: redirected
 sitemap: false
 permalink: /parse-server/api/
 redirect_to:
-  - https://parseplatform.org/parse-server/api
+  - https://website.parseplatform.org/parse-server/api/
 ---


### PR DESCRIPTION
### What changed
- Updates the `/parse-server/api/` redirect to the active Parse Server API docs host.
- Updates Parse Server option links in the docs from `parseplatform.org/parse-server/api/...` to `website.parseplatform.org/parse-server/api/...`.

### Why
`https://parseplatform.org/parse-server/api/` currently returns 404, while the same API documentation is available under `https://website.parseplatform.org/parse-server/api/`. This keeps the docs redirect and inline API links usable.

Related to #889 and parse-community/parse-server#10460.

### Validation
- `git diff --check`
- `rg -n "https?://parseplatform\\.org/parse-server/api" _config.yml parse-server-api.md _includes -S` returns no matches
- Verified these URLs return HTTP 200:
  - `https://website.parseplatform.org/parse-server/api/`
  - `https://website.parseplatform.org/parse-server/api/master/ParseServerOptions.html`
  - `https://website.parseplatform.org/parse-server/api/5.2.0/ParseServerOptions.html`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Parse Server API documentation links across configuration files and multiple setup guides including Dart, Flutter, and GraphQL.
  * Enhanced Parse Server documentation references for deployment on AWS Ubuntu, including CORS header configuration guidance.
  * Refreshed documentation links to ensure users access current Parse Server configuration and API reference materials.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parse-community/docs/pull/975)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->